### PR TITLE
test: apply post-merge Codex feedback from #31 and deflake the capture script

### DIFF
--- a/examples/rsc-agent-runtime/src/runtime/state-file-test-support.ts
+++ b/examples/rsc-agent-runtime/src/runtime/state-file-test-support.ts
@@ -20,6 +20,13 @@ export interface RuntimeStateTestAdapter {
   readonly beforeRepair?: (signal: AbortSignal) => Promise<void>;
   readonly criticalSectionMs?: number;
   readonly fatalOwnerTeardown?: (error: Error) => void;
+  /**
+   * Observes every settled lock-acquisition attempt: 'held' when the lock
+   * was refused because another owner holds it, 'acquired' when the attempt
+   * won the lease. Lets exclusion tests order assertions on observed
+   * contender attempts instead of fixed sleeps that race the retry loop.
+   */
+  readonly onLockAttempt?: (outcome: 'acquired' | 'held') => void;
   readonly ownerSettlementMs?: number;
   readonly platform?: NodeJS.Platform;
   readonly prepareStateFile?: (input: Readonly<{ stateFile: string }>) => Promise<string>;
@@ -44,10 +51,17 @@ export const createTestFileRuntimeKernel = ({ adapter = {}, ...options }: TestFi
   const native = createNodeStateStorage({ platform: adapter.platform, syncParent: adapter.syncParent });
   const storage: StateStorage = {
     ...native,
-    acquire: async (input) => wrapRelease(
-      await (adapter.acquireLock === undefined ? native.acquire(input) : adapter.acquireLock(input)),
-      adapter,
-    ),
+    acquire: async (input) => {
+      let release: StateLeaseRelease;
+      try {
+        release = await (adapter.acquireLock === undefined ? native.acquire(input) : adapter.acquireLock(input));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException | undefined)?.code === 'ELOCKED') adapter.onLockAttempt?.('held');
+        throw error;
+      }
+      adapter.onLockAttempt?.('acquired');
+      return wrapRelease(release, adapter);
+    },
     async append(stateFile, contents, signal) {
       await adapter.beforeAppend?.(signal);
       if (signal.aborted) {

--- a/examples/rsc-agent-runtime/tests/state-and-definition.test.ts
+++ b/examples/rsc-agent-runtime/tests/state-and-definition.test.ts
@@ -10,7 +10,7 @@ import { serializeRuntimeDefinition } from '../src/build/serialize-definition.js
 import { runtimeDefinition } from '../src/definition.js';
 import { createFileRuntimeKernel } from '../src/runtime/state-file.js';
 import { createTestFileRuntimeKernel } from '../src/runtime/state-file-test-support.js';
-import { timeScale } from '../../../packages/agent-bundle/tests/support/time-scale.ts';
+import { timeScale } from './support/time-scale.ts';
 
 const readOnlyAnnotations = {
   destructiveHint: false,
@@ -42,6 +42,30 @@ const observeCancellation = (signal: AbortSignal, onCancelled: () => void): void
     return;
   }
   signal.addEventListener('abort', onCancelled, { once: true });
+};
+
+/**
+ * Observes a contender kernel's settled lock-acquisition attempts. A fixed
+ * sleep before asserting the contender has not settled races the retry loop:
+ * on a loaded runner a wrongly released lease can take longer than the sleep
+ * to be noticed, so the assertion passes without testing anything. Waiting
+ * for an observed refusal proves the lease was actually held when the
+ * contender asked.
+ */
+const observeLockAttempts = () => {
+  let waiters: Array<(outcome: 'acquired' | 'held') => void> = [];
+  return {
+    /** Resolves with the outcome of the next attempt settled from now on. */
+    next: async (): Promise<'acquired' | 'held'> =>
+      new Promise((resolve) => {
+        waiters.push(resolve);
+      }),
+    record: (outcome: 'acquired' | 'held'): void => {
+      const settled = waiters;
+      waiters = [];
+      for (const waiter of settled) waiter(outcome);
+    },
+  };
 };
 
 const eagerPromise = <T>(value: T): Promise<T> => ({
@@ -619,7 +643,8 @@ test('retains the lease until a timed-out mutation phase actually settles', { ti
       ownerSettlementMs: 30_000,
     },
   });
-  const second = createTestFileRuntimeKernel({ stateFile });
+  const lockAttempts = observeLockAttempts();
+  const second = createTestFileRuntimeKernel({ stateFile, adapter: { onLockAttempt: lockAttempts.record } });
 
   const firstMutation = first.recordEdit({
     host: 'claude',
@@ -644,13 +669,17 @@ test('retains the lease until a timed-out mutation phase actually settles', { ti
   ).finally(() => {
     contenderSettled = true;
   });
-  await wait(40);
+  await expect(lockAttempts.next()).resolves.toBe('held');
   expect(contenderSettled).toBe(false);
 
   // The deadline has cancelled the mutation, but the lease must stay held
-  // while the phase is unsettled.
+  // while the phase is unsettled. The first observed refusal may belong to
+  // an attempt already in flight when the cancellation landed; the second
+  // necessarily started after it, so a wrongly released lease would surface
+  // here as 'acquired'.
   await phaseCancelled;
-  await wait(40);
+  await expect(lockAttempts.next()).resolves.toBe('held');
+  await expect(lockAttempts.next()).resolves.toBe('held');
   expect(contenderSettled).toBe(false);
 
   settle();
@@ -703,7 +732,8 @@ for (const phase of ['truncate', 'append', 'fsync'] as const) {
         ownerSettlementMs: 30_000,
       },
     });
-    const second = createTestFileRuntimeKernel({ stateFile });
+    const lockAttempts = observeLockAttempts();
+    const second = createTestFileRuntimeKernel({ stateFile, adapter: { onLockAttempt: lockAttempts.record } });
     const firstMutation = first.recordEdit({
       host: 'claude',
       idempotencyKey: `test:state:${phase}-owner`,
@@ -727,13 +757,17 @@ for (const phase of ['truncate', 'append', 'fsync'] as const) {
     ).finally(() => {
       contenderSettled = true;
     });
-    await wait(40);
+    await expect(lockAttempts.next()).resolves.toBe('held');
     expect(contenderSettled).toBe(false);
 
     // The deadline has cancelled the mutation, but the lease must stay held
-    // while the phase is unsettled.
+    // while the phase is unsettled. The first observed refusal may belong to
+    // an attempt already in flight when the cancellation landed; the second
+    // necessarily started after it, so a wrongly released lease would
+    // surface here as 'acquired'.
     await phaseCancelled;
-    await wait(40);
+    await expect(lockAttempts.next()).resolves.toBe('held');
+    await expect(lockAttempts.next()).resolves.toBe('held');
     expect(contenderSettled).toBe(false);
 
     settle();
@@ -765,7 +799,8 @@ test('keeps contenders excluded until a delayed release settles', async () => {
       releaseMs: 200,
     },
   });
-  const second = createTestFileRuntimeKernel({ stateFile });
+  const lockAttempts = observeLockAttempts();
+  const second = createTestFileRuntimeKernel({ stateFile, adapter: { onLockAttempt: lockAttempts.record } });
   const firstMutation = first.recordEdit({
     host: 'claude',
     idempotencyKey: 'test:state:delayed-release-owner',
@@ -787,7 +822,7 @@ test('keeps contenders excluded until a delayed release settles', async () => {
   ).finally(() => {
     contenderSettled = true;
   });
-  await wait(40);
+  await expect(lockAttempts.next()).resolves.toBe('held');
   expect(contenderSettled).toBe(false);
   settleRelease();
   await expect(firstMutation).resolves.toMatchObject({ stateVersion: 1 });

--- a/examples/rsc-agent-runtime/tests/support/time-scale.ts
+++ b/examples/rsc-agent-runtime/tests/support/time-scale.ts
@@ -1,0 +1,15 @@
+/**
+ * Fixed test budgets are tuned on many-core development machines, while CI
+ * runners have two cores and share them between Chrome, dev servers, child
+ * processes, and rsbuild compiles inside a single test. Scaling the budgets
+ * costs nothing on green runs - polling assertions return on success - and
+ * the workflow-level timeout-minutes still bounds real hangs.
+ *
+ * This example is user-facing and must run independently of the repository
+ * layout, so it keeps its own copy of the helper instead of importing
+ * another package's private test sources.
+ */
+const localScale = Number(process.env['AGENT_BUNDLE_TEST_TIME_SCALE'] ?? '');
+export const timeScale = process.env['CI'] !== undefined
+  ? 4
+  : Number.isSafeInteger(localScale) && localScale >= 1 ? localScale : 1;

--- a/packages/workbench/scripts/capture-runtime-playground.mjs
+++ b/packages/workbench/scripts/capture-runtime-playground.mjs
@@ -67,6 +67,22 @@ export const atomically = async (path, write) => {
 
 const screenshot = (page, path) => atomically(path, async (temporary) => page.screenshot({ path: temporary }));
 
+/**
+ * Replaces a watched source atomically through a rename staged OUTSIDE the
+ * watched project. An in-place write is truncate-then-append: the dev
+ * compiler can start a compile off the truncation event, read incomplete
+ * content, and then drop the append event because both operations land
+ * within the same mtime tick, so the final content never compiles and the
+ * expected generation never activates. The temp file lives in the project's
+ * parent (same filesystem, never watched) so the rename into place is the
+ * only event the watcher observes.
+ */
+const replaceWatchedSource = async (projectRoot, path, content) => {
+  const temporary = join(projectRoot, '..', `.${basename(path)}.${process.pid}.${temporaryOutputSequence += 1}.tmp`);
+  await writeFile(temporary, content, 'utf8');
+  await rename(temporary, path);
+};
+
 const writeEvidence = (path, evidence) => atomically(path, async (temporary) => {
   await writeFile(temporary, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
 });
@@ -331,8 +347,8 @@ const captureCompileErrorLayout = async (page, generation) => {
   return Object.freeze({ diagnostics, diagnosticsVisible, lastGood, lastGoodVisible });
 };
 
-const restore = async (path, contents) => {
-  await writeFile(path, contents, 'utf8');
+const restore = async (projectRoot, path, contents) => {
+  await replaceWatchedSource(projectRoot, path, contents);
   if (await readFile(path, 'utf8') !== contents) throw new Error(`Capture fixture did not restore ${basename(path)}.`);
 };
 
@@ -386,7 +402,7 @@ const capture = async (outputs) => {
     const history = page.getByRole('region', { name: 'Runtime run history' }).locator('ol > li');
     const historyBeforeHmr = await history.count();
     const runIdsBeforeHmr = await runtimeRunIds(page);
-    await writeFile(fixture.serverComponentSource, editedServer, 'utf8');
+    await replaceWatchedSource(fixture.root, fixture.serverComponentSource, editedServer);
     const generationAfter = await waitForNewGeneration(page, generationBefore);
     await page.waitForFunction(
       ({ expected, selector }) => globalThis.document.querySelectorAll(selector).length > expected,
@@ -415,7 +431,7 @@ const capture = async (outputs) => {
     const historyBeforeError = await history.count();
     const eventSequenceBeforeError = Number((await attributes(identity))['data-runtime-event-sequence']);
     if (!Number.isFinite(eventSequenceBeforeError)) throw new Error('Runtime identity omitted its event sequence.');
-    await writeFile(fixture.serverComponentSource, `${editedServer}\nconst = ;\n`, 'utf8');
+    await replaceWatchedSource(fixture.root, fixture.serverComponentSource, `${editedServer}\nconst = ;\n`);
     await page.waitForFunction(
       ({ expected, selector }) => Number(globalThis.document.querySelector(selector)?.getAttribute('data-runtime-event-sequence')) > expected,
       { expected: eventSequenceBeforeError, selector: '[data-runtime-provider-session]' },
@@ -447,7 +463,7 @@ const capture = async (outputs) => {
     const compileErrorLayout = await captureCompileErrorLayout(page, compactRunGeneration);
     await screenshot(page, outputs.compileError);
 
-    await writeFile(fixture.serverComponentSource, repairedServer, 'utf8');
+    await replaceWatchedSource(fixture.root, fixture.serverComponentSource, repairedServer);
     const generationRecovered = await waitForNewGeneration(page, lastGoodGenerationDuringError);
     await page.waitForFunction(
       ({ expected, selector }) => globalThis.document.querySelectorAll(selector).length > expected,
@@ -481,8 +497,8 @@ const capture = async (outputs) => {
     if (editedWidget === originals[1]) throw new Error('Capture fixture App source did not contain the expected heading.');
     const editedStyles = `${originals[2]}\n.timeline__header [data-testid="runtime-capture-marker"] { color: rgb(1, 2, 3); }\n`;
     await Promise.all([
-      writeFile(fixture.widgetAppSource, editedWidget, 'utf8'),
-      writeFile(fixture.appStyles, editedStyles, 'utf8'),
+      replaceWatchedSource(fixture.root, fixture.widgetAppSource, editedWidget),
+      replaceWatchedSource(fixture.root, fixture.appStyles, editedStyles),
     ]);
     let appFrame;
     const deadline = Date.now() + browserTimeout;
@@ -525,9 +541,9 @@ const capture = async (outputs) => {
     await screenshot(page, outputs.desktop);
 
     await Promise.all([
-      restore(fixture.serverComponentSource, originals[0]),
-      restore(fixture.widgetAppSource, originals[1]),
-      restore(fixture.appStyles, originals[2]),
+      restore(fixture.root, fixture.serverComponentSource, originals[0]),
+      restore(fixture.root, fixture.widgetAppSource, originals[1]),
+      restore(fixture.root, fixture.appStyles, originals[2]),
     ]);
     if (pageErrors.length > 0) throw new Error('Runtime capture encountered a browser page error.');
     evidence = Object.freeze({
@@ -571,9 +587,9 @@ const capture = async (outputs) => {
     browser,
     fixture,
     restores: fixture === undefined || originals.length !== 3 ? [] : [
-      () => restore(fixture.serverComponentSource, originals[0]),
-      () => restore(fixture.widgetAppSource, originals[1]),
-      () => restore(fixture.appStyles, originals[2]),
+      () => restore(fixture.root, fixture.serverComponentSource, originals[0]),
+      () => restore(fixture.root, fixture.widgetAppSource, originals[1]),
+      () => restore(fixture.root, fixture.appStyles, originals[2]),
     ],
   });
   const failure = captureFailureAfterCleanup(primaryFailure, cleanup);


### PR DESCRIPTION
## Summary

Addresses the two unresolved Codex review threads on #31 and fixes the remaining watched-source write race that failed the #29 merge run on main.

### 1. Example test reached into another package's private test sources (Codex P1 on #31)

`examples/rsc-agent-runtime/tests/state-and-definition.test.ts` imported `timeScale` from `packages/agent-bundle/tests/support/time-scale.ts`, so the user-facing example could no longer run or be copied independently of this repository layout (AGENTS.md examples rule). The example now keeps its own `tests/support/time-scale.ts` copy with a comment explaining why it is duplicated.

### 2. Fixed 40ms sleeps could not detect a wrongly released lease (Codex P2 on #31)

The lock exclusion tests asserted `contenderSettled === false` after fixed 40ms sleeps. That races the contender's 25ms retry loop: on a loaded runner, a lease wrongly released by the cancellation can take longer than 40ms for the contender to notice and settle, so the assertion passes without testing anything.

The test-support adapter now exposes `onLockAttempt('acquired' | 'held')`, and the tests order the exclusion assertions on observed lock refusals instead of wall-clock margins. After the cancellation, the tests require **two** consecutive refusals: the first observed refusal may belong to an attempt already in flight when the cancellation landed, while the second necessarily started after it — so a wrongly released lease deterministically surfaces as `'acquired'`. Applied to the retains-lease test, the `{truncate,append,fsync}` phase loop, and the delayed-release test.

### 3. Capture script still wrote watched fixture sources in place (failed the #29 merge run)

[Node 24 Verify on the #29 merge commit](https://github.com/ScriptedAlchemy/agent-bundle/actions/runs/33237600572) failed in `runtime-playground-capture.test.ts`: `page.waitForFunction: Timeout 120000ms exceeded` after a fixture write. `capture-runtime-playground.mjs` rewrote `components.tsx`, the widget App source, and its styles in place with `writeFile` — the same truncate-then-append watcher race #31 removed from `runtime-playground-hmr.e2e.test.ts` (the compiler compiles off the truncation event and drops the append). All watched-source writes and restores now stage a temp file in the fixture project's parent (same filesystem, never watched) and `rename` it into place, matching the #31 pattern.

Deliberately not touched (owned by an in-flight follow-up): `overview.e2e.test.ts`, `mcp-app-real.e2e.test.ts`, `packed-release.e2e.test.ts` and their staged-rename test-support helpers.

## Test plan

- [x] `pnpm typecheck` (root + workbench project) green
- [x] Example package `tsc --noEmit` green
- [x] `pnpm lint` green
- [x] `state-and-definition.test.ts`: 33/33, and 5/5 repeats under `taskset -c 0,1` (CI-like 2-core affinity)
- [x] `runtime-playground-capture.test.ts` (integration config, prebuilt workbench): 2/2 including the full HMR → compile-error → recovery capture through the staged-rename writes