### PR TITLE
fix(tests): destroy browser-held connections before closing fixture servers

### DIFF
--- a/packages/workbench/tests/evals-real.e2e.test.ts
+++ b/packages/workbench/tests/evals-real.e2e.test.ts
@@ -462,7 +462,6 @@ e2e('fails closed while replacing an active Eval client and ignores every late c
     }).__evalClientScopeFixture.stats().eventsB)).toEqual(['run-b']);
     expect(pageErrors).toEqual([]);
   } finally {
-    await page.goto('about:blank');
     await fixture.close();
   }
 });

--- a/packages/workbench/tests/support/http.ts
+++ b/packages/workbench/tests/support/http.ts
@@ -1,6 +1,14 @@
 import type { Server } from 'node:http';
 
+/**
+ * Teardown must not wait for the browser to release its connections: Node's
+ * `server.close()` blocks while any connection still has a request in flight,
+ * which hangs test teardown on two-core CI runners where the page can hold a
+ * request open at close time. Destroying connections first keeps `close()`
+ * deterministic regardless of browser state.
+ */
 export const closeServer = async (server: Server): Promise<void> => {
+  server.closeAllConnections();
   await new Promise<void>((resolve, reject) => {
     server.close((error) => error === undefined ? resolve() : reject(error));
   });


### PR DESCRIPTION
## Summary

Follow-up to #20, which merged while its final `Verify (Node 22.19.0)` run was still executing; that run then failed in `evals-real.e2e.test.ts > ignores delayed client-A suite and run-list completions after the client scope changes`, timing out at its full 120s budget with all 4 assertions completed — i.e. the hang was in the `finally` block's `fixture.close()`.

Root cause: the shared `closeServer` teardown in `packages/workbench/tests/support/http.ts` only calls `server.close()`, which per Node semantics waits for any connection that still has a request in flight. On a two-core CI runner the Playwright page can hold a request open at close time, so teardown blocks for the entire test budget. This was previously band-aided for the *sibling* client-scope test only (ad3a5bc navigated to `about:blank` before closing), leaving the same latent hang in this test and the other `closeServer` consumers (`mcp-page-app-browser.test.ts`, `comparisons-page-client-scope-browser.test.ts`).

Fix: destroy connections via `server.closeAllConnections()` before `server.close()` — the same teardown pattern already used throughout `runtime-client-surface-proxy.test.ts` — making `close()` deterministic regardless of browser connection state, and drop the now-redundant `about:blank` navigation. This eliminates the race rather than enlarging a timeout.

## Test plan

- [x] `pnpm typecheck`
- [x] `evals-real.e2e.test.ts` (all 8 tests) green with `CI=1`, including under `taskset -c 0,1` to mirror the two-core runner
- [x] Other `closeServer` consumers green: `mcp-page-app-browser.test.ts`, `comparisons-page-client-scope-browser.test.ts`