### PR TITLE
fix(ci): bound every job and wait so hangs fail instead of wedging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
   push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +19,7 @@ jobs:
   spot-check:
     name: Micro-eval spot-check (Node 22.19)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/setup@v2
@@ -32,6 +34,7 @@ jobs:
   verify:
     name: Verify (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +60,7 @@ jobs:
   release-gates:
     name: Release gates (Node 22.19)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/setup@v2
@@ -75,6 +79,7 @@ jobs:
     # the manually dispatched native-host-smoke workflow on purpose.
     name: RSC runtime micro-eval (Node 22.19)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/setup@v2
@@ -89,6 +94,7 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Dependency review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/dependency-review-action@v5

--- a/packages/workbench/tests/packed-release.e2e.test.ts
+++ b/packages/workbench/tests/packed-release.e2e.test.ts
@@ -1145,7 +1145,9 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 }
             const url = new URL(response.url());
             return response.request().method() === 'GET' && url.origin === origin &&
               url.pathname === '/api/logs/stream' && hasCanonicalAfterCursor(url);
-          }, { timeout: 0 })
+          // Wider than the interaction budget for a loaded runner, but finite:
+          // a stream that never responds must fail the test, not hang the job.
+          }, { timeout: browserTimeout * 5 })
           : undefined;
         await page.getByRole('link', { name: route.label, exact: true }).click();
         await expect(page.getByRole('heading', { name: route.heading })).toBeVisible({ timeout: browserTimeout });

--- a/packages/workbench/tests/runtime-playground-capture.test.ts
+++ b/packages/workbench/tests/runtime-playground-capture.test.ts
@@ -150,7 +150,7 @@ test('settles every capture cleanup action without masking the primary failure',
   }
 });
 
-test('captures identity-backed HMR, last-good, recovery, and responsive browser evidence', { timeout: 0 }, async () => {
+test('captures identity-backed HMR, last-good, recovery, and responsive browser evidence', { timeout: 600_000 }, async () => {
   const outputRoot = await mkdtemp(join(tmpdir(), 'agent-bundle-runtime-capture-'));
   const outputs = Object.freeze({
     compileError: join(outputRoot, 'compile-error.png'),


### PR DESCRIPTION
## Summary
- Overnight, three CI jobs hung 60-90 minutes and had to be cancelled by hand. Root causes, each fixed here:
  - No job declared `timeout-minutes`, so hangs ran toward GitHub's 6-hour default. Every job now has an explicit budget sized from observed runtimes (Verify 45m vs ~16-20m typical, spot-check 25m, release gates 30m, RSC micro-eval 15m, dependency review 10m).
  - Two unbounded browser waits remained: the Logs stream `waitForResponse({ timeout: 0 })` in `packed-release.e2e.test.ts` (now 5× the file's interaction budget, finite) and the capture e2e's test-level `{ timeout: 0 }` (now 10 minutes).
  - `on: push` had no branch filter, so every PR branch ran the full suite twice (push + pull_request). That doubled load was what starved the runner into the timeout flakes to begin with. CI pushes are now scoped to `main`, matching the package-preview workflow's existing convention; PRs keep full coverage via the pull_request event.

## Test plan
- [x] Workflow contract tests pass (`package-lint-workflow`, `package-preview-workflow`, `native-host-smoke-workflow`)
- [x] `pnpm rslint` on touched test files — clean
- [ ] PR CI (which itself exercises the changed workflow on the pull_request event)