### PR TITLE
feat(hooks): lower hooks to Cursor with a dedicated wrapper codec

### DIFF
--- a/.changeset/cursor-hook-lowering.md
+++ b/.changeset/cursor-hook-lowering.md
@@ -1,0 +1,11 @@
+---
+"agent-bundle": minor
+---
+
+Lower hooks to Cursor. The `cursor` target now emits the flat versioned
+`hooks/hooks.json` with per-hook wrappers speaking Cursor's own stdin/stdout
+envelope (pinned from the published hooks reference and verified against
+installed Cursor plugins), and the unified `plugin` bundle ships dedicated
+`hooks/<name>.cursor.mjs` wrapper variants beside the shared Claude/Codex
+wrappers, replacing the empty schema-collision guard whenever a hook lowers
+to Cursor. One authored hook now serves Claude Code, Codex, and Cursor.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ agent-bundle build --root . --output dist
 installs into multiple hosts from the same root: `.claude-plugin/` (Claude
 Code), `.codex-plugin/` (Codex), and `.cursor-plugin/` (Cursor) manifests over
 shared `skills/`, `hooks/`, `mcp/`, `scripts/`, and `assets/` directories,
-plus a generated `AGENTS.md` install matrix. Hooks compile once into
-host-detecting wrappers that serve Claude Code and Codex; Cursor consumes the
-skills and MCP servers. Per-host artifacts remain available as `claude`,
-`codex`, `cursor`, and `portable` targets when a host-specific layout is
-required.
+plus a generated `AGENTS.md` install matrix. Hooks compile into host-detecting
+wrappers shared by Claude Code and Codex plus dedicated Cursor-codec wrappers,
+so one authored hook serves all three hosts. Per-host artifacts remain
+available as `claude`, `codex`, `cursor`, and `portable` targets when a
+host-specific layout is required.
 
 ## Install and build
 
@@ -247,12 +247,13 @@ artifact/
     .cursor-plugin/plugin.json
     mcp.json
     scripts/<name>.mjs
+    hooks/<name>.mjs
     skills/<skill>/...
 ```
 
 `agent-bundle.manifest.json` records each emitted file's path, byte length, and SHA-256 digest. This allows `validate --artifact` and artifact operations to run after the source project is no longer present.
 
-Portable artifacts contain portable plugin, skills, MCP, and App-resource files. Codex and Claude artifacts contain their respective native metadata and generated hook wrappers. Cursor artifacts contain the `.cursor-plugin/plugin.json` manifest, the auto-discovered `mcp.json` (Cursor's typeless server format), and shared skills, scripts, and assets; hooks stay Claude/Codex-only until Cursor's hook stdin contract is pinned. Terminal hosts can use normal MCP tools and resources; visual rendering of an MCP App depends on the host supporting the standard resource metadata.
+Portable artifacts contain portable plugin, skills, MCP, and App-resource files. Codex and Claude artifacts contain their respective native metadata and generated hook wrappers. Cursor artifacts contain the `.cursor-plugin/plugin.json` manifest, the auto-discovered `mcp.json` (Cursor's typeless server format), the flat versioned `hooks/hooks.json` with Cursor-codec wrappers, and shared skills, scripts, and assets. Terminal hosts can use normal MCP tools and resources; visual rendering of an MCP App depends on the host supporting the standard resource metadata.
 
 ## Public examples
 

--- a/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
+++ b/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
@@ -1,5 +1,21 @@
 {
   "host": "cursor",
+  "hooks": {
+    "config": "hooks/hooks.json",
+    "events": {
+      "afterTool": "postToolUse",
+      "beforeTool": "preToolUse",
+      "sessionStart": "sessionStart",
+      "stop": "stop"
+    },
+    "matchers": {
+      "agent": "^Task$",
+      "file.read": "^Read$",
+      "file.write": "^Write$",
+      "mcp": "^MCP:",
+      "shell": "^Shell$"
+    }
+  },
   "mcp": {
     "pathTokens": {
       "args": [

--- a/packages/agent-bundle/src/adapters/cursor.ts
+++ b/packages/agent-bundle/src/adapters/cursor.ts
@@ -14,6 +14,15 @@ import {
 } from '../services/mcp-path-tokens.ts';
 import { createTargetMcpRuntime } from '../services/mcp-runtime.ts';
 import capabilityTable from './capabilities/cursor-2026-08-28.json' with { type: 'json' };
+import {
+  cursorHookWrapperSource,
+  encodeCursorPlaygroundInput,
+  encodeCursorPlaygroundOutput,
+  planHooks,
+  readCursorNativeHookCommands,
+  type TargetHookContract,
+  type TargetHookDocumentEntryInput,
+} from './hook-contract.ts';
 import schemaProvenance from './schemas/cursor/PROVENANCE.json' with { type: 'json' };
 import hooksSchema from './schemas/cursor/hooks.schema.json' with { type: 'json' };
 import mcpSchema from './schemas/cursor/mcp.schema.json' with { type: 'json' };
@@ -33,12 +42,10 @@ const cursorName = 'cursor';
 
 /**
  * Cursor's conventional artifact document paths, shared with the unified
- * bundle adapter. Cursor auto-discovers `mcp.json` at the plugin root (never
- * the Claude-convention `.mcp.json`); the manifest still carries an explicit
- * pointer so relocations stay impossible to configure apart. Hooks are not
- * emitted by any target until Cursor's hook stdin contract is pinned; the
- * hooks document is declared only so a hand-authored one validates against
- * the pinned schema.
+ * bundle adapter. Cursor auto-discovers `mcp.json` and `hooks/hooks.json` at
+ * the plugin root (never the Claude-convention `.mcp.json`); the manifest
+ * still carries explicit pointers so relocations stay impossible to
+ * configure apart.
  */
 export const cursorArtifactPaths = Object.freeze({
   hooks: 'hooks/hooks.json',
@@ -62,8 +69,41 @@ const cursorNamePattern = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/u;
 export const isValidCursorPluginName = (name: string): boolean =>
   cursorNamePattern.test(name) && name.length <= 64;
 
-/** The Cursor hooks document every target emits until the hook stdin contract is pinned. */
+/** The schema-collision guard the bundle emits when no hook lowers to Cursor. */
 export const emptyCursorHooksDocument = Object.freeze({ hooks: {}, version: 1 });
+
+const cursorHookDocumentEntry = (input: TargetHookDocumentEntryInput): Record<string, unknown> => ({ ...input });
+
+const cursorHookDocumentEnvelope = (hooks: Record<string, unknown[]>): Record<string, unknown> => ({ hooks, version: 1 });
+
+export interface CursorHookContractOptions {
+  /** See TargetHookContract.indexedWrappers; the bundle's Cursor wrappers are document variants. */
+  readonly indexedWrappers?: false;
+  readonly manifestPath: string;
+  readonly wrapperPath: TargetHookContract['wrapperPath'];
+}
+
+/**
+ * Cursor hook lowering, shared with the unified bundle adapter: flat
+ * `{ command, matcher?, timeout? }` entries under a `version: 1` envelope,
+ * `${CURSOR_PLUGIN_ROOT}` command interpolation, and the dedicated Cursor
+ * wrapper codec (Cursor's stdin/stdout envelope is not the shared
+ * Claude/Codex format; see cursorHookWrapperSource).
+ */
+export const createCursorHookContract = (options: CursorHookContractOptions): TargetHookContract => Object.freeze({
+  commandRoot: '${CURSOR_PLUGIN_ROOT}',
+  documentEntry: cursorHookDocumentEntry,
+  documentEnvelope: cursorHookDocumentEnvelope,
+  encodePlaygroundInput: encodeCursorPlaygroundInput,
+  encodePlaygroundOutput: (result, canonicalEvent) => encodeCursorPlaygroundOutput(result, canonicalEvent),
+  eventNames: capabilityTable.hooks.events,
+  ...(options.indexedWrappers === false ? { indexedWrappers: false as const } : {}),
+  manifestPath: options.manifestPath,
+  matchers: capabilityTable.hooks.matchers,
+  readNativeCommands: readCursorNativeHookCommands,
+  wrapperPath: options.wrapperPath,
+  wrapperSource: cursorHookWrapperSource,
+} satisfies TargetHookContract);
 
 /**
  * Cursor documents `${env:NAME}` / `${workspaceFolder}` interpolation and
@@ -164,9 +204,14 @@ export const cursorManifest = (
 const metadata = Object.freeze({
   adapterRevision: '1.0.0',
   capabilityRevision: capabilityTable.observedCliVersion,
-  capabilitySha256: 'c9e916ce4caf1865f57078765c27f47a2d225796ac36c1b65ccadf6a5290c86e',
+  capabilitySha256: 'b8990776721f3e2cf4707364812586a0043b8a1247899a47f256302739c00443',
   observedVersion: capabilityTable.observedCliVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.observedCliVersion),
+});
+
+const hookContract = createCursorHookContract({
+  manifestPath: cursorArtifactPaths.hooks,
+  wrapperPath: (hook) => `hooks/${hook.name}.mjs`,
 });
 
 const artifactValidation = Object.freeze({
@@ -229,7 +274,14 @@ export const planCursorArtifacts = (model: NormalizedPlugin): TargetArtifactPlan
   const mcpValid = mcp !== undefined && validateMcp(mcp);
   if (mcp !== undefined) diagnostics.push(...schemaDiagnostics('mcp', mcpValid, validateMcp.errors));
 
+  const generatedHooks = planHooks(model, cursorName, hookContract);
+  diagnostics.push(...generatedHooks.diagnostics);
+  const hookDocument = generatedHooks.document;
+  const hookDocumentValid = hookDocument !== undefined && validateHooks(hookDocument);
+  if (hookDocument !== undefined) diagnostics.push(...schemaDiagnostics('hooks', hookDocumentValid, validateHooks.errors));
+
   const plugin = cursorManifest(model, {
+    ...(hookDocument !== undefined && hookDocumentValid ? { hooks: `./${cursorArtifactPaths.hooks}` } : {}),
     ...(mcp !== undefined && mcpValid ? { mcp: `./${cursorArtifactPaths.mcp}` } : {}),
     ...(model.skills.some((skill) => isSelected(skill.targets)) ? { skills: './skills/' } : {}),
   });
@@ -237,8 +289,9 @@ export const planCursorArtifacts = (model: NormalizedPlugin): TargetArtifactPlan
 
   return standardPluginArtifactPlan({
     diagnostics,
-    hookDocumentValid: false,
-    hookEntries: [],
+    hookDocument,
+    hookDocumentValid,
+    hookEntries: generatedHooks.hookEntries,
     hookManifestPath: cursorArtifactPaths.hooks,
     isSelected,
     marketplaceRelativePath: '.cursor-plugin/marketplace.json',
@@ -255,17 +308,13 @@ export const planCursorArtifacts = (model: NormalizedPlugin): TargetArtifactPlan
 
 export const cursorAdapter: TargetAdapter = Object.freeze({
   artifactValidation,
-  artifactLayout: Object.freeze({
-    assets: standardArtifactLayout.assets,
-    mcpApps: standardArtifactLayout.mcpApps,
-    mcpEntries: standardArtifactLayout.mcpEntries,
-    scripts: standardArtifactLayout.scripts,
-    skills: standardArtifactLayout.skills,
-  }),
+  artifactLayout: standardArtifactLayout,
   capabilities: Object.freeze({
+    hooks: true,
     mcp: capabilityTable.mcp.stdio && capabilityTable.mcp.streamableHttp,
     skills: capabilityTable.plugin.skills,
   }),
+  hookContract,
   metadata,
   mcpRuntime,
   name: cursorName,

--- a/packages/agent-bundle/src/adapters/hook-contract.ts
+++ b/packages/agent-bundle/src/adapters/hook-contract.ts
@@ -12,6 +12,8 @@ import type {
 export interface TargetHookWrapper {
   readonly event: CanonicalHookEvent;
   readonly hook: NormalizedHook;
+  /** False when this wrapper is a host-document variant of an indexed hook rather than its canonical entry. */
+  readonly indexed?: false;
   readonly nativeEvent: string;
   /** The computed native tool matcher, absent when the host applies the hook unconditionally. */
   readonly nativeMatcher?: string;
@@ -31,8 +33,22 @@ export type TargetNativeHookCommandsReadResult =
   | Readonly<{ readonly commands: readonly TargetNativeHookCommand[]; readonly status: 'found' }>
   | Readonly<{ readonly status: 'invalid' }>;
 
+export interface TargetHookDocumentEntryInput {
+  readonly command: string;
+  readonly matcher?: string;
+  readonly timeout?: number;
+}
+
 export interface TargetHookContract {
   readonly commandRoot: string;
+  /**
+   * Shapes one generated hook command into the host's per-event array entry.
+   * Defaults to the Claude/Codex grouped shape; Cursor's document keeps flat
+   * `{ command, matcher?, timeout? }` entries.
+   */
+  readonly documentEntry?: (input: TargetHookDocumentEntryInput) => Record<string, unknown>;
+  /** Wraps the per-event groups into the host's document root; defaults to `{ hooks }`. */
+  readonly documentEnvelope?: (hooks: Record<string, unknown[]>) => Record<string, unknown>;
   readonly encodePlaygroundInput: (
     input: Readonly<Record<string, unknown>>,
     nativeEvent: string,
@@ -43,6 +59,12 @@ export interface TargetHookContract {
     nativeEvent: string,
   ) => Readonly<Record<string, unknown>> | undefined;
   readonly eventNames: Readonly<Record<CanonicalHookEvent, string>>;
+  /**
+   * False when this contract plans host-document wrapper variants of hooks
+   * whose canonical wrappers another contract already indexes; the canonical
+   * hook index keeps exactly one entry per hook and target.
+   */
+  readonly indexedWrappers?: false;
   readonly manifestPath: string;
   readonly matchers: Readonly<Partial<Record<CanonicalHookTool, string>>>;
   readonly readNativeCommands?: (document: unknown) => TargetNativeHookCommandsReadResult;
@@ -124,6 +146,27 @@ export const readStandardNativeHookCommands = (document: unknown): TargetNativeH
   return Object.freeze({ commands: Object.freeze(commands), status: 'found' });
 };
 
+/** Enumerates commands from Cursor's flat `{ version, hooks: { event: [{ command }] } }` document. */
+export const readCursorNativeHookCommands = (document: unknown): TargetNativeHookCommandsReadResult => {
+  if (!isPlainDataRecord(document)) return Object.freeze({ status: 'invalid' });
+  const hooks = ownDataValue(document, 'hooks');
+  if (hooks === undefined || !hooks.found || !isPlainDataRecord(hooks.value)) return Object.freeze({ status: 'invalid' });
+  const commands: TargetNativeHookCommand[] = [];
+  for (const entries of Object.values(hooks.value)) {
+    const hooksForEvent = dataArrayValues(entries);
+    if (hooksForEvent === undefined) return Object.freeze({ status: 'invalid' });
+    for (const hook of hooksForEvent) {
+      if (!isPlainDataRecord(hook)) return Object.freeze({ status: 'invalid' });
+      const command = ownDataValue(hook, 'command');
+      if (command === undefined || !command.found || typeof command.value !== 'string') {
+        return Object.freeze({ status: 'invalid' });
+      }
+      commands.push(Object.freeze({ command: command.value }));
+    }
+  }
+  return Object.freeze({ commands: Object.freeze(commands), status: 'found' });
+};
+
 const nativeHookInputFields = Object.freeze([
   Object.freeze({ canonical: 'cwd', native: 'cwd' }),
   Object.freeze({ canonical: 'hookEventName', native: 'hook_event_name' }),
@@ -185,6 +228,179 @@ export const encodeNativeHookPlaygroundOutput = (
     ? undefined
     : { hookSpecificOutput: output };
 };
+
+/**
+ * Cursor's hook envelope differs from the shared Claude/Codex format: input
+ * carries `conversation_id` plus per-event fields (`tool_output` is a
+ * JSON-stringified record, `stop` carries `loop_count`/`status` instead of
+ * `stop_hook_active`/`last_assistant_message`), and output uses the
+ * documented per-event shapes (`additional_context`, `permission` with
+ * `user_message`/`agent_message`, `updated_input`, `followup_message`).
+ * Observed at https://cursor.com/docs/agent/hooks (2026-08-28) and against
+ * installed plugins that ship working Cursor hooks. A denied `stop` maps to
+ * `followup_message`, Cursor's loop-continuation channel. `additionalContext`
+ * from an allowed `beforeTool` handler has no Cursor output channel and is
+ * dropped; inject context from `afterTool` instead.
+ */
+export const encodeCursorPlaygroundInput = (
+  input: Readonly<Record<string, unknown>>,
+  nativeEvent: string,
+): Readonly<Record<string, unknown>> => defined({
+  conversation_id: input.sessionId,
+  cwd: input.cwd,
+  hook_event_name: nativeEvent,
+  ...(nativeEvent === 'stop'
+    ? { loop_count: input.stopHookActive === true ? 1 : 0, status: 'completed' }
+    : {}),
+  session_id: input.sessionId,
+  tool_input: input.toolInput,
+  tool_name: input.toolName,
+  ...(nativeEvent === 'postToolUse' && input.toolResponse !== undefined
+    ? { tool_output: JSON.stringify(input.toolResponse) }
+    : {}),
+  tool_use_id: input.toolUseId,
+  transcript_path: input.transcriptPath,
+});
+
+export const encodeCursorPlaygroundOutput = (
+  result: Readonly<Record<string, unknown>> | undefined,
+  canonicalEvent: CanonicalHookEvent,
+): Readonly<Record<string, unknown>> | undefined => {
+  if (result === undefined) return undefined;
+  if (canonicalEvent === 'stop') {
+    return result.outcome === 'deny' ? defined({ followup_message: result.reason }) : undefined;
+  }
+  if (canonicalEvent === 'beforeTool') {
+    if (result.outcome === 'deny') {
+      return defined({ agent_message: result.reason, permission: 'deny', user_message: result.reason });
+    }
+    return result.updatedInput === undefined
+      ? undefined
+      : { permission: 'allow', updated_input: result.updatedInput };
+  }
+  return result.additionalContext === undefined
+    ? undefined
+    : { additional_context: result.additionalContext };
+};
+
+/** Emits the published Cursor hook wrapper source; see encodeCursorPlaygroundInput for the envelope contract. */
+export const cursorHookWrapperSource = (entry: TargetHookWrapper): string => [
+  `import * as handlerModule from ${JSON.stringify(entry.hook.source)};`,
+  'const target = "cursor";',
+  `const canonicalEvent = ${JSON.stringify(entry.event)};`,
+  `const nativeEvent = ${JSON.stringify(entry.nativeEvent)};`,
+  '',
+  'const isRecord = (value) => typeof value === "object" && value !== null && !Array.isArray(value);',
+  'const defined = (value) => Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));',
+  'const fail = (message) => { throw new Error(`Agent Bundle hook error: ${message}`); };',
+  'const parsedToolOutput = (nativeInput) => {',
+  '  if (canonicalEvent !== "afterTool") return undefined;',
+  '  let parsed;',
+  '  try { parsed = JSON.parse(nativeInput.tool_output); } catch { fail("native tool_output must be a JSON string"); }',
+  '  if (!isRecord(parsed)) fail("native tool_output must encode an object");',
+  '  return parsed;',
+  '};',
+  'const decodeCursorNative = (nativeInput) => defined({',
+  '  cwd: nativeInput.cwd,',
+  '  hookEventName: nativeInput.hook_event_name,',
+  '  sessionId: nativeInput.session_id ?? nativeInput.conversation_id,',
+  '  stopHookActive: canonicalEvent === "stop" ? nativeInput.loop_count > 0 : undefined,',
+  '  toolInput: nativeInput.tool_input,',
+  '  toolName: nativeInput.tool_name,',
+  '  toolResponse: parsedToolOutput(nativeInput),',
+  '  toolUseId: nativeInput.tool_use_id,',
+  '  transcriptPath: nativeInput.transcript_path ?? undefined,',
+  '});',
+  'const encodeCursorNative = (canonicalInput) => defined({',
+  '  conversation_id: canonicalInput.sessionId,',
+  '  cwd: canonicalInput.cwd,',
+  '  hook_event_name: nativeEvent,',
+  '  ...(canonicalEvent === "stop" ? { loop_count: canonicalInput.stopHookActive === true ? 1 : 0, status: "completed" } : {}),',
+  '  session_id: canonicalInput.sessionId,',
+  '  tool_input: canonicalInput.toolInput,',
+  '  tool_name: canonicalInput.toolName,',
+  '  ...(canonicalEvent === "afterTool" && canonicalInput.toolResponse !== undefined ? { tool_output: JSON.stringify(canonicalInput.toolResponse) } : {}),',
+  '  tool_use_id: canonicalInput.toolUseId,',
+  '  transcript_path: canonicalInput.transcriptPath,',
+  '});',
+  'const validateResult = (result) => {',
+  '  if (result === undefined) return undefined;',
+  '  if (!isRecord(result)) fail("handler must return void or a result object");',
+  '  const allowed = new Set(["outcome", "reason", "updatedInput", "additionalContext"]);',
+  '  for (const key of Object.keys(result)) if (!allowed.has(key)) fail(`handler result has unsupported field ${key}`);',
+  '  if (result.outcome !== undefined && !["continue", "deny", "stop"].includes(result.outcome)) fail("handler result outcome is invalid");',
+  '  if (result.reason !== undefined && typeof result.reason !== "string") fail("handler result reason must be a string");',
+  '  if (result.additionalContext !== undefined && typeof result.additionalContext !== "string") fail("handler result additionalContext must be a string");',
+  '  if (result.updatedInput !== undefined && !isRecord(result.updatedInput)) fail("handler result updatedInput must be an object");',
+  '  if (result.reason !== undefined && !(result.outcome === "deny" && (canonicalEvent === "beforeTool" || canonicalEvent === "stop"))) fail("reason is only valid for a denied beforeTool or stop hook");',
+  '  if (result.outcome === "deny" && (canonicalEvent === "beforeTool" || canonicalEvent === "stop") && (typeof result.reason !== "string" || result.reason.trim().length === 0)) fail(`denied ${canonicalEvent} hook requires a nonempty reason`);',
+  '  if ((canonicalEvent === "sessionStart" || canonicalEvent === "afterTool") && (result.outcome === "deny" || result.outcome === "stop" || result.updatedInput !== undefined)) fail(`${canonicalEvent} cannot deny, stop, or replace input`);',
+  '  if (canonicalEvent === "beforeTool" && (result.outcome === "stop" || (result.outcome === "deny" && result.updatedInput !== undefined))) fail("beforeTool cannot stop or replace input while denying");',
+  '  if (canonicalEvent === "stop" && (result.outcome === "stop" || result.updatedInput !== undefined || result.additionalContext !== undefined)) fail("stop only accepts continue or deny with a reason");',
+  '  return result;',
+  '};',
+  'const encodeOutput = (result) => {',
+  '  if (result === undefined) return undefined;',
+  '  if (canonicalEvent === "stop") return result.outcome === "deny" ? defined({ followup_message: result.reason }) : undefined;',
+  '  if (canonicalEvent === "beforeTool") {',
+  '    if (result.outcome === "deny") return defined({ agent_message: result.reason, permission: "deny", user_message: result.reason });',
+  '    return result.updatedInput === undefined ? undefined : { permission: "allow", updated_input: result.updatedInput };',
+  '  }',
+  '  return result.additionalContext === undefined ? undefined : { additional_context: result.additionalContext };',
+  '};',
+  'const decodeOutput = (nativeOutput) => {',
+  '  if (nativeOutput === undefined) return undefined;',
+  '  if (canonicalEvent === "stop") return typeof nativeOutput.followup_message === "string" ? { outcome: "deny", reason: nativeOutput.followup_message } : undefined;',
+  '  if (canonicalEvent === "beforeTool") {',
+  '    if (nativeOutput.permission === "deny") return defined({ outcome: "deny", reason: nativeOutput.agent_message });',
+  '    return defined({ outcome: "continue", updatedInput: nativeOutput.updated_input });',
+  '  }',
+  '  return defined({ additionalContext: nativeOutput.additional_context, outcome: "continue" });',
+  '};',
+  'const requireString = (input, field) => {',
+  '  if (typeof input[field] !== "string") fail(`native ${field} must be a string`);',
+  '};',
+  'const validateNativeInput = (input) => {',
+  '  if (input.hook_event_name !== nativeEvent) fail(`native hook_event_name must equal ${nativeEvent}`);',
+  '  if (typeof input.session_id !== "string" && typeof input.conversation_id !== "string") fail("native session_id or conversation_id must be a string");',
+  '  if (input.transcript_path !== undefined && input.transcript_path !== null && typeof input.transcript_path !== "string") fail("native transcript_path must be a string or null");',
+  '  if (canonicalEvent === "sessionStart") return;',
+  '  if (canonicalEvent === "beforeTool" || canonicalEvent === "afterTool") {',
+  '    requireString(input, "tool_name");',
+  '    if (!isRecord(input.tool_input)) fail(`native ${nativeEvent} tool_input must be an object`);',
+  '    requireString(input, "tool_use_id");',
+  '    if (canonicalEvent === "afterTool") requireString(input, "tool_output");',
+  '    return;',
+  '  }',
+  '  if (typeof input.loop_count !== "number") fail("native stop loop_count must be a number");',
+  '  requireString(input, "status");',
+  '};',
+  'const run = async () => {',
+  '  const handler = Reflect.get(handlerModule, "default");',
+  '  if (typeof handler !== "function") fail("default export must be a function");',
+  '  let raw = "";',
+  '  for await (const chunk of process.stdin) raw += chunk;',
+  '  if (raw.trim().length === 0) fail("stdin must contain exactly one JSON value");',
+  '  let input;',
+  '  try { input = JSON.parse(raw); } catch { fail("stdin must contain exactly one JSON value"); }',
+  '  if (!isRecord(input)) fail("stdin JSON value must be an object");',
+  '  const simulation = process.env.AGENT_BUNDLE_HOOK_SIMULATION === "1";',
+  '  const nativeInput = simulation ? encodeCursorNative(input) : input;',
+  '  validateNativeInput(nativeInput);',
+  '  const event = decodeCursorNative(nativeInput);',
+  '  const result = validateResult(await handler(event, { nativeEvent, nativeInput, target }));',
+  '  const nativeOutput = encodeOutput(result);',
+  '  const output = simulation ? decodeOutput(nativeOutput) : nativeOutput;',
+  '  if (output !== undefined) process.stdout.write(JSON.stringify(output));',
+  '};',
+  'if (import.meta.main) {',
+  '  await run().catch((error) => {',
+  '    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\\n`);',
+  '    process.exitCode = 1;',
+  '  });',
+  '}',
+  '',
+].join('\n');
 
 export interface HookPlan {
   readonly diagnostics: readonly Diagnostic[];
@@ -353,19 +569,26 @@ export const planHooks = (
     if (diagnostics.length > diagnosticCount) continue;
     const relativePath = contract.wrapperPath(hook);
     const command = generatedHookCommand(contract, relativePath);
-    const hookCommand = {
+    const entryInput: TargetHookDocumentEntryInput = {
       command,
-      ...(hook.timeout === undefined ? {} : { timeout: hook.timeout }),
-      type: 'command',
-    };
-    const group = {
-      hooks: [hookCommand],
       ...(matcher === undefined ? {} : { matcher }),
+      ...(hook.timeout === undefined ? {} : { timeout: hook.timeout }),
     };
+    const group = contract.documentEntry === undefined
+      ? {
+          hooks: [{
+            command,
+            ...(hook.timeout === undefined ? {} : { timeout: hook.timeout }),
+            type: 'command',
+          }],
+          ...(matcher === undefined ? {} : { matcher }),
+        }
+      : contract.documentEntry(entryInput);
     (groups[nativeEvent] ??= []).push(group);
     const wrapper: TargetHookWrapper = {
       event: hook.event,
       hook,
+      ...(contract.indexedWrappers === false ? { indexed: false as const } : {}),
       nativeEvent,
       ...(matcher === undefined ? {} : { nativeMatcher: matcher }),
       relativePath,
@@ -376,7 +599,9 @@ export const planHooks = (
 
   return Object.freeze({
     diagnostics: Object.freeze(diagnostics),
-    ...(Object.keys(groups).length === 0 ? {} : { document: { hooks: groups } }),
+    ...(Object.keys(groups).length === 0
+      ? {}
+      : { document: contract.documentEnvelope === undefined ? { hooks: groups } : contract.documentEnvelope(groups) }),
     hookEntries: Object.freeze(hookEntries),
   });
 };

--- a/packages/agent-bundle/src/adapters/plugin.ts
+++ b/packages/agent-bundle/src/adapters/plugin.ts
@@ -13,6 +13,7 @@ import codexCapabilityTable from './capabilities/codex-0.147.0.json' with { type
 import { claudeAdapter, claudeArtifactPaths, claudeHooksValidator, planClaudeArtifacts } from './claude.ts';
 import { codexAdapter, codexArtifactPaths, codexPluginDocumentValidator, planCodexArtifacts } from './codex.ts';
 import {
+  createCursorHookContract,
   cursorAdapter,
   cursorHooksValidator,
   cursorManifest,
@@ -39,6 +40,7 @@ import {
   type TargetArtifactEntry,
   type TargetArtifactLayout,
   type TargetArtifactPlan,
+  type TargetHookEntry,
 } from './types.ts';
 
 const pluginName = 'plugin';
@@ -62,9 +64,11 @@ const pluginName = 'plugin';
  * `skills/` as-is, an explicit pointer to a Cursor-format MCP document (its
  * auto-discovery reads `mcp.json`, never the Claude-convention `.mcp.json`),
  * and - because Cursor auto-discovers `hooks/hooks.json` with an incompatible
- * schema - an explicit pointer to a Cursor-format hooks document. That
- * document stays empty until Cursor's hook stdin contract is pinned; hooks
- * currently serve Claude Code and Codex.
+ * schema - an explicit pointer to a Cursor-format hooks document. Cursor's
+ * hook stdin/stdout envelope is not the shared Claude/Codex format, so that
+ * document points at dedicated per-hook `hooks/<name>.cursor.mjs` wrappers
+ * carrying the Cursor codec; the empty document remains only as a
+ * schema-collision guard when no hook lowers to Cursor.
  *
  * An Agent Plugins v1 root `plugin.json` is deliberately not emitted: Codex
  * selects it ahead of `.codex-plugin/plugin.json` and, under that format,
@@ -224,7 +228,7 @@ const agentsDocument = (model: NormalizedPlugin): string => {
     '- `.codex-plugin/` — Codex manifest and host documents.',
     '- `.cursor-plugin/` — Cursor manifest and its MCP document.',
     '- `.mcp.json` — Claude Code MCP configuration (plugin-root convention).',
-    '- `hooks/` — one `hooks.json` and one host-detecting wrapper per hook (Claude Code and Codex; the Cursor hooks document stays empty until its contract is pinned).',
+    '- `hooks/` — one `hooks.json` with a host-detecting wrapper per hook (Claude Code and Codex), plus `hooks-cursor.json` with per-hook Cursor wrappers (`<name>.cursor.mjs`).',
     '- `skills/` — agent skills (`SKILL.md` per skill), shared by every host.',
     '- `scripts/`, `mcp/`, `mcp-apps/`, `assets/` — compiled shared surfaces.',
     '',
@@ -267,6 +271,12 @@ const mergeEntries = (
 };
 
 const cursorMcpPlanContext = Object.freeze({ codePrefix: 'plugin.cursor', errorDiagnostic });
+
+const cursorBundleHookContract = createCursorHookContract({
+  indexedWrappers: false,
+  manifestPath: cursorPaths.hooks,
+  wrapperPath: (hook: NormalizedHook) => `hooks/${hook.name}.cursor.mjs`,
+});
 
 const plan = (model: NormalizedPlugin): TargetArtifactPlan => {
   const diagnostics: Diagnostic[] = [];
@@ -319,6 +329,7 @@ const plan = (model: NormalizedPlugin): TargetArtifactPlan => {
   const cursorMcpValid = cursorMcp !== undefined && cursorMcpValidator(cursorMcp);
   if (cursorMcp !== undefined) diagnostics.push(...schemaDiagnostics('cursor-mcp', cursorMcpValid, cursorMcpValidator.errors));
 
+  let cursorHookEntries: readonly TargetHookEntry[] = Object.freeze([]);
   if (!isValidCursorPluginName(model.metadata.name)) {
     diagnostics.push(errorDiagnostic(
       'plugin.cursor.name',
@@ -326,6 +337,23 @@ const plan = (model: NormalizedPlugin): TargetArtifactPlan => {
     ));
   } else {
     const emitCursorHooks = hookDocument !== undefined && hookDocumentValid;
+    // Cursor's envelope is not the shared Claude/Codex format, so its hooks
+    // lower separately: a Cursor-shaped document over dedicated
+    // `hooks/<name>.cursor.mjs` wrappers. The empty document remains as a
+    // schema-collision guard when no hook lowers to Cursor.
+    let cursorHooksDocument: Record<string, unknown> = emptyCursorHooksDocument;
+    if (emitCursorHooks) {
+      const cursorHooks = planHooks(model, pluginName, cursorBundleHookContract);
+      diagnostics.push(...cursorHooks.diagnostics);
+      if (cursorHooks.document !== undefined) {
+        const cursorHooksDocumentValid = cursorHooksValidator(cursorHooks.document);
+        diagnostics.push(...schemaDiagnostics('cursor-hooks', cursorHooksDocumentValid, cursorHooksValidator.errors));
+        if (cursorHooksDocumentValid) {
+          cursorHooksDocument = cursorHooks.document;
+          cursorHookEntries = cursorHooks.hookEntries;
+        }
+      }
+    }
     const manifest = cursorManifest(model, {
       ...(emitCursorHooks ? { hooks: `./${cursorPaths.hooks}` } : {}),
       ...(cursorMcp !== undefined && cursorMcpValid ? { mcp: `./${cursorPaths.mcp}` } : {}),
@@ -349,15 +377,16 @@ const plan = (model: NormalizedPlugin): TargetArtifactPlan => {
         });
       }
       if (emitCursorHooks) {
-        // Empty until Cursor's hook stdin contract is pinned; the explicit
-        // pointer keeps Cursor away from the Claude-format hooks/hooks.json.
+        const cursorHookSourceInputs = cursorHookEntries.map((entry) => entry.hook.provenance.sourcePath);
         entries.push({
-          content: `${stableJson(emptyCursorHooksDocument)}\n`,
+          content: `${stableJson(cursorHooksDocument)}\n`,
           kind: 'write',
           relativePath: cursorPaths.hooks,
-          sourceInputs: sourceInputs(...targetSourceInputs),
+          sourceInputs: sourceInputs(...targetSourceInputs, ...cursorHookSourceInputs),
         });
       }
+    } else {
+      cursorHookEntries = Object.freeze([]);
     }
   }
 
@@ -371,7 +400,9 @@ const plan = (model: NormalizedPlugin): TargetArtifactPlan => {
   return Object.freeze({
     diagnostics: Object.freeze(diagnostics),
     entries: sortedEntries(entries),
-    hookEntries: hookDocumentValid ? generatedHooks.hookEntries : Object.freeze([]),
+    hookEntries: hookDocumentValid
+      ? Object.freeze([...generatedHooks.hookEntries, ...cursorHookEntries])
+      : Object.freeze([]),
   });
 };
 

--- a/packages/agent-bundle/src/build/build.ts
+++ b/packages/agent-bundle/src/build/build.ts
@@ -301,7 +301,10 @@ export const build = async (options: BuildOptions): Promise<BuildResult> => {
     ));
     await writeHookIndex({
       artifactRoot: stageRoot,
-      hooks: compiledHooks.map((entry) => ({
+      // Host-document wrapper variants stay out of the canonical index: it
+      // keeps exactly one entry per hook and target, pointing at the
+      // canonical wrapper their target contract simulates.
+      hooks: compiledHooks.filter((entry) => entry.indexed !== false).map((entry) => ({
         event: entry.event,
         id: entry.id,
         name: entry.name,

--- a/packages/agent-bundle/src/build/entries.ts
+++ b/packages/agent-bundle/src/build/entries.ts
@@ -25,6 +25,8 @@ interface PlannedScriptEntry extends CompiledEntry {
 export interface CompiledHookEntry extends CompiledEntry {
   readonly event: TargetHookEntry['event'];
   readonly id: string;
+  /** False when this wrapper is a host-document variant excluded from the canonical hook index. */
+  readonly indexed?: false;
   readonly target: string;
   /** Native hook timeout in seconds. Omit it to use the host default. */
   readonly timeout?: number;
@@ -197,6 +199,7 @@ export const planCompiledHooks = (
 ): readonly CompiledHookEntry[] => Object.freeze(entries.map((entry) => Object.freeze({
   event: entry.event,
   id: entry.hook.id,
+  ...(entry.indexed === false ? { indexed: false as const } : {}),
   name: entry.hook.name,
   output: resolveArtifactDestination(options.outDir, entry.relativePath),
   outputKind: 'bundle',
@@ -214,7 +217,10 @@ export const compileHooks = async (
   const evidence = await buildWithRslib({
     cwd: options.cwd,
     entries: compiled.map((entry, index) => ({
-      name: entry.name,
+      // One hook can compile into several host wrappers (for example a shared
+      // Claude/Codex wrapper plus a Cursor-codec wrapper), so the bundler
+      // library id derives from the unique output path, not the hook name.
+      name: entries[index]!.relativePath.replaceAll('/', '-').replace(/\.mjs$/u, ''),
       outputRelativePath: entries[index]!.relativePath,
       source: entry.source,
       sourceInputs: entry.sourceInputs,

--- a/packages/agent-bundle/tests/adapter-metadata.test.ts
+++ b/packages/agent-bundle/tests/adapter-metadata.test.ts
@@ -130,7 +130,7 @@ it('records exact immutable metadata for every built-in target', () => {
   expect(registryMetadata(registry, 'cursor')).toEqual({
     adapterRevision: '1.0.0',
     capabilityRevision: '2026-08-28',
-    capabilitySha256: 'c9e916ce4caf1865f57078765c27f47a2d225796ac36c1b65ccadf6a5290c86e',
+    capabilitySha256: 'b8990776721f3e2cf4707364812586a0043b8a1247899a47f256302739c00443',
     observedVersion: '2026-08-28',
     schemas: [
       {

--- a/packages/agent-bundle/tests/cursor-adapter.test.ts
+++ b/packages/agent-bundle/tests/cursor-adapter.test.ts
@@ -74,8 +74,8 @@ it('registers cursor as a first-class target with pinned schema validation', () 
   expect(registry.defaultTargetNames()).toEqual(['portable']);
   expect(registry.supports('cursor', 'mcp')).toBe(true);
   expect(registry.supports('cursor', 'skills')).toBe(true);
-  expect(registry.supports('cursor', 'hooks')).toBe(false);
-  expect(registry.hookContract('cursor')).toBeUndefined();
+  expect(registry.supports('cursor', 'hooks')).toBe(true);
+  expect(registry.hookContract('cursor')?.commandRoot).toBe('${CURSOR_PLUGIN_ROOT}');
   expect(registry.artifactValidation('cursor').documents).toEqual([
     { path: '.cursor-plugin/plugin.json', required: true, schema: 'plugin' },
     { path: 'hooks/hooks.json', required: false, schema: 'hooks' },
@@ -143,7 +143,64 @@ it('rejects the plugin-data token and omits the failed server from the document'
   expect(manifest).not.toHaveProperty('mcpServers');
 });
 
-it('never emits hooks and drops hooks scoped to other targets from the plan', () => {
+it('lowers cursor-targeted hooks into the flat versioned document with dedicated wrappers', () => {
+  const model = plugin();
+  const plan = cursorAdapter.plan({
+    ...model,
+    hooks: [
+      {
+        event: 'sessionStart',
+        id: 'hook:session-start',
+        name: 'session-start',
+        provenance: { kind: 'config', sourcePath: configPath },
+        source: '/workspace/src/hooks/session-start.ts',
+        targets: ['cursor'],
+        tools: [],
+      },
+      {
+        event: 'afterTool',
+        id: 'hook:record-write',
+        name: 'record-write',
+        provenance: { kind: 'config', sourcePath: configPath },
+        source: '/workspace/src/hooks/record-write.ts',
+        targets: ['cursor'],
+        timeout: 30,
+        tools: ['file.write'],
+      },
+    ],
+  });
+  expect(plan.diagnostics).toEqual([]);
+
+  const documents = Object.fromEntries(plan.entries
+    .filter((entry): entry is Extract<typeof entry, { readonly kind: 'write' }> => entry.kind === 'write')
+    .map((entry) => [entry.relativePath, entry.content]));
+  expect(JSON.parse(documents['hooks/hooks.json']!)).toEqual({
+    hooks: {
+      postToolUse: [{
+        command: 'node "${CURSOR_PLUGIN_ROOT}/hooks/record-write.mjs"',
+        matcher: '^Write$',
+        timeout: 30,
+      }],
+      sessionStart: [{ command: 'node "${CURSOR_PLUGIN_ROOT}/hooks/session-start.mjs"' }],
+    },
+    version: 1,
+  });
+  expect(JSON.parse(documents['.cursor-plugin/plugin.json']!)).toMatchObject({ hooks: './hooks/hooks.json' });
+
+  const wrappers = plan.hookEntries ?? [];
+  expect(wrappers.map((entry) => entry.relativePath).sort()).toEqual([
+    'hooks/record-write.mjs',
+    'hooks/session-start.mjs',
+  ]);
+  const sessionWrapper = wrappers.find((entry) => entry.relativePath === 'hooks/session-start.mjs');
+  expect(sessionWrapper?.virtualSource).toContain('const target = "cursor";');
+  expect(sessionWrapper?.virtualSource).toContain('decodeCursorNative');
+  expect(sessionWrapper?.virtualSource).toContain('additional_context');
+  const toolWrapper = wrappers.find((entry) => entry.relativePath === 'hooks/record-write.mjs');
+  expect(toolWrapper?.virtualSource).toContain('tool_output');
+});
+
+it('drops hooks scoped to other targets from the plan', () => {
   const model = plugin();
   const plan = cursorAdapter.plan({
     ...model,

--- a/packages/agent-bundle/tests/plugin-bundle.test.ts
+++ b/packages/agent-bundle/tests/plugin-bundle.test.ts
@@ -132,7 +132,16 @@ it('lays both host manifests over one shared bundle root', () => {
   const cursorMcp = JSON.parse(documents['.cursor-plugin/mcp.json']!) as { readonly mcpServers: Record<string, { readonly args: readonly string[] }> };
   expect(cursorMcp.mcpServers['status']!.args[0]).toBe('${CURSOR_PLUGIN_ROOT}/mcp/server.mjs');
   expect(cursorMcp.mcpServers['status']).not.toHaveProperty('type');
-  expect(JSON.parse(documents['hooks/hooks-cursor.json']!)).toEqual({ hooks: {}, version: 1 });
+  expect(JSON.parse(documents['hooks/hooks-cursor.json']!)).toEqual({
+    hooks: {
+      postToolUse: [{
+        command: 'node "${CURSOR_PLUGIN_ROOT}/hooks/record-write.cursor.mjs"',
+        matcher: '^Write$',
+      }],
+      sessionStart: [{ command: 'node "${CURSOR_PLUGIN_ROOT}/hooks/session-start.cursor.mjs"' }],
+    },
+    version: 1,
+  });
 });
 
 it('emits each shared surface exactly once with no duplicate artifact paths', () => {
@@ -144,7 +153,9 @@ it('emits each shared surface exactly once with no duplicate artifact paths', ()
 
   const hookEntries = plan.hookEntries ?? [];
   expect(hookEntries.map((entry) => entry.relativePath).sort()).toEqual([
+    'hooks/record-write.cursor.mjs',
     'hooks/record-write.mjs',
+    'hooks/session-start.cursor.mjs',
     'hooks/session-start.mjs',
   ]);
   expect(new Set(hookEntries.map((entry) => entry.target))).toEqual(new Set(['plugin']));
@@ -245,6 +256,16 @@ it('builds the unified bundle root on disk with a compiled universal hook wrappe
       code: 0,
       stdout: expect.stringContaining('host:codex'),
     });
+    // The Cursor wrapper speaks Cursor's own envelope: session ids over
+    // conversation fields in, snake_case additional_context out.
+    const cursorWrapper = join(bundleRoot, 'hooks', 'session-start.cursor.mjs');
+    const cursorInput = JSON.stringify({
+      composer_mode: 'agent', conversation_id: 'conv-1', cursor_version: '2.4.1', hook_event_name: 'sessionStart',
+      is_background_agent: false, session_id: 'conv-1', transcript_path: null, workspace_roots: ['/workspace'],
+    });
+    const cursorRun = await runNodeScript({ args: [cursorWrapper], input: cursorInput });
+    expect(cursorRun.code).toBe(0);
+    expect(JSON.parse(cursorRun.stdout) as Record<string, unknown>).toEqual({ additional_context: 'host:cursor' });
     const manifest = JSON.parse(await readFile(join(outputRoot, 'agent-bundle.manifest.json'), 'utf8')) as {
       readonly files: readonly { readonly path: string }[];
       readonly targets: readonly { readonly name: string }[];
@@ -256,6 +277,7 @@ it('builds the unified bundle root on disk with a compiled universal hook wrappe
       'plugin/.cursor-plugin/plugin.json',
       'plugin/AGENTS.md',
       'plugin/hooks/hooks-cursor.json',
+      'plugin/hooks/session-start.cursor.mjs',
       'plugin/skills/review/SKILL.md',
     ]));
   } finally {


### PR DESCRIPTION
## Summary
- Completes the last functional gap from the session-mining pass: Cursor hook lowering, previously stubbed with an empty `hooks-cursor.json` because "Cursor's hook stdin contract is undocumented". The contract is now pinned from https://cursor.com/docs/agent/hooks (2026-08-28) and cross-checked against installed Cursor plugins that ship working hooks (`${CURSOR_PLUGIN_ROOT}` interpolation and env var, snake_case `additional_context` output, `version: 1` flat document).
- Cursor's envelope is not the shared Claude/Codex format, so hooks compile into a dedicated Cursor wrapper codec: canonical events map `sessionStart→sessionStart`, `beforeTool→preToolUse`, `afterTool→postToolUse`, `stop→stop`; `tool_output` (JSON-stringified) decodes to the canonical `toolResponse`; a denied `stop` maps to Cursor's `followup_message` loop channel. Host differences are documented in the codec (`additionalContext` from an allowed `beforeTool` has no Cursor channel and is dropped).
- Standalone `cursor` target: emits the flat versioned `hooks/hooks.json` over `hooks/<name>.mjs` wrappers, declares hooks capability + contract, and the manifest carries the explicit hooks pointer.
- Unified `plugin` bundle: emits a real `hooks-cursor.json` over dedicated `hooks/<name>.cursor.mjs` wrapper variants beside the shared Claude/Codex wrappers; the empty document remains only as a schema-collision guard when nothing lowers to Cursor.
- Infrastructure: `planHooks` gains contract-driven document entry/envelope shapes (Cursor's flat entries vs the grouped Claude shape); the canonical hook index keeps one entry per hook+target, so document-variant wrappers are compiled but not separately indexed; rslib library ids derive from output paths since one hook can now compile into several wrappers.
- Capability table gains the pinned hooks events/matchers section (sha256 re-pinned); Claude/Codex wrapper codec parity invariant untouched.

## Test plan
- [x] `pnpm test:unit` — 1665 passed, 0 failed; includes a new end-to-end assertion that the compiled `.cursor.mjs` wrapper, run with a real Cursor `sessionStart` envelope, returns `{"additional_context":"host:cursor"}`
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [ ] PR CI