### PR TITLE
fix(ci): pin the new preview trigger and gate npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/setup@v1
+      # No npm release is cut yet; skip publishing until an NPM_TOKEN secret
+      # exists instead of failing every push to main. Previews stay on
+      # pkg.pr.new (docs/preview-packages.md).
+      - id: gate
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "enabled=${{ env.NPM_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+      - if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/setup@v1
         with:
           cache: true
           install: false
           runtime: node@22.19.0
-      - run: pnpm install --frozen-lockfile
-      - uses: changesets/action@v1
+      - if: steps.gate.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+      - if: steps.gate.outputs.enabled == 'true'
+        uses: changesets/action@v1
         with:
           publish: pnpm release
           version: pnpm version-packages

--- a/packages/agent-bundle/tests/package-preview-workflow.test.ts
+++ b/packages/agent-bundle/tests/package-preview-workflow.test.ts
@@ -32,7 +32,8 @@ it('publishes one locked package preview for pull requests', async () => {
   };
   const steps = parsed.jobs?.publish?.steps ?? [];
 
-  expect(Object.keys(parsed.on ?? {})).toEqual(['pull_request']);
+  expect(Object.keys(parsed.on ?? {})).toEqual(['pull_request', 'push']);
+  expect((parsed.on as Readonly<Record<string, unknown>>)['push']).toEqual({ branches: ['main'] });
   expect(parsed.permissions).toEqual({});
   expect(steps.map((step) => step.uses ?? step.run)).toEqual([
     'actions/checkout@v7',


### PR DESCRIPTION
Repairs main's CI: the preview workflow's new push trigger is now covered by its contract test, and the release workflow skips publishing while no NPM_TOKEN secret exists (pkg.pr.new previews are the distribution channel for now) instead of failing every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMWczsXAkj7fC5ssSxGK43