### PR TITLE
test(workbench): adopt the shared packed-release harness and route helper

### DIFF
--- a/packages/workbench/tests/artifacts-real.e2e.test.ts
+++ b/packages/workbench/tests/artifacts-real.e2e.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@rstest/playwright';
 import { createWorkbenchAssetSource } from '../../agent-bundle/src/dev/workbench-assets.ts';
 import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
-import { buildWorkbench, e2e, workbenchAssets } from './support/workbench-e2e.ts';
+import { buildWorkbench, e2e, workbenchAssets, workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 12_000;
 
@@ -19,7 +19,7 @@ e2e('contains the mounted Artifacts page and its table at desktop and 390px widt
   try {
     const pageErrors: Error[] = [];
     page.on('pageerror', (error) => pageErrors.push(error));
-    await page.goto(`${server.url}#artifacts`);
+    await page.goto(workbenchUrl(server.url, 'artifacts'));
     await expect(page.getByRole('heading', { name: 'Artifacts' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.locator('.artifact-table').first()).toBeVisible({ timeout: browserTimeout });
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);

--- a/packages/workbench/tests/evals-real.e2e.test.ts
+++ b/packages/workbench/tests/evals-real.e2e.test.ts
@@ -15,7 +15,7 @@ import { seedEvalProject, writeEvalSuite } from '../../agent-bundle/tests/suppor
 import { readFinalizedEvalRun } from '../src/evals/evals-page.tsx';
 import { closeServer } from './support/http.ts';
 import { workbenchBrowserAliases } from './support/workbench-browser-modules.ts';
-import { buildWorkbench, e2e, workbenchAssets, workspaceRoot } from './support/workbench-e2e.ts';
+import { buildWorkbench, e2e, workbenchAssets, workspaceRoot, workbenchUrl } from './support/workbench-e2e.ts';
 
 const evalsPage = join(workspaceRoot, 'packages', 'workbench', 'src', 'evals', 'evals-page.tsx');
 const browserTimeout = 12_000;
@@ -228,7 +228,7 @@ e2e('admits a deterministic Eval promptly and renders refreshed durable evidence
     page.on('request', (request) => {
       if (request.method() === 'GET' && request.url().includes('/api/evals/runs/')) durableReads.push(request.url());
     });
-    await page.goto(`${server.url}#evals`);
+    await page.goto(workbenchUrl(server.url, 'evals'));
     await expect(page.getByRole('heading', { name: 'Evals' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByRole('button', { name: 'Run deterministic suite' })).toBeEnabled({ timeout: browserTimeout });
     await expect(page.getByLabel('Harness')).toHaveValue('deterministic');
@@ -326,7 +326,7 @@ e2e('keeps a gated deterministic run cancellable exactly once and rejects stale 
       await heldCancel;
       await route.continue();
     });
-    await page.goto(`${server.url}#evals`);
+    await page.goto(workbenchUrl(server.url, 'evals'));
     await expect(page.getByRole('heading', { name: 'Evals' })).toBeVisible({ timeout: browserTimeout });
     await page.getByLabel('Suite').selectOption('gated-cancel');
     const admitted = page.waitForResponse((response) =>
@@ -381,7 +381,7 @@ e2e('does not cancel a gated run when a newer admission replaces it or the Eval 
     page.on('request', (request) => {
       if (request.method() === 'POST' && request.url().includes('/cancel')) cancellations += 1;
     });
-    await page.goto(`${server.url}#evals`);
+    await page.goto(workbenchUrl(server.url, 'evals'));
     await expect(page.getByRole('heading', { name: 'Evals' })).toBeVisible({ timeout: browserTimeout });
     await page.getByLabel('Suite').selectOption('gated-cancel');
     const firstAdmission = page.waitForResponse((response) =>
@@ -397,7 +397,7 @@ e2e('does not cancel a gated run when a newer admission replaces it or the Eval 
     await expect(page.locator('.eval-summary')).toContainText(replacement.run.id, { timeout: browserTimeout });
     await page.waitForTimeout(150);
     await expect(page.locator('.eval-summary')).not.toContainText(first.run.id);
-    await page.goto(`${server.url}#overview`);
+    await page.goto(workbenchUrl(server.url, 'overview'));
     await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
     expect(cancellations).toBe(0);
   } finally {

--- a/packages/workbench/tests/examples-real.e2e.test.ts
+++ b/packages/workbench/tests/examples-real.e2e.test.ts
@@ -14,7 +14,7 @@ import {
   waitForSettledWorkbench,
   writeExampleReport,
 } from './support/example-acceptance.ts';
-import { buildWorkbench, e2e, workbenchAssets } from './support/workbench-e2e.ts';
+import { buildWorkbench, e2e, workbenchAssets, workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 15_000;
 
@@ -48,7 +48,7 @@ e2e('drives the populated Skills Starter in real Chrome', { timeout: 90_000 }, a
   });
   const ledger = createExampleErrorLedger(page, server.url);
   try {
-    await page.goto(`${server.url}#skills`);
+    await page.goto(workbenchUrl(server.url, 'skills'));
     await waitForSettledWorkbench(page);
     await expect(page.getByRole('heading', { name: 'dependency-upgrade', exact: true })).toBeVisible({ timeout: browserTimeout });
     await expect(page.locator('.skill-tree-item')).toHaveCount(3, { timeout: browserTimeout });
@@ -73,7 +73,7 @@ e2e('drives the populated Skills Starter in real Chrome', { timeout: 90_000 }, a
     );
     await captureExampleState(page, 'skills-starter', 'skills-populated');
 
-    await page.goto(`${server.url}#hooks`);
+    await page.goto(workbenchUrl(server.url, 'hooks'));
     await waitForSettledWorkbench(page);
     await expect(page).toHaveURL(new URL('#overview', server.url).href, { timeout: browserTimeout });
     await expect(page.getByRole('heading', { name: 'Bundle dashboard', exact: true })).toBeVisible({ timeout: browserTimeout });
@@ -126,7 +126,7 @@ e2e('reveals, retains, repairs, and removes capabilities without reloading Chrom
     expect(status).toBe(200);
   };
   try {
-    await page.goto(`${server.url}#hooks`);
+    await page.goto(workbenchUrl(server.url, 'hooks'));
     await waitForSettledWorkbench(page);
     await expect(page).toHaveURL(new URL('#overview', server.url).href, { timeout: browserTimeout });
     await expect(page.getByRole('link', { name: 'Hooks', exact: true })).toHaveCount(0, { timeout: browserTimeout });
@@ -187,7 +187,7 @@ e2e('drives Hooks, scripts, logs, diagnostics, and repair in real Chrome', { tim
   });
   const ledger = createExampleErrorLedger(page, server.url);
   try {
-    await page.goto(`${server.url}#hooks`);
+    await page.goto(workbenchUrl(server.url, 'hooks'));
     await waitForSettledWorkbench(page);
     await expect(page.locator('#hook-binding option')).not.toHaveCount(0, { timeout: browserTimeout });
     const canonicalHookDraft = JSON.stringify({
@@ -285,7 +285,7 @@ e2e('drives every populated MCP App workflow surface in real Chrome', { timeout:
   });
   const ledger = createExampleErrorLedger(page, server.url);
   try {
-    await page.goto(`${server.url}#overview`);
+    await page.goto(workbenchUrl(server.url, 'overview'));
     await waitForSettledWorkbench(page);
     await expect(page.getByRole('heading', { name: 'Bundle dashboard', exact: true })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByText('See what this bundle publishes, try supported workflows, and rebuild after source changes.', { exact: true })).toBeVisible({ timeout: browserTimeout });

--- a/packages/workbench/tests/inspector-shell.e2e.test.ts
+++ b/packages/workbench/tests/inspector-shell.e2e.test.ts
@@ -7,7 +7,7 @@ import { agentBundleNodeModules, workbenchNodeModules } from '../../agent-bundle
 import { createWorkbenchAssetSource } from '../../agent-bundle/src/dev/workbench-assets.ts';
 import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
-import { e2e, execFile, workbenchAssets, workspaceRoot } from './support/workbench-e2e.ts';
+import { e2e, execFile, workbenchAssets, workspaceRoot, workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 5_000;
 
@@ -83,7 +83,7 @@ e2e('treats an unsupported Inspector hash as the overview without opening an MCP
       if (request.url() === `${server.url}/api/mcp/sessions` && request.method() === 'POST') sessionPosts += 1;
     });
 
-    await page.goto(`${server.url}#inspector`);
+    await page.goto(workbenchUrl(server.url, 'inspector'));
     await expect(page).toHaveURL(/#inspector$/u, { timeout: browserTimeout });
     await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByRole('link', { name: 'Overview' })).toHaveAttribute('aria-current', 'page');
@@ -114,7 +114,7 @@ e2e('shares one real session between the MCP Playground and Inspector presentati
       if (request.url() === `${server.url}/api/mcp/sessions` && request.method() === 'POST') sessionPosts += 1;
     });
 
-    await page.goto(`${server.url}#mcp`);
+    await page.goto(workbenchUrl(server.url, 'mcp'));
     const playgroundTab = page.getByRole('tab', { name: 'Playground' });
     const inspectorTab = page.getByRole('tab', { name: 'Inspector' });
     const presentationHistoryLength = await page.evaluate(() => window.history.length);
@@ -246,7 +246,7 @@ e2e('mounts the internal Inspector presentation from an explicit development-mod
   try {
     const pageErrors: Error[] = [];
     page.on('pageerror', (error) => pageErrors.push(error));
-    await page.goto(`${server.url}#mcp`);
+    await page.goto(workbenchUrl(server.url, 'mcp'));
     const inspectorTab = page.getByRole('tab', { name: 'Inspector' });
     await inspectorTab.click();
     await expect(inspectorTab).toHaveAttribute('aria-selected', 'true');

--- a/packages/workbench/tests/logs-real.e2e.test.ts
+++ b/packages/workbench/tests/logs-real.e2e.test.ts
@@ -5,7 +5,7 @@ import { expect } from '@rstest/playwright';
 import { createWorkbenchAssetSource } from '../../agent-bundle/src/dev/workbench-assets.ts';
 import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
-import { buildWorkbench, e2e, workbenchAssets } from './support/workbench-e2e.ts';
+import { buildWorkbench, e2e, workbenchAssets, workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 12_000;
 
@@ -25,7 +25,7 @@ e2e('shows real producer logs with replay, filters, redaction, responsive layout
       const url = new URL(response.url());
       return url.origin === server.url && url.pathname === '/api/logs/replay' && url.searchParams.get('after') === '0' && response.ok();
     });
-    await page.goto(`${server.url}#logs`);
+    await page.goto(workbenchUrl(server.url, 'logs'));
     await expect(page.getByRole('heading', { name: 'Logs' })).toBeVisible({ timeout: browserTimeout });
     const replay = await (await replayed).json() as { readonly replay: Readonly<{ readonly records: readonly unknown[] }> };
     expect(replay.replay.records.length).toBeGreaterThan(0);
@@ -40,9 +40,9 @@ e2e('shows real producer logs with replay, filters, redaction, responsive layout
     await expect(page.locator('.logs-entry-source').first()).toHaveText('project', { timeout: browserTimeout });
     await page.locator('#logs-producer').selectOption('');
     const replayCount = await page.locator('.logs-entries > li').count();
-    await page.goto(`${server.url}#overview`);
+    await page.goto(workbenchUrl(server.url, 'overview'));
     await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
-    await page.goto(`${server.url}#logs`);
+    await page.goto(workbenchUrl(server.url, 'logs'));
     await expect(page.getByRole('heading', { name: 'Logs' })).toBeVisible({ timeout: browserTimeout });
     const replayedSequences = await page.waitForFunction(
       ({ count, selector }) => {

--- a/packages/workbench/tests/mcp-app-real.e2e.test.ts
+++ b/packages/workbench/tests/mcp-app-real.e2e.test.ts
@@ -11,6 +11,7 @@ import { createWorkbenchAssetSource } from '../../agent-bundle/src/dev/workbench
 import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
 import { startRuntimePlaygroundFixture } from './helpers/runtime-playground-fixture.ts';
+import { workbenchUrl } from './support/workbench-e2e.ts';
 
 const workspaceRoot = process.cwd();
 const workbenchAssets = join(workspaceRoot, 'packages', 'workbench', 'dist');
@@ -255,7 +256,7 @@ e2e('runs a generated SDK-v2 App through the real foreground session and separat
       }).catch(() => undefined);
     });
 
-    await page.goto(`${foregroundOrigin}#mcp`);
+    await page.goto(workbenchUrl(foregroundOrigin, 'mcp'));
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await page.locator('#mcp-target').selectOption('portable');
     await page.locator('#mcp-server-name').fill('fixture');
@@ -553,7 +554,7 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     }).catch(() => undefined);
   });
   try {
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: 15_000 });
     const runtimeIdentity = page.locator('[data-runtime-provider-session]');
     const runtimeSurface = page.getByLabel('Runtime surface');
@@ -1430,7 +1431,7 @@ e2e('keeps Portable, ChatGPT, and Claude simulated App profiles isolated over on
     }).catch(() => undefined);
   });
   try {
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: 15_000 });
     const runtimeIdentity = page.locator('[data-runtime-provider-session]');
     const runtimeSurface = page.getByLabel('Runtime surface');
@@ -1648,7 +1649,7 @@ e2e('renders a compiler-bundled App template through the canonical sandbox URL',
       }
     });
 
-    await page.goto(`${foregroundOrigin}#mcp`);
+    await page.goto(workbenchUrl(foregroundOrigin, 'mcp'));
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await page.locator('#mcp-target').selectOption('portable');
     await page.locator('#mcp-server-name').fill('fixture');

--- a/packages/workbench/tests/packed-release.e2e.test.ts
+++ b/packages/workbench/tests/packed-release.e2e.test.ts
@@ -14,10 +14,24 @@ import {
   validateOutageLedger,
   type ConsoleErrorRecord,
 } from './support/packed-outage-ledger.ts';
+import {
+  availablePort,
+  awaitReady,
+  buildPackage,
+  closeChild,
+  descendantProcessIds,
+  execFile,
+  firstRecord,
+  installedEnvironment,
+  isWithin,
+  packageRoot,
+  record,
+  string,
+  workspaceRoot,
+  writeFakeClaude,
+} from './support/packed-release-harness.ts';
+import { workbenchUrl } from './support/workbench-e2e.ts';
 
-const execFile = promisify((await import('node:child_process')).execFile);
-const workspaceRoot = process.cwd();
-const packageRoot = join(workspaceRoot, 'packages', 'agent-bundle');
 const fixtureRoot = join(workspaceRoot, 'fixtures', 'integration', 'packed-release');
 const browserTimeout = 12_000;
 const packedServerStartupBudget = 45_000;
@@ -26,7 +40,6 @@ const productTemporaryRootPrefixes = [
   'agent-bundle-mcp-',
   'agent-bundle-playground-script-',
 ] as const;
-let builtPackage: Promise<void> | undefined;
 
 const expectedAgentApiToolNames = [
   'project_status',
@@ -50,170 +63,6 @@ const e2e = test.extend({
     contextOptions: { viewport: { height: 900, width: 1440 } },
   } satisfies PlaywrightOptions,
 });
-
-const installedEnvironment = (): NodeJS.ProcessEnv => {
-  const { NODE_PATH: _nodePath, ...environment } = process.env;
-  return environment;
-};
-
-const availablePort = async (): Promise<number> => {
-  const server = createServer();
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    server.once('error', rejectPromise);
-    server.listen({ host: '127.0.0.1', port: 0 }, resolvePromise);
-  });
-  const address = server.address();
-  if (address === null || typeof address === 'string') throw new Error('Expected a TCP address.');
-  await new Promise<void>((resolvePromise, rejectPromise) => server.close((error) => {
-    if (error === undefined) resolvePromise();
-    else rejectPromise(error);
-  }));
-  return address.port;
-};
-
-const buildPackage = (): Promise<void> => builtPackage ??= (async (): Promise<void> => {
-  const { RSTEST: _rstest, ...environment } = process.env;
-  await execFile('npm', ['run', 'build'], {
-    cwd: workspaceRoot,
-    env: { ...environment, NODE_ENV: 'production' },
-  });
-})();
-
-const awaitReady = async (origin: string, child: ChildProcess, output: () => string): Promise<void> => {
-  const startedAt = Date.now();
-  const diagnostics = (): string =>
-    `after ${String(Date.now() - startedAt)}ms (PID ${String(child.pid ?? 'unknown')}): ${output()}`;
-  while (Date.now() - startedAt < packedServerStartupBudget) {
-    if (child.exitCode !== null) throw new Error(`The packed dev server exited before readiness ${diagnostics()}`);
-    try {
-      if ((await fetch(origin)).ok) return;
-    } catch {
-      // The fixed loopback port is not ready yet.
-    }
-    await new Promise<void>((resolvePromise) => { setTimeout(resolvePromise, 50); });
-  }
-  throw new Error(`Timed out waiting for the packed dev server ${diagnostics()}`);
-};
-
-const childExitedWithin = (child: ChildProcess, timeoutMs: number): Promise<boolean> => {
-  if (child.exitCode !== null) return Promise.resolve(true);
-  return new Promise((resolvePromise, rejectPromise) => {
-    const finish = (exited: boolean): void => {
-      clearTimeout(timeout);
-      child.off('exit', onExit);
-      child.off('error', onError);
-      resolvePromise(exited);
-    };
-    const onExit = (): void => { finish(true); };
-    const onError = (error: Error): void => {
-      clearTimeout(timeout);
-      child.off('exit', onExit);
-      rejectPromise(error);
-    };
-    child.once('exit', onExit);
-    child.once('error', onError);
-    const timeout = setTimeout(() => { finish(false); }, timeoutMs);
-    if (child.exitCode !== null) finish(true);
-  });
-};
-
-const closeChild = async (child: ChildProcess): Promise<void> => {
-  if (child.exitCode !== null) return;
-  const signalAndWait = async (signal: NodeJS.Signals): Promise<boolean> => {
-    if (child.exitCode !== null) return true;
-    if (!child.kill(signal)) {
-      if (child.exitCode !== null) return true;
-      throw new Error(`The packed dev server could not receive ${signal}.`);
-    }
-    return childExitedWithin(child, 5_000);
-  };
-  const closeFailures: unknown[] = [];
-  try {
-    if (await signalAndWait('SIGTERM')) return;
-    closeFailures.push(new Error('The packed dev server did not exit after SIGTERM.'));
-  } catch (error) {
-    closeFailures.push(error);
-  }
-  let forceExited = false;
-  try { forceExited = await signalAndWait('SIGKILL'); }
-  catch (error) { closeFailures.push(error); }
-  if (forceExited) throw new AggregateError(closeFailures, 'The packed dev server required SIGKILL after SIGTERM.');
-  closeFailures.push(new Error('The packed dev server remained alive after SIGKILL.'));
-  throw new AggregateError(closeFailures, 'The packed dev server could not be stopped.');
-};
-
-const writeFakeClaude = async (root: string): Promise<string> => {
-  const directory = join(root, '.packed-release-fake-claude');
-  const executable = join(directory, 'claude');
-  await mkdir(directory, { recursive: true });
-  await Promise.all([
-    writeFile(executable, '#!/bin/sh\nexec node "$(dirname "$0")/claude.mjs" "$@"\n'),
-    writeFile(join(directory, 'claude.mjs'), [
-      "import { writeFileSync } from 'node:fs';",
-      '',
-      'const args = process.argv.slice(2);',
-      "if (args[0] === '--version') { process.stdout.write('2.1.240 (Claude Code)\\n'); process.exit(0); }",
-      "if (args[0] === 'auth' && args[1] === 'status') { process.stdout.write('{\"authMethod\":\"claude.ai\",\"loggedIn\":true,\"subscriptionType\":\"max\"}\\n'); process.exit(0); }",
-      "const prompt = args.at(-1) ?? '';",
-      "if (prompt.includes('Wait for packed native cancellation.')) setInterval(() => undefined, 1_000);",
-      "writeFileSync('result.json', '{\"risk\":\"packed-native\"}\\n');",
-      'process.stdout.write([',
-      "  '{\"type\":\"system\",\"subtype\":\"init\",\"plugins\":[{\"name\":\"packed-release-fixture\"}],\"mcp_servers\":[{\"name\":\"fixture\"}]}',",
-      "  '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Skill\",\"input\":{\"skill\":\"packed-release-fixture:review\"}}]}}',",
-      "  '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"mcp__fixture__show-dashboard\",\"input\":{}}]}}',",
-      "  '{\"type\":\"system\",\"hook_event_name\":\"SessionStart\"}',",
-      "  '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"duration_ms\":7,\"num_turns\":2,\"result\":\"Packed native fixture completed.\",\"usage\":{\"input_tokens\":4,\"output_tokens\":2}}',",
-      "  '',",
-      "].join('\\n'));",
-      '',
-    ].join('\n')),
-  ]);
-  await chmod(executable, 0o755);
-  return directory;
-};
-
-const record = (value: unknown, label: string): Record<string, unknown> => {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`Expected ${label} to be an object: ${JSON.stringify(value)}`);
-  return value as Record<string, unknown>;
-};
-
-const string = (value: unknown, label: string): string => {
-  if (typeof value !== 'string') throw new Error(`Expected ${label} to be a string.`);
-  return value;
-};
-
-const firstRecord = (value: unknown, label: string): Record<string, unknown> => {
-  if (!Array.isArray(value) || value.length === 0) throw new Error(`Expected ${label} to contain one entry.`);
-  return record(value[0], `${label}[0]`);
-};
-
-const isWithin = (parent: string, candidate: string): boolean => {
-  const path = relative(parent, candidate);
-  return path.length === 0 || (!isAbsolute(path) && !path.startsWith('..'));
-};
-
-const descendantProcessIds = async (parentProcessId: number): Promise<readonly number[]> => {
-  const { stdout } = await execFile('ps', ['-eo', 'pid=,ppid=']);
-  const children = new Map<number, number[]>();
-  for (const row of stdout.split('\n')) {
-    const [processIdText, ancestorProcessIdText] = row.trim().split(/\s+/u);
-    const processId = Number(processIdText);
-    const ancestorProcessId = Number(ancestorProcessIdText);
-    if (!Number.isInteger(processId) || !Number.isInteger(ancestorProcessId)) continue;
-    const descendants = children.get(ancestorProcessId) ?? [];
-    descendants.push(processId);
-    children.set(ancestorProcessId, descendants);
-  }
-  const descendants = new Set<number>();
-  const pending = [...(children.get(parentProcessId) ?? [])];
-  while (pending.length > 0) {
-    const processId = pending.pop();
-    if (processId === undefined || descendants.has(processId)) continue;
-    descendants.add(processId);
-    pending.push(...(children.get(processId) ?? []));
-  }
-  return [...descendants];
-};
 
 const isAppRoute = (url: URL): boolean =>
   url.pathname.startsWith('/api/mcp/apps/') || /^\/api\/mcp\/sessions\/[^/]+\/apps$/u.test(url.pathname);
@@ -397,7 +246,7 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 }
       ).map((request) => `${request.method} ${request.url}`), { timeout: browserTimeout }).toEqual([]);
     };
     phase = 'browser startup navigation';
-    await page.goto(`${origin}#overview`);
+    await page.goto(workbenchUrl(origin, 'overview'));
     phase = 'browser startup dashboard';
     await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
     phase = 'browser startup build health';
@@ -491,16 +340,16 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 }
         .toEqual(expect.objectContaining({ outcome: 'continue' }));
 
       phase = 'Skills and Artifacts pages';
-      await page.goto(`${origin}#skills`);
+      await page.goto(workbenchUrl(origin, 'skills'));
       await expect(page.getByRole('heading', { name: 'Skills' })).toBeVisible({ timeout: browserTimeout });
       await expect(page.getByRole('heading', { name: 'review', exact: true })).toBeVisible({ timeout: browserTimeout });
-      await page.goto(`${origin}#artifacts`);
+      await page.goto(workbenchUrl(origin, 'artifacts'));
       await expect(page.getByRole('heading', { name: 'Artifacts' })).toBeVisible({ timeout: browserTimeout });
       await expect(page.getByRole('heading', { name: 'Artifact tree' })).toBeVisible({ timeout: browserTimeout });
 
       phase = 'Hooks page simulation';
       const hookListing = page.waitForResponse((response) => new URL(response.url()).pathname === '/api/hooks');
-      await page.goto(`${origin}#hooks`);
+      await page.goto(workbenchUrl(origin, 'hooks'));
       phase = 'Hooks page heading';
       await expect(page.getByRole('heading', { name: 'Hooks' })).toBeVisible({ timeout: browserTimeout });
       phase = 'Hooks catalog';
@@ -525,7 +374,7 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 }
       await expect(page.getByRole('heading', { name: 'Canonical result' })).toBeVisible({ timeout: browserTimeout });
 
       phase = 'MCP, Inspector, and App pages';
-      await page.goto(`${origin}#mcp`);
+      await page.goto(workbenchUrl(origin, 'mcp'));
       await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
       await page.locator('#mcp-target').selectOption('portable');
       await page.locator('#mcp-server-name').fill('fixture');
@@ -559,24 +408,24 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 }
       await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
 
       phase = 'Logs, Evals, and Comparisons pages';
-      await page.goto(`${origin}#logs`);
+      await page.goto(workbenchUrl(origin, 'logs'));
       phase = 'Logs page heading';
       await expect(page.getByRole('heading', { name: 'Logs' })).toBeVisible({ timeout: browserTimeout });
       const initialEvalsRequestIndex = browserRequests.length;
-      await page.goto(`${origin}#evals`);
+      await page.goto(workbenchUrl(origin, 'evals'));
       phase = 'Evals page heading';
       await expect(page.getByRole('heading', { name: 'Evals' })).toBeVisible({ timeout: browserTimeout });
       phase = 'Evals suite catalog';
       await expect(page.getByLabel('Suite')).toContainText('packed-deterministic', { timeout: browserTimeout });
       await waitForBrowserRequestsAfter(initialEvalsRequestIndex);
       const initialComparisonsRequestIndex = browserRequests.length;
-      await page.goto(`${origin}#comparisons`);
+      await page.goto(workbenchUrl(origin, 'comparisons'));
       phase = 'Comparisons page heading';
       await expect(page.getByRole('heading', { name: 'Comparisons' })).toBeVisible({ timeout: browserTimeout });
       await waitForBrowserRequestsAfter(initialComparisonsRequestIndex);
 
       phase = 'Playground direct skill';
-      await page.goto(`${origin}#playground`);
+      await page.goto(workbenchUrl(origin, 'playground'));
       await expect(page.getByRole('heading', { name: 'Playground' })).toBeVisible({ timeout: browserTimeout });
       await page.locator('#playground-operation').selectOption('skill.inspect');
       await page.locator('#playground-target').selectOption('portable');

--- a/packages/workbench/tests/playground-real.e2e.test.ts
+++ b/packages/workbench/tests/playground-real.e2e.test.ts
@@ -9,6 +9,7 @@ import { agentBundleNodeModules, workbenchNodeModules } from '../../agent-bundle
 import { createWorkbenchAssetSource } from '../../agent-bundle/src/dev/workbench-assets.ts';
 import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
+import { workbenchUrl } from './support/workbench-e2e.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -189,7 +190,7 @@ e2e('executes server-owned Playground operations with pinned traces, export, pro
       }
     });
 
-    await page.goto(`${server.url}#hooks`);
+    await page.goto(workbenchUrl(server.url, 'hooks'));
     await expect(page.getByRole('heading', { name: 'Hooks' })).toBeVisible({ timeout: browserTimeout });
     const hookOption = page.locator('#hook-binding option').first();
     await expect(hookOption).toBeAttached({ timeout: browserTimeout });
@@ -197,7 +198,7 @@ e2e('executes server-owned Playground operations with pinned traces, export, pro
     if (hookKey === null || !hookKey.startsWith('claude/')) throw new Error('Expected the fixture to publish one selectable Claude Hook binding.');
     const hookId = hookKey.slice('claude/'.length);
 
-    await page.goto(`${server.url}#playground`);
+    await page.goto(workbenchUrl(server.url, 'playground'));
     await expect(page.getByRole('heading', { name: 'Playground' })).toBeVisible({ timeout: browserTimeout });
     await page.locator('#playground-operation').selectOption('skill.inspect');
     await page.locator('#playground-target').selectOption('claude');

--- a/packages/workbench/tests/runtime-playground-hmr.e2e.test.ts
+++ b/packages/workbench/tests/runtime-playground-hmr.e2e.test.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { expect, test, type PlaywrightOptions } from '@rstest/playwright';
 
 import { startRuntimePlaygroundFixture } from './helpers/runtime-playground-fixture.ts';
+import { workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 30_000;
 
@@ -131,7 +132,7 @@ e2e('activates an edited RSC generation and replays the selected hook without re
   let clientPage: Awaited<ReturnType<typeof context.newPage>> | undefined;
   let clientSurface: Awaited<ReturnType<typeof fixture.openRuntimeClientSurface>> | undefined;
   try {
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const runtimeSessionToken = await page.evaluate(async () => {
       const response = await fetch('/api/project/session', { credentials: 'same-origin' });

--- a/packages/workbench/tests/runtime-playground.e2e.test.ts
+++ b/packages/workbench/tests/runtime-playground.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, type PlaywrightOptions } from '@rstest/playwright';
 
 import { startRuntimePlaygroundFixture } from './helpers/runtime-playground-fixture.ts';
+import { workbenchUrl } from './support/workbench-e2e.ts';
 
 const browserTimeout = 12_000;
 
@@ -28,13 +29,13 @@ e2e('renders the capability-gated Runtime sibling in the real RSC workbench', { 
     }
   });
   try {
-    await page.goto(`${fixture.url}#overview`);
+    await page.goto(workbenchUrl(fixture.url, 'overview'));
     await expect(page.getByRole('link', { exact: true, name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByRole('link', { name: 'Inspector' })).toHaveCount(0, { timeout: browserTimeout });
     await expect(page.getByRole('link', { name: 'Runtime' })).toBeVisible({ timeout: browserTimeout });
 
     for (const sibling of ['hooks', 'artifacts', 'playground', 'logs'] as const) {
-      await page.goto(`${fixture.url}#${sibling}`);
+      await page.goto(workbenchUrl(fixture.url, sibling));
       await expect(page.locator(`#${sibling}`)).toBeVisible({ timeout: browserTimeout });
       expect(
         await page.getByRole('link', { name: 'Runtime' }).count(),
@@ -42,15 +43,15 @@ e2e('renders the capability-gated Runtime sibling in the real RSC workbench', { 
       ).toBe(1);
     }
 
-    await page.goto(`${fixture.url}#mcp`);
+    await page.goto(workbenchUrl(fixture.url, 'mcp'));
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByLabel('MCP App preview controls')).toHaveCount(1, { timeout: browserTimeout });
     await page.getByRole('tab', { name: 'Inspector' }).click();
     await expect(page.getByRole('tab', { name: 'Inspector' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByRole('heading', { name: 'Inspector' })).toBeVisible({ timeout: browserTimeout });
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
-    await page.goto(`${fixture.url}#mcp`);
+    await page.goto(workbenchUrl(fixture.url, 'mcp'));
     await page.getByRole('tab', { name: 'Inspector' }).click();
     await expect(page.getByRole('tab', { name: 'Inspector' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByRole('heading', { name: 'Inspector' })).toBeVisible({ timeout: browserTimeout });
@@ -59,7 +60,7 @@ e2e('renders the capability-gated Runtime sibling in the real RSC workbench', { 
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByLabel('MCP App preview controls')).toHaveCount(1, { timeout: browserTimeout });
 
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.locator('[data-runtime-provider-session]')).toHaveCount(1, { timeout: browserTimeout });
     const runtimeIdentity = await page.evaluate(async () => {
@@ -101,11 +102,11 @@ e2e('renders the capability-gated Runtime sibling in the real RSC workbench', { 
     await expect(input).toHaveValue(/"limit": 2/);
     await input.fill('{"broken":');
     await expect(page.locator('#runtime-input-raw-error')).toBeVisible();
-    await page.goto(`${fixture.url}#mcp`);
+    await page.goto(workbenchUrl(fixture.url, 'mcp'));
     await page.getByRole('tab', { name: 'Inspector' }).click();
     await expect(page.getByRole('tab', { name: 'Inspector' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByRole('heading', { name: 'Inspector' })).toBeVisible({ timeout: browserTimeout });
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.locator('[data-runtime-provider-session]')).toHaveCount(1, { timeout: browserTimeout });
     await expect(input).toHaveValue('{"broken":');
@@ -190,7 +191,7 @@ e2e('renders the capability-gated Runtime sibling in the real RSC workbench', { 
     const stateTab = page.getByRole('tab', { name: 'State', exact: true });
     await stateTab.click();
     await expect(stateTab).toHaveAttribute('aria-selected', 'true');
-    await page.goto(`${fixture.url}#mcp`);
+    await page.goto(workbenchUrl(fixture.url, 'mcp'));
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.getByLabel('MCP App preview controls')).toHaveCount(1, { timeout: browserTimeout });
     expect(forbiddenRequests).toEqual([]);
@@ -206,7 +207,7 @@ e2e('keeps Runtime controls at least 40px tall and inside the 390px viewport wit
   page.on('pageerror', (error) => pageErrors.push(error));
   try {
     await page.setViewportSize({ height: 844, width: 390 });
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(page.locator('[data-runtime-provider-session]')).toHaveCount(1, { timeout: browserTimeout });
     await page.getByLabel('Runtime surface').selectOption('mcp.recent_edits');
@@ -379,7 +380,7 @@ e2e('resets the selected Claude fixture to its seed without replacing prior runt
     }
   });
   try {
-    await page.goto(`${fixture.url}#runtime`);
+    await page.goto(workbenchUrl(fixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const identity = page.locator('[data-runtime-provider-session]');
     await expect(identity).toHaveCount(1, { timeout: browserTimeout });
@@ -540,7 +541,7 @@ e2e('retains real MCP runtime history across reload and isolates a fresh provide
   context.on('request', recordRequest);
   page.on('pageerror', (error) => pageErrors.push(error));
   try {
-    await page.goto(`${firstFixture.url}#runtime`);
+    await page.goto(workbenchUrl(firstFixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const identity = page.locator('[data-runtime-provider-session]');
     await expect(identity).toHaveCount(1, { timeout: browserTimeout });
@@ -679,7 +680,7 @@ e2e('retains real MCP runtime history across reload and isolates a fresh provide
 
     await firstFixture.close();
     secondFixture = await startRuntimePlaygroundFixture();
-    await page.goto(`${secondFixture.url}#runtime`);
+    await page.goto(workbenchUrl(secondFixture.url, 'runtime'));
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     await expect(identity).toHaveCount(1, { timeout: browserTimeout });
     await expect.poll(() => identity.getAttribute('data-runtime-provider-session'), { timeout: browserTimeout }).not.toBe(firstHistory.providerSessionId);

--- a/packages/workbench/tests/support/workbench-e2e.ts
+++ b/packages/workbench/tests/support/workbench-e2e.ts
@@ -19,6 +19,13 @@ export const e2e = test.extend({
   } satisfies PlaywrightOptions,
 });
 
+/**
+ * Canonical Workbench route URL for browser navigation. The dedicated
+ * route-contract test (overview.e2e) keeps literal hash strings so this
+ * helper cannot make its assertions self-fulfilling.
+ */
+export const workbenchUrl = (origin: string, page: string): string => `${origin}#${page}`;
+
 let workbenchBuild: Promise<void> | undefined;
 
 export const buildWorkbench = (): Promise<void> => workbenchBuild ??= (async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- Applies two reviewer recommendations mined from the Aug 26 Codex review sessions:
  - `packed-release.e2e.test.ts` duplicated the entire `support/packed-release-harness.ts` module (extracted by an earlier session but never wired in). The test now imports the shared helpers — dropping 152 duplicate lines (1300 → 1148) and picking up the harness's more robust fake-claude launcher, which resolves `process.execPath` instead of assuming `node` on the packed server's clamped PATH. Nine of the twelve helpers were byte-identical; `buildPackage` (`pnpm build` vs `npm run build`) and `writeFakeClaude` (parametrized, identical default behavior — verified line-by-line) are equivalent.
  - Adds the suggested test-only `workbenchUrl(origin, page)` helper and converts ~35 route-navigation call sites across ten browser suites. The dedicated route-contract test (`overview.e2e.test.ts`) keeps its literal hash strings, per the reviewer's note, so the helper cannot make its assertions self-fulfilling.
- The full 1,301-line body split remains future work (it is one sequential scenario with pervasive shared state); this lands the safe, started-but-abandoned first step.

## Test plan
- [x] `packed-release.e2e.test.ts` full run locally — "runs every Agent API tool from the installed tarball" passes (52s)
- [x] `pnpm typecheck` / `pnpm rslint` — clean
- [ ] PR CI (remaining browser suites)