### PR TITLE
test: fix two burn-in flakes (shared-tmpdir scan, missing example prebuild)

### DIFF
--- a/examples/rsc-agent-runtime/tests/host-artifacts.test.ts
+++ b/examples/rsc-agent-runtime/tests/host-artifacts.test.ts
@@ -10,10 +10,13 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { expect, test } from '@rstest/core';
 
+import { ensureExampleBuilt } from './support/ensure-built.js';
+
 const exampleRoot = process.cwd();
 const pluginsRoot = join(exampleRoot, 'dist/plugins');
 
 const runPackageHosts = async (): Promise<void> => {
+  await ensureExampleBuilt();
   const child = spawn(process.execPath, ['scripts/package-hosts.mjs'], { cwd: exampleRoot, stdio: 'pipe' });
   const [exitCode, signal] = (await once(child, 'close')) as [number | null, NodeJS.Signals | null];
   expect(signal).toBeNull();

--- a/examples/rsc-agent-runtime/tests/mcp-transports.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/mcp-transports.integration.test.ts
@@ -14,6 +14,7 @@ import { expect, test } from '@rstest/core';
 
 import { createFileRuntimeKernel } from '../src/runtime/state-file.js';
 import { createRscRuntimeRsbuildConfig } from '../rsbuild.config.js';
+import { ensureExampleBuilt } from './support/ensure-built.js';
 
 const createStateFile = async (): Promise<string> => {
   const directory = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-mcp-'));
@@ -91,6 +92,7 @@ const expectStaticSurface = async (client: Client) => {
 };
 
 test('built stdio MCP serves static tools, file-backed data, Flight results, and inline widget', async () => {
+  await ensureExampleBuilt();
   const stateFile = await createStateFile();
   const client = createClient();
   const transport = new StdioClientTransport({
@@ -144,6 +146,7 @@ test('built stdio MCP serves static tools, file-backed data, Flight results, and
 });
 
 test('implicit hook and MCP callers share one external workspace identity', async () => {
+  await ensureExampleBuilt();
   const runtimeRoot = join(process.cwd(), 'dist/runtime');
   const workspace = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-shared-workspace-'));
   const stateHome = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-shared-state-'));
@@ -199,6 +202,7 @@ test('implicit hook and MCP callers share one external workspace identity', asyn
 });
 
 test('built Streamable HTTP MCP reports its one JSON startup line and closes cleanly', async () => {
+  await ensureExampleBuilt();
   const stateFile = await createStateFile();
   const child = spawn(process.execPath, [join(process.cwd(), 'dist/runtime/mcp/http.js')], {
     env: { ...process.env, AGENT_RUNTIME_STATE_FILE: stateFile, PORT: '0' },
@@ -245,6 +249,7 @@ test('built Streamable HTTP MCP reports its one JSON startup line and closes cle
 });
 
 test('built Streamable HTTP MCP accepts only explicitly allowed public tunnel origins', async () => {
+  await ensureExampleBuilt();
   const stateFile = await createStateFile();
   const child = spawn(process.execPath, [join(process.cwd(), 'dist/runtime/mcp/http.js')], {
     env: {
@@ -280,6 +285,7 @@ test('built Streamable HTTP MCP accepts only explicitly allowed public tunnel or
 });
 
 test('adds an explicit public MCP URL domain only to returned resource content', async () => {
+  await ensureExampleBuilt();
   const stateFile = await createStateFile();
   const child = spawn(process.execPath, [join(process.cwd(), 'dist/runtime/mcp/http.js')], {
     env: {
@@ -315,6 +321,7 @@ test('adds an explicit public MCP URL domain only to returned resource content',
 });
 
 test('runtime manifest declares every Node entry and dynamic chunk in its artifact root', async () => {
+  await ensureExampleBuilt();
   const entries = ['hook/index.js', 'rsc/index.js', 'mcp/stdio.js', 'mcp/http.js'];
   const runtimeRoot = join(process.cwd(), 'dist/runtime');
   const manifest = JSON.parse(await readFile(join(runtimeRoot, 'runtime-assets.json'), 'utf8')) as {
@@ -344,6 +351,7 @@ test('runtime manifest declares every Node entry and dynamic chunk in its artifa
 });
 
 test('production and development runtime graphs exclude state test controls', async () => {
+  await ensureExampleBuilt();
   const forbidden = [
     'state-file-test-support',
     'createFileRuntimeKernelForTesting',

--- a/examples/rsc-agent-runtime/tests/micro-eval.spot.test.ts
+++ b/examples/rsc-agent-runtime/tests/micro-eval.spot.test.ts
@@ -8,6 +8,8 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { expect, test } from '@rstest/core';
 
+import { ensureExampleBuilt } from './support/ensure-built.js';
+
 // This is the ordinary-CI micro-eval spot-check (`npm run eval:spot`): one
 // deterministic pass over the built production artifacts, with no real Claude
 // or Codex host. It proves the end-to-end runtime path in a small way: a
@@ -15,6 +17,7 @@ import { expect, test } from '@rstest/core';
 // state, and the MCP server then RSC-lowers that same shared state for a tool
 // call while linking the MCP App resource.
 test('micro-eval spot-check: built hook and MCP server share one RSC-rendered runtime', async () => {
+  await ensureExampleBuilt();
   const workspace = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-micro-eval-'));
   const stateFile = join(workspace, 'events.jsonl');
   const client = new Client({ name: 'rsc-agent-runtime-micro-eval', version: '1.0.0' });

--- a/examples/rsc-agent-runtime/tests/rsc-hook.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/rsc-hook.integration.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
 import { normalizeClaudeHook, normalizeCodexHook } from '../src/hook/normalize.js';
+import { ensureExampleBuilt } from './support/ensure-built.js';
 
 const temporaryDirectories: string[] = [];
 
@@ -21,6 +22,7 @@ const runHook = async (
   stateFile: string | undefined,
   additionalEnvironment: Record<string, string> = {},
 ) => {
+  await ensureExampleBuilt();
   const child = spawn(process.execPath, [join(process.cwd(), 'dist/runtime/hook/index.js'), '--host', host], {
     env: {
       ...process.env,
@@ -61,6 +63,7 @@ const runHook = async (
 };
 
 const runRscWorker = async (request: Record<string, unknown>) => {
+  await ensureExampleBuilt();
   const child = spawn(process.execPath, [join(process.cwd(), 'dist/runtime/rsc/index.js')], {
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/examples/rsc-agent-runtime/tests/support/ensure-built.ts
+++ b/examples/rsc-agent-runtime/tests/support/ensure-built.ts
@@ -1,0 +1,37 @@
+import { execFile as executeFile } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFile = promisify(executeFile);
+
+const exampleRoot = process.cwd();
+
+/** One probe per build output the dist-consuming tests spawn or read. */
+const requiredArtifacts = [
+  'dist/app/standalone.html',
+  'dist/plugins/claude/.claude-plugin/plugin.json',
+  'dist/plugins/codex/.codex-plugin/plugin.json',
+  'dist/runtime/runtime-assets.json',
+] as const;
+
+let exampleBuild: Promise<void> | undefined;
+
+/**
+ * The demo's `test` script assumes `pnpm build` already produced `dist/`
+ * (the `check` script runs the build first), but nothing enforces that. On a
+ * fresh checkout a bare `pnpm test` fails in every dist-consuming file until
+ * host-artifacts happens to run its full production build mid-suite, so the
+ * suite's outcome depends on file ordering and leftover state. Build once
+ * when any required artifact is missing to make `pnpm test` deterministic.
+ */
+export const ensureExampleBuilt = (): Promise<void> => exampleBuild ??= (async (): Promise<void> => {
+  const probes = await Promise.allSettled(requiredArtifacts.map(async (artifact) => access(join(exampleRoot, artifact))));
+  if (probes.every((probe) => probe.status === 'fulfilled')) return;
+  const { RSTEST: _rstest, ...environment } = process.env;
+  await execFile('npm', ['run', 'build'], {
+    cwd: exampleRoot,
+    env: environment,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+})();

--- a/packages/agent-bundle/tests/mcp.test.ts
+++ b/packages/agent-bundle/tests/mcp.test.ts
@@ -871,8 +871,16 @@ it('creates session state only after setup succeeds and always inherits the stdi
   const root = await mkdtemp(join(tmpdir(), 'agent-bundle-mcp-stdio-options-'));
   const inheritedKey = 'AGENT_BUNDLE_TEST_MCP_INHERITED';
   const previousInherited = process.env[inheritedKey];
+  // McpService creates session state via mkdtemp('agent-bundle-mcp-') in
+  // os.tmpdir(), and other files in the parallel integration pool create
+  // identically-prefixed directories there concurrently, so scanning the
+  // shared OS tmpdir races with sibling workers. Point TMPDIR (which
+  // os.tmpdir() re-reads on every call) at a directory this test owns and
+  // scan only that.
+  const sessionTmp = await mkdtemp(join(tmpdir(), 'agent-bundle-mcp-stdio-options-sessions-'));
+  const previousTmpdir = process.env['TMPDIR'];
   const sessionDirectories = async (): Promise<readonly string[]> =>
-    (await readdir(tmpdir())).filter((name) => name.startsWith('agent-bundle-mcp-')).sort();
+    (await readdir(sessionTmp)).filter((name) => name.startsWith('agent-bundle-mcp-')).sort();
   try {
     process.env[inheritedKey] = 'inherited-sentinel';
     await mkdir(join(root, 'src'), { recursive: true });
@@ -898,6 +906,7 @@ it('creates session state only after setup succeeds and always inherits the stdi
     const artifact = join(root, 'dist');
     await build({ model, outputRoot: artifact, projectRoot: root, registry: createDefaultRegistry() });
 
+    process.env['TMPDIR'] = sessionTmp;
     const beforeInvalidTimeout = await sessionDirectories();
     await expect(new McpService().list({
       artifact,
@@ -942,11 +951,17 @@ it('creates session state only after setup succeeds and always inherits the stdi
     });
     expect(stdio[1]?.env).toMatchObject({ [inheritedKey]: 'inherited-sentinel' });
   } finally {
+    if (previousTmpdir === undefined) {
+      delete process.env['TMPDIR'];
+    } else {
+      process.env['TMPDIR'] = previousTmpdir;
+    }
     if (previousInherited === undefined) {
       delete process.env[inheritedKey];
     } else {
       process.env[inheritedKey] = previousInherited;
     }
+    await rm(sessionTmp, { force: true, recursive: true });
     await rm(root, { force: true, recursive: true });
   }
 }, 30_000);


### PR DESCRIPTION
## Summary

A 5x burn-in of the parallel integration suite plus 2x of the RSC example suite on a 96-core machine (with other jobs contending) surfaced two unowned-file failures; both are fixed at the root here.

- **`packages/agent-bundle/tests/mcp.test.ts` (flaked 1/5 integration runs):** the stdio-options session-state test snapshotted every `agent-bundle-mcp-*` entry in the shared OS tmpdir, so sibling pool workers (and other checkouts on the same machine) creating/removing their own fixtures between the two snapshots failed the equality assertion. `McpService` re-reads `TMPDIR` through `os.tmpdir()` on every `mkdtemp`, so the test now points `TMPDIR` at a directory it owns and scans only that.
- **RSC example suite (failed its first-ever run, 8 tests):** a bare `pnpm --filter @agent-bundle/rsc-agent-runtime-demo test` on a fresh checkout has no `dist/`; every dist-consuming file failed until host-artifacts happened to run its full production build mid-suite, making the outcome ordering/state dependent. The dist-consuming tests now share a memoized `ensure-built` helper that probes the required artifacts and runs the documented build once when any are missing (mirrors the workbench prebuilt-assets pattern; warm runs only pay four `access` probes).

## Stress evidence

- mcp.test.ts, unfixed, under real cross-checkout contention: fails (organic repro of the burn-in failure, another checkout's `agent-bundle-mcp-page-app-*` fixture leaked into the diff).
- mcp.test.ts, fixed: 5/5 repeats green, 3/3 green under an adversarial tight create/delete churn loop on the colliding prefix, 1/1 green under `taskset -c 0,1`.
- RSC example, fixed: previously-failing file green from an empty `dist` (cold), full 171-test suite green from an empty `dist`, 5/5 warm repeats of the four dist-consuming files green, 1/1 green under a two-core `taskset`.
- `pnpm lint`, root `tsc --noEmit`, and the example `typecheck` all pass.

## Test plan

- [x] Burn-in integration suite (5x, 4-worker parallel pool): 1 flake in mcp.test.ts, reproduced and fixed
- [x] RSC example suite cold + warm + 2-core stress: all green
