### PR TITLE
docs: complete the getting-started path with host install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ once, and compile it for every host you target:
 npm install --save-dev agent-bundle
 ```
 
+No version has been published to npm yet. Until the first release is cut,
+install the identical preview package CI publishes for every commit and pull
+request — see [Preview packages](docs/preview-packages.md).
+
 ```ts
 // agent-bundle.config.ts
 import { defineConfig } from 'agent-bundle/config';
@@ -60,6 +64,25 @@ The implemented commands are:
 - `agent-bundle eval` runs deterministic or native Claude/Codex eval suites and records a run.
 
 `inspect` is intentionally a source/config-plan command; run it before source removal. Artifact-only inspection is the validation contract (`validate --artifact`).
+
+## Install the built bundle into hosts
+
+The compiled `dist/plugin/` directory is the installable product, and its
+generated `AGENTS.md` repeats this install matrix next to the artifact:
+
+- **Claude Code** — add the directory (or its repository) as a plugin:
+  `claude plugin marketplace add <source>`.
+- **Codex** — `codex plugin marketplace add <source>`; the manifest is
+  `.codex-plugin/plugin.json`.
+- **Cursor** — clone (or symlink) the directory to
+  `~/.cursor/plugins/local/<name>`; the manifest is
+  `.cursor-plugin/plugin.json`.
+- **skills CLI** — `npx skills add <source> --skill <name>` consumes the
+  shared `skills/` directory directly.
+
+Per-host artifacts (`dist/claude/`, `dist/codex/`, `dist/portable/`) install
+the same way into their single host. Validate any artifact after the source
+project is gone with `agent-bundle validate --artifact <dir>`.
 
 `agent-bundle dev` is available without the RSC example. Installing
 `agent-bundle` does not install the example provider or React/RSC dependencies.


### PR DESCRIPTION
## Summary
- The quick start previously dead-ended for an external reader: `npm install agent-bundle` has no published version yet, and nothing explained how to install the compiled bundle into a host. The install step now links the pkg.pr.new preview channel (docs/preview-packages.md) until the first npm release is cut.
- Adds an "Install the built bundle into hosts" section mirroring the install matrix the compiler generates into each bundle's `AGENTS.md`: Claude Code, Codex, Cursor, and the skills CLI, plus the `validate --artifact` closing step.

## Test plan
- [x] Docs-only change; wording cross-checked against the generated `AGENTS.md` matrix in `adapters/plugin.ts` and `docs/preview-packages.md`