### PR TITLE
fix: stop watched-file write races in e2e suites and host message drops in the Runtime App relay

### DIFF
--- a/.changeset/runtime-relay-handshake-queue.md
+++ b/.changeset/runtime-relay-handshake-queue.md
@@ -1,0 +1,14 @@
+---
+"agent-bundle": patch
+---
+
+Stop dropping host messages relayed to a Runtime App during its initialize
+handshake. The dev-server client-surface relay forwarded host-to-app
+traffic only once the App had reported `ui/notifications/initialized`
+(plus the initialize response itself) and silently discarded anything
+earlier, so a host request that raced the handshake — observed as
+`ui/resource-teardown` on contended runners — could never be answered.
+The relay now queues up to 32 validated host messages during the handshake
+and flushes them once the App initializes; the queue survives an HMR entry
+reload so a request sent to a retiring App instance is answered by its
+replacement.

--- a/packages/agent-bundle/src/dev/runtime-client-surface-proxy.ts
+++ b/packages/agent-bundle/src/dev/runtime-client-surface-proxy.ts
@@ -191,6 +191,8 @@ const runtimeProxyShell = (entryPath: string, entryDocument: string, hostOrigin:
   const allowedKeys = new Set(['error', 'id', 'jsonrpc', 'method', 'params', 'result']);
   let initializeId;
   let lifecycle = 'created';
+  const maxPendingHostMessages = 32;
+  let pendingHostMessages = [];
   let hmr;
   let hmrReconnectAttempts = 0;
   let hmrReconnectTimer;
@@ -296,14 +298,23 @@ const runtimeProxyShell = (entryPath: string, entryDocument: string, hostOrigin:
   addEventListener('message', (event) => {
     if (lifecycle === 'closed') return;
     if (event.source === parent) {
-      if (!isRpc(event.data, maxHostToAppMessageBytes)) return;
-      if (lifecycle === 'initializing') {
-        if (event.origin !== hostOrigin || !isInitializeResponse(event.data)) return;
+      if (event.origin !== hostOrigin || !isRpc(event.data, maxHostToAppMessageBytes)) return;
+      if (lifecycle === 'initializing' && isInitializeResponse(event.data)) {
         lifecycle = 'initialize-responded';
         post(app.contentWindow, '*', event.data, event.ports, maxHostToAppMessageBytes);
         return;
       }
-      if (lifecycle !== 'initialized' || event.origin !== hostOrigin) return;
+      if (lifecycle !== 'initialized') {
+        // Queue instead of dropping: a host request relayed into the
+        // handshake window (ui/resource-teardown racing the App's
+        // ui/notifications/initialized) would otherwise vanish, its sender
+        // would burn its bounded grace waiting for an answer that can never
+        // arrive, and the acknowledgement evidence would be lost forever.
+        // The queue also survives an HMR entry reload, so a request sent to
+        // the retiring App instance is answered by its replacement.
+        if (pendingHostMessages.length < maxPendingHostMessages) pendingHostMessages.push({ data: event.data, ports: event.ports });
+        return;
+      }
       post(app.contentWindow, '*', event.data, event.ports, maxHostToAppMessageBytes);
       return;
     }
@@ -317,12 +328,14 @@ const runtimeProxyShell = (entryPath: string, entryDocument: string, hostOrigin:
     if (lifecycle === 'initialize-responded' && isNotification(event.data, 'ui/notifications/initialized', maxAppToHostMessageBytes)) {
       lifecycle = 'initialized';
       post(parent, hostOrigin, event.data, event.ports, maxAppToHostMessageBytes);
+      for (const pending of pendingHostMessages.splice(0)) post(app.contentWindow, '*', pending.data, pending.ports, maxHostToAppMessageBytes);
       return;
     }
     if (lifecycle === 'initialized') post(parent, hostOrigin, event.data, event.ports, maxAppToHostMessageBytes);
   });
   addEventListener('pagehide', () => {
     lifecycle = 'closed';
+    pendingHostMessages = [];
     if (hmrReconnectTimer !== undefined) clearTimeout(hmrReconnectTimer);
     hmrReconnectTimer = undefined;
     const activeHmr = hmr;

--- a/packages/agent-bundle/tests/runtime-client-surface-proxy.test.ts
+++ b/packages/agent-bundle/tests/runtime-client-surface-proxy.test.ts
@@ -518,7 +518,7 @@ it('uses a one-use bootstrap capability before proxying only the declared app an
     expect(shell).toContain('<iframe id="app" sandbox="allow-scripts"');
     expect(shell).toContain(`const maxAppToHostMessageBytes = ${runtimeAppMessageLimits.appToHostBytes};`);
     expect(shell).toContain(`const maxHostToAppMessageBytes = ${runtimeAppMessageLimits.hostToAppBytes};`);
-    expect(shell).toContain("if (!isRpc(event.data, maxHostToAppMessageBytes)) return;");
+    expect(shell).toContain("if (event.origin !== hostOrigin || !isRpc(event.data, maxHostToAppMessageBytes)) return;");
     expect(shell).toContain("!isRpc(event.data, maxAppToHostMessageBytes)");
 
     const second = await fetch(binding.bootstrapUrl, { redirect: 'manual' });

--- a/packages/workbench/src/mcp/runtime-app-bridge.ts
+++ b/packages/workbench/src/mcp/runtime-app-bridge.ts
@@ -56,6 +56,8 @@ export interface RuntimeAppBridgeOptions {
   readonly preview: McpAppPreviewSnapshot;
   readonly requestConsent: (challenge: McpAppConsentChallenge, signal?: AbortSignal) => Promise<'allow-once' | 'deny'>;
   readonly simulationFeatures: McpAppSimulationFeatures;
+  /** Test seam for the graceful `ui/resource-teardown` ack budget. Production always uses the module default. */
+  readonly teardownAckTimeoutMs?: number;
 }
 
 interface BrowserMessageEvent {
@@ -117,7 +119,16 @@ const maximumInboundMessageBytes = runtimeAppMessageLimits.appToHostBytes;
 const maximumOutboundMessageBytes = runtimeAppMessageLimits.hostToAppBytes;
 const maximumQueuedMessages = 32;
 const maximumFailures = 3;
-const gracefulTeardownTimeoutMs = 1_000;
+/**
+ * The ack budget for `ui/resource-teardown` before the host proceeds to
+ * revoke the binding and unmount the frame. Missing this window is
+ * unrecoverable: the frame is destroyed, so a late acknowledgement can never
+ * be delivered. The round trip crosses two postMessage hops and the
+ * sandboxed app's event loop; a healthy app answers in milliseconds, but a
+ * contended two-core CI runner was observed missing a 1s window (PR #29
+ * Verify), so the budget only bounds a genuinely hung app.
+ */
+const gracefulTeardownTimeoutMs = 10_000;
 
 const aggregateFailure = (message: string, reasons: readonly unknown[]): Error =>
   new AggregateError(reasons, message);
@@ -548,11 +559,12 @@ export const createRuntimeAppBridgeFactory = (options: RuntimeAppBridgeOptions):
       }) as unknown as RuntimeAppBridge;
       rawBridgeClose = bridge.close.bind(bridge);
       const rawTeardownResource = bridge.teardownResource.bind(bridge);
+      const teardownAckTimeoutMs = options.teardownAckTimeoutMs ?? gracefulTeardownTimeoutMs;
       Object.defineProperty(bridge, 'teardownResource', {
         configurable: false,
         value: (params: Readonly<Record<string, never>>): Promise<Readonly<Record<string, never>>> => rawTeardownResource(params, {
-          maxTotalTimeout: gracefulTeardownTimeoutMs,
-          timeout: gracefulTeardownTimeoutMs,
+          maxTotalTimeout: teardownAckTimeoutMs,
+          timeout: teardownAckTimeoutMs,
         }),
         writable: false,
       });

--- a/packages/workbench/src/mcp/runtime-app-bridge.ts
+++ b/packages/workbench/src/mcp/runtime-app-bridge.ts
@@ -123,10 +123,12 @@ const maximumFailures = 3;
  * The ack budget for `ui/resource-teardown` before the host proceeds to
  * revoke the binding and unmount the frame. Missing this window is
  * unrecoverable: the frame is destroyed, so a late acknowledgement can never
- * be delivered. The round trip crosses two postMessage hops and the
+ * be delivered. The round trip crosses two postMessage hops (the client
+ * surface queues it until the App's initialize handshake settles) plus the
  * sandboxed app's event loop; a healthy app answers in milliseconds, but a
- * contended two-core CI runner was observed missing a 1s window (PR #29
- * Verify), so the budget only bounds a genuinely hung app.
+ * contended two-core runner was observed missing a 1s window during a
+ * dev-compile storm (PR #29 Verify), so the budget only bounds an app that
+ * cannot answer at all — it never delays a responsive one.
  */
 const gracefulTeardownTimeoutMs = 10_000;
 

--- a/packages/workbench/tests/mcp-app-real.e2e.test.ts
+++ b/packages/workbench/tests/mcp-app-real.e2e.test.ts
@@ -1297,6 +1297,7 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: 15_000 * timeScale });
     await expect(page.locator('.mcp-page-app-preview iframe')).toHaveCount(0);
     expect(runtimeCreates()).toHaveLength(2);
+    const appMessagesBeforeThirdCreate = appMessages.length;
     await page.evaluate(() => { window.location.hash = '#runtime'; });
     await expect.poll(runtimeCreates, { timeout: 15_000 * timeScale }).toHaveLength(3);
     const thirdCreate = runtimeCreates()[2];
@@ -1336,6 +1337,17 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     if (thirdController === null) throw new Error('Third Runtime App trusted controller frame was unavailable.');
     const thirdFrameHref = thirdController.url();
     const thirdDeletePath = `/api/runtime/apps/${encodeURIComponent(thirdBinding.id)}`;
+    // The App can acknowledge ui/resource-teardown only once its SDK
+    // transport is connected, evidenced by its ui/initialize request reaching
+    // the host. The rendered heading alone does not prove that: navigating
+    // away earlier relays teardown into a frame that cannot answer yet, the
+    // host's bounded grace elapses, the frame is destroyed, and the
+    // acknowledgement becomes unobservable forever (the third-teardown ack
+    // poll timed out this way on contended two-core runners).
+    await expect.poll(() => appMessages.slice(appMessagesBeforeThirdCreate).filter((entry) =>
+      new URL(entry.href).origin === fixture.url && entry.senderOrigin === thirdOrigin &&
+      entry.message !== null && typeof entry.message === 'object' &&
+      (entry.message as Readonly<Record<string, unknown>>).method === 'ui/initialize').length, { timeout: 15_000 * timeScale }).toBeGreaterThan(0);
     await page.evaluate(() => { window.location.hash = '#mcp'; });
     const teardownRequestForThird = (): RuntimeAppMessage | undefined => appMessages.find((entry) =>
       entry.href === thirdFrameHref && entry.senderOrigin === fixture.url && entry.message !== null && typeof entry.message === 'object' &&

--- a/packages/workbench/tests/mcp-app-real.e2e.test.ts
+++ b/packages/workbench/tests/mcp-app-real.e2e.test.ts
@@ -1360,7 +1360,21 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     if (typeof thirdTeardownId !== 'string' && typeof thirdTeardownId !== 'number') throw new Error('Third Runtime App teardown request omitted its JSON-RPC id.');
     const thirdAcknowledgement = () => messageFor(fixture.url, thirdOrigin, (message) =>
       message.id === thirdTeardownId && (Object.hasOwn(message, 'result') || Object.hasOwn(message, 'error')));
-    await expect.poll(thirdAcknowledgement, { timeout: 15_000 * timeScale }).toBeDefined();
+    try {
+      await expect.poll(thirdAcknowledgement, { timeout: 15_000 * timeScale }).toBeDefined();
+    } catch {
+      throw new Error(`Third Runtime App teardown was never acknowledged: ${JSON.stringify({
+        deletes: runtimeAppRequests.filter((entry) => entry.method === 'DELETE').map((entry) => entry.path),
+        frames: page.frames().map((frame) => frame.url()),
+        hmrSockets: runtimePreviewSockets,
+        messagesSinceThirdCreate: appMessages.slice(appMessagesBeforeThirdCreate).map((entry) => Object.freeze({
+          method: (entry.message as Readonly<{ readonly method?: unknown }>).method,
+          id: (entry.message as Readonly<{ readonly id?: unknown }>).id,
+          receiver: new URL(entry.href).origin,
+          sender: entry.senderOrigin,
+        })),
+      })}`);
+    }
     await expect.poll(() => runtimeAppRequests.filter((entry) => entry.method === 'DELETE' && entry.path === thirdDeletePath), { timeout: 15_000 * timeScale }).toHaveLength(1);
     const thirdDelete = runtimeAppRequests.find((entry) => entry.method === 'DELETE' && entry.path === thirdDeletePath);
     expect(lifecycleIndex('message', thirdAcknowledgement()!)).toBeGreaterThan(lifecycleIndex('message', thirdTeardown!));

--- a/packages/workbench/tests/overview.e2e.test.ts
+++ b/packages/workbench/tests/overview.e2e.test.ts
@@ -19,6 +19,7 @@ import { startDevServer } from '../../agent-bundle/src/dev/workbench-server.ts';
 import { createProjectFixture, removeProjectFixture } from '../../agent-bundle/tests/helpers/project-fixture.ts';
 import { timeScale } from '../../agent-bundle/tests/support/time-scale.ts';
 import { startRuntimePlaygroundFixture } from './helpers/runtime-playground-fixture.ts';
+import { replaceWatchedSource } from './support/watched-files.ts';
 import { buildWorkbench } from './support/workbench-e2e.ts';
 
 const workspaceRoot = process.cwd();
@@ -356,8 +357,8 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     const editedStyles = `${styles}\n.timeline__header [data-testid="runtime-hmr-marker"] { color: rgb(1, 2, 3); }\n`;
     expect(editedSource).not.toBe(source);
     await Promise.all([
-      writeFile(fixture.widgetAppSource, editedSource),
-      writeFile(fixture.appStyles, editedStyles),
+      replaceWatchedSource(fixture.root, fixture.widgetAppSource, editedSource),
+      replaceWatchedSource(fixture.root, fixture.appStyles, editedStyles),
     ]);
     await expect.poll(() => runtimePreviewHmrMessages.some((message) => message === JSON.stringify({ type: 'full-reload' })), { timeout: 15_000 })
       .toBe(true);
@@ -420,7 +421,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     const finiteConfigMarker = `config-reconcile-finite-${Math.random().toString(36).slice(2)}`;
     const finiteConfig = sourceConfig.replace('  codex: {},', `  codex: { configReconcileMarker: '${finiteConfigMarker}' },`);
     expect(finiteConfig).not.toBe(sourceConfig);
-    await writeFile(fixture.configSource, finiteConfig);
+    await replaceWatchedSource(fixture.root, fixture.configSource, finiteConfig);
     await expect.poll(async () => {
       const source = await readProjectSource();
       return source.state === 'ready' && source.revision !== sourceRevision ? source.revision : undefined;
@@ -435,7 +436,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       'configReconcileMarker: Number.NaN',
     );
     expect(invalidConfig).not.toBe(finiteConfig);
-    await writeFile(fixture.configSource, invalidConfig);
+    await replaceWatchedSource(fixture.root, fixture.configSource, invalidConfig);
     await expect.poll(async () => {
       const source = await readProjectSource();
       const diagnostic = source.diagnostics.find((candidate) => candidate.code === 'AB4500');
@@ -515,7 +516,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       'configReconcileMarker: Number.NaN',
       `configReconcileMarker: '${repairedConfigMarker}'`,
     );
-    await writeFile(fixture.configSource, repairedConfig);
+    await replaceWatchedSource(fixture.root, fixture.configSource, repairedConfig);
     await expect.poll(async () => {
       const source = await readProjectSource();
       return source.state === 'ready' && source.revision !== finiteSourceRevision ? source.revision : undefined;
@@ -870,7 +871,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     );
     expect(changedDefinition).not.toBe(definitionSource);
     const definitionEventStart = runtimeEvents.length;
-    await writeFile(fixture.definitionSource, changedDefinition);
+    await replaceWatchedSource(fixture.root, fixture.definitionSource, changedDefinition);
     await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.restarting', initial), { timeout: 15_000 }).not.toEqual([]);
     await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.ready', initial), { timeout: 15_000 }).not.toEqual([]);
     expect(runtimeEvents.findIndex((event, index) => index >= definitionEventStart && event.payload.type === 'runtime.mcp.restarting')).toBeLessThan(
@@ -930,7 +931,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     fixture.disconnectProjectEventStream();
     await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: 15_000 })
       .toBe(serverOwnedProjectSubscriptions);
-    await writeFile(fixture.configSource, changedTransport);
+    await replaceWatchedSource(fixture.root, fixture.configSource, changedTransport);
     const definitionOperationPath = `/api/runtime/apps/${encodeURIComponent(definitionRun.id)}/operations`;
     await expect.poll(async () => {
       const response = await fetch(new URL(definitionOperationPath, fixture.url), {
@@ -1224,7 +1225,7 @@ e2e('opens one real epoch MCP session and keeps its playground operations respon
     const sourceConfig = await readFile(configPath, 'utf8');
     const changedConfig = sourceConfig.replace(initialConfigValue, changedConfigValue);
     expect(changedConfig).not.toBe(sourceConfig);
-    await writeFile(configPath, changedConfig);
+    await replaceWatchedSource(project.root, configPath, changedConfig);
     await expect.poll(() => {
       const next = server!.status().artifact;
       return next.state === 'active' && next.activeEpoch.id !== epochId && next.activeEpoch.modelDigest !== modelDigest
@@ -1492,7 +1493,7 @@ e2e('retains the Overview and marks the foreground connection unavailable after 
       });
     });
 
-    await writeFile(join(project.skillDir, 'SKILL.md'), `${project.skillMarkdown}\n\nThe source refresh failure fixture changed.\n`);
+    await replaceWatchedSource(project.root, join(project.skillDir, 'SKILL.md'), `${project.skillMarkdown}\n\nThe source refresh failure fixture changed.\n`);
 
     await expect.poll(() => failedStatusRequests, { timeout: browserTimeout }).toBe(1);
     await expect(page.getByRole('status')).toContainText('Foreground server unavailable', { timeout: browserTimeout });

--- a/packages/workbench/tests/overview.e2e.test.ts
+++ b/packages/workbench/tests/overview.e2e.test.ts
@@ -149,7 +149,7 @@ e2e('preserves a direct Runtime deep link until capability discovery succeeds', 
     expect(new URL(page.url()).hash).toBe('#runtime');
 
     releaseRuntimeStatus();
-    await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     expect(new URL(page.url()).hash).toBe('#runtime');
   } finally {
     releaseRuntimeStatus();
@@ -257,7 +257,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const runtimeIdentity = page.locator('[data-runtime-provider-session]');
     const runtimeSurface = page.getByLabel('Runtime surface');
-    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: 15_000 });
+    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: browserTimeout });
     await runtimeSurface.selectOption('mcp.edit-timeline');
     clientSurface = await fixture.openRuntimeClientSurface('mcp.edit-timeline');
     if (clientSurface === undefined) throw new Error('Runtime client surface was not available.');
@@ -265,18 +265,18 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     clientPage.on('pageerror', (error) => pageErrors.push(error));
     const bootstrapResponse = await clientPage.goto(clientSurface.bootstrapUrl, { waitUntil: 'domcontentloaded' });
     expect(bootstrapResponse?.status()).toBe(200);
-    await expect.poll(async () => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 15_000 }).toBe('1');
-    await expect(page.locator('.runtime-status')).toHaveText('HMR endpoint ready · active', { timeout: 15_000 });
+    await expect.poll(async () => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: browserTimeout }).toBe('1');
+    await expect(page.locator('.runtime-status')).toHaveText('HMR endpoint ready · active', { timeout: browserTimeout });
     await runtimeSurface.selectOption('mcp.render_edit_timeline');
     await page.getByLabel('Runtime target').selectOption('portable');
     await page.getByRole('radio', { name: 'Raw JSON' }).check();
     await page.locator('#runtime-input-raw').fill('{}');
     await page.getByRole('button', { name: 'Run', exact: true }).click();
-    await expect.poll(async () => page.getByRole('region', { name: 'Runtime run history' }).locator('ol > li').count(), { timeout: 15_000 }).toBeGreaterThan(0);
+    await expect.poll(async () => page.getByRole('region', { name: 'Runtime run history' }).locator('ol > li').count(), { timeout: browserTimeout }).toBeGreaterThan(0);
 
-    await expect(page.getByRole('button', { name: 'Open in MCP playground' })).toBeEnabled({ timeout: 15_000 });
-    await expect.poll(() => runtimeAppRequests.filter((request) => request === 'POST /api/runtime/apps').length, { timeout: 15_000 }).toBe(1);
-    await expect.poll(() => runtimeAppResponses.length, { timeout: 15_000 }).toBe(1);
+    await expect(page.getByRole('button', { name: 'Open in MCP playground' })).toBeEnabled({ timeout: browserTimeout });
+    await expect.poll(() => runtimeAppRequests.filter((request) => request === 'POST /api/runtime/apps').length, { timeout: browserTimeout }).toBe(1);
+    await expect.poll(() => runtimeAppResponses.length, { timeout: browserTimeout }).toBe(1);
     const expectedRegisteredConfiguration = [
       { configured: true, id: 'extension:claude', key: 'claude', provenance: { kind: 'config', sourcePath: 'agent-bundle.config.ts' }, target: 'claude' },
       { configured: true, id: 'extension:codex', key: 'codex', provenance: { kind: 'config', sourcePath: 'agent-bundle.config.ts' }, target: 'codex' },
@@ -323,7 +323,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       await expect(configuration.getByRole('listitem').nth(1)).toContainText('extension:codex');
       await expect(configuration.getByRole('listitem').nth(2)).toContainText('extension:portable');
     };
-    await page.locator('iframe').waitFor({ state: 'attached', timeout: 15_000 });
+    await page.locator('iframe').waitFor({ state: 'attached', timeout: browserTimeout });
     await expectRuntimeProfileInspection(page.locator('.runtime-stage .mcp-app-preview'), sourceRevision);
     const sourceBinding = (runtimeAppResponses[0] as {
       readonly preview: { readonly binding: Readonly<{
@@ -340,7 +340,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       sessionRevision: expect.any(Number),
     });
     const sourcePreview = page.locator('.runtime-stage .mcp-app-preview iframe');
-    await expect(sourcePreview).toBeVisible({ timeout: 15_000 });
+    await expect(sourcePreview).toBeVisible({ timeout: browserTimeout });
     const sourcePreviewHandle = await sourcePreview.elementHandle();
     if (sourcePreviewHandle === null) throw new Error('Runtime App outer preview iframe was unavailable.');
     const sourcePreviewUrl = await sourcePreviewHandle.getAttribute('src');
@@ -360,7 +360,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       replaceWatchedSource(fixture.root, fixture.widgetAppSource, editedSource),
       replaceWatchedSource(fixture.root, fixture.appStyles, editedStyles),
     ]);
-    await expect.poll(() => runtimePreviewHmrMessages.some((message) => message === JSON.stringify({ type: 'full-reload' })), { timeout: 15_000 })
+    await expect.poll(() => runtimePreviewHmrMessages.some((message) => message === JSON.stringify({ type: 'full-reload' })), { timeout: browserTimeout })
       .toBe(true);
     const refreshedWidget = async () => {
       for (const frame of page.frames()) {
@@ -368,7 +368,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       }
       return undefined;
     };
-    await expect.poll(refreshedWidget, { timeout: 15_000 }).toBeDefined();
+    await expect.poll(refreshedWidget, { timeout: browserTimeout }).toBeDefined();
     const refreshedFrame = await refreshedWidget();
     if (refreshedFrame === undefined) throw new Error('Runtime App did not receive the App compiler full reload.');
     await expect(refreshedFrame.getByTestId('runtime-hmr-marker')).toHaveText(hmrMarker);
@@ -478,9 +478,9 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     await refreshedFrame.evaluate(({ id, uri }) => {
       window.parent.postMessage({ id, jsonrpc: '2.0', method: 'resources/read', params: { uri } }, '*');
     }, { id: resourceRequestId, uri: resourceUri });
-    await expect.poll(resourceOperationRequests, { timeout: 15_000 }).toHaveLength(1);
+    await expect.poll(resourceOperationRequests, { timeout: browserTimeout }).toHaveLength(1);
     expect(resourceOperationRequests()[0]?.body).toEqual({ kind: 'resources/read', uri: resourceUri });
-    await expect.poll(resourceOperationResponses, { timeout: 15_000 }).toHaveLength(1);
+    await expect.poll(resourceOperationResponses, { timeout: browserTimeout }).toHaveLength(1);
     const resourceOperationResult = (resourceOperationResponses()[0]?.response as Readonly<{ readonly result?: unknown }> | undefined)?.result;
     expect(resourceOperationResult).toMatchObject({
       operationId: expect.any(String),
@@ -498,7 +498,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     const resourceValue = (resourceOperationResult as Readonly<{ readonly value?: unknown }> | undefined)?.value;
     if (resourceValue === null || typeof resourceValue !== 'object') throw new Error('Retained Runtime App resource operation omitted its result value.');
     await expect.poll(() => wireMessage(fixture.url, sourceControllerOrigin, (message) =>
-      message.id === resourceRequestId && message.method === 'resources/read'), { timeout: 15_000 }).toBeDefined();
+      message.id === resourceRequestId && message.method === 'resources/read'), { timeout: browserTimeout }).toBeDefined();
     expect(wireMessage(fixture.url, sourceControllerOrigin, (message) =>
       message.id === resourceRequestId && message.method === 'resources/read')?.message).toEqual({
       id: resourceRequestId,
@@ -507,7 +507,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       params: { uri: resourceUri },
     });
     await expect.poll(() => wireMessage(sourceControllerOrigin, fixture.url, (message) =>
-      message.id === resourceRequestId && Object.hasOwn(message, 'result')), { timeout: 15_000 }).toBeDefined();
+      message.id === resourceRequestId && Object.hasOwn(message, 'result')), { timeout: browserTimeout }).toBeDefined();
     expect(wireMessage(sourceControllerOrigin, fixture.url, (message) =>
       message.id === resourceRequestId && Object.hasOwn(message, 'result'))?.message).toEqual({
       id: resourceRequestId,
@@ -533,9 +533,9 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     const handoff = page.getByRole('button', { name: 'Open in MCP playground' });
     await handoff.click({ timeout: browserTimeout });
     await expect(page.getByRole('heading', { name: 'MCP playground' })).toBeVisible({ timeout: browserTimeout });
-    await expect.poll(() => runtimeAppRequests.filter((request) => request === 'POST /api/runtime/apps').length, { timeout: 15_000 }).toBe(2);
-    await expect.poll(() => runtimeAppResponses.length, { timeout: 15_000 }).toBe(2);
-    await expect.poll(() => runtimeAppRequests.findIndex((request) => request.startsWith('DELETE /api/runtime/apps/')), { timeout: 15_000 }).toBeGreaterThan(-1);
+    await expect.poll(() => runtimeAppRequests.filter((request) => request === 'POST /api/runtime/apps').length, { timeout: browserTimeout }).toBe(2);
+    await expect.poll(() => runtimeAppResponses.length, { timeout: browserTimeout }).toBe(2);
+    await expect.poll(() => runtimeAppRequests.findIndex((request) => request.startsWith('DELETE /api/runtime/apps/')), { timeout: browserTimeout }).toBeGreaterThan(-1);
 
     const runtimeDelete = runtimeAppRequests.findIndex((request) => request.startsWith('DELETE /api/runtime/apps/'));
     const secondRuntimeCreate = runtimeAppRequests.lastIndexOf('POST /api/runtime/apps');
@@ -544,7 +544,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     expect(artifactMcpSessionRequests).toEqual([]);
     expect(runtimeMcpSessionRequests.filter((request) => request === 'POST /api/runtime/mcp/sessions')).toEqual([]);
     expect(projectEventStreams).toEqual(['GET /api/project/events']);
-    await page.locator('.mcp-page-app-preview iframe').waitFor({ state: 'attached', timeout: 15_000 });
+    await page.locator('.mcp-page-app-preview iframe').waitFor({ state: 'attached', timeout: browserTimeout });
     expect(await page.locator('.mcp-page-app-preview iframe').count()).toBe(1);
     const handedOffConfigInspection = (runtimeAppResponses[1] as {
       readonly preview: { readonly profile: { readonly configExtensions: { readonly sourceRevision: string } } };
@@ -594,27 +594,27 @@ e2e('keeps runtime MCP routing constrained after direct navigation from a bound 
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const runtimeIdentity = page.locator('[data-runtime-provider-session]');
     const runtimeSurface = page.getByLabel('Runtime surface');
-    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: 15_000 });
+    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: browserTimeout });
     await runtimeSurface.selectOption('mcp.edit-timeline');
     clientSurface = await fixture.openRuntimeClientSurface('mcp.edit-timeline');
     if (clientSurface === undefined) throw new Error('Runtime client surface was not available.');
     clientPage = await page.context().newPage();
     const bootstrapResponse = await clientPage.goto(clientSurface.bootstrapUrl, { waitUntil: 'domcontentloaded' });
     expect(bootstrapResponse?.status()).toBe(200);
-    await expect.poll(async () => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 15_000 }).toBe('1');
+    await expect.poll(async () => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: browserTimeout }).toBe('1');
     await runtimeSurface.selectOption('mcp.render_edit_timeline');
     await page.getByLabel('Runtime target').selectOption('portable');
     await page.getByRole('radio', { name: 'Raw JSON' }).check();
     await page.locator('#runtime-input-raw').fill('{}');
     await page.getByRole('button', { name: 'Run', exact: true }).click();
-    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'attached', timeout: 15_000 });
+    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'attached', timeout: browserTimeout });
 
     await page.getByRole('link', { name: 'MCP playground' }).click();
-    await expect(page.getByLabel('Runtime-bound MCP session')).toBeVisible({ timeout: 15_000 });
-    await expect(page.locator('#mcp-epoch')).toHaveCount(0, { timeout: 15_000 });
-    await expect(page.getByRole('button', { name: 'Open MCP session' })).toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByLabel('Runtime-bound MCP session')).toBeVisible({ timeout: browserTimeout });
+    await expect(page.locator('#mcp-epoch')).toHaveCount(0, { timeout: browserTimeout });
+    await expect(page.getByRole('button', { name: 'Open MCP session' })).toHaveCount(0, { timeout: browserTimeout });
     expect(artifactMcpSessionRequests).toEqual([]);
-    await expect.poll(() => unsupportedOperationRequests.length, { timeout: 15_000 }).toBe(0);
+    await expect.poll(() => unsupportedOperationRequests.length, { timeout: browserTimeout }).toBe(0);
   } finally {
     await clientPage?.close();
     await clientSurface?.close();
@@ -644,7 +644,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
         if (runtimeAppResponseWaiters.get(count) !== settle) return;
         runtimeAppResponseWaiters.delete(count);
         reject(new Error(`Runtime App create ${String(count)} did not return a response.`));
-      }, 15_000);
+      }, browserTimeout);
       const settle = () => {
         clearTimeout(timeout);
         runtimeAppResponseWaiters.delete(count);
@@ -813,12 +813,12 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     const initialAppCreateResponse = runCount === 1 && previewCreateCount !== undefined
       ? awaitRuntimeAppResponse(previewCreateCount)
       : undefined;
-    await expect(page.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: 'Run', exact: true })).toBeEnabled({ timeout: browserTimeout });
     await page.getByRole('button', { name: 'Run', exact: true }).click();
     const confirmation = page.getByRole('dialog', { name: 'Run mutable runtime surface?' }).getByRole('button', { name: 'Confirm' });
     if (await confirmation.count() === 1) await confirmation.click();
-    await expect.poll(() => runtimeRunRequests.filter((request) => request === 'POST /api/runtime/runs').length, { timeout: 15_000 }).toBe(runCount);
-    await expect.poll(() => runtimeRuns.filter((candidate) => candidate.response !== undefined).length, { timeout: 15_000 }).toBe(runCount);
+    await expect.poll(() => runtimeRunRequests.filter((request) => request === 'POST /api/runtime/runs').length, { timeout: browserTimeout }).toBe(runCount);
+    await expect.poll(() => runtimeRuns.filter((candidate) => candidate.response !== undefined).length, { timeout: browserTimeout }).toBe(runCount);
     const response = runtimeRuns[runCount - 1]?.response as { readonly run?: RunOutcome } | undefined;
     const outcome = response?.run;
     if (outcome === undefined || typeof outcome.id !== 'string' || (outcome.status !== 'succeeded' && outcome.status !== 'failed')) {
@@ -829,7 +829,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
       await expect.poll(() => runtimeAppCreates.length, { timeout: 1_000 }).toBe((previewCreateCount ?? 3) - 1);
       const runId = outcome.id;
       const history = page.locator(`[data-runtime-run-id="${runId}"]`);
-      await expect(history).toHaveCount(1, { timeout: 15_000 });
+      await expect(history).toHaveCount(1, { timeout: browserTimeout });
       if (outcome.status === 'succeeded' && previewCreateCount !== undefined) appCreateResponse = awaitRuntimeAppResponse(previewCreateCount);
       await history.getByRole('button').first().click();
       await expect(history.getByRole('button').first()).toHaveAttribute('aria-pressed', 'true');
@@ -839,7 +839,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     if (previewCreateCount === undefined) throw new Error('Runtime App preview response lacks a create count.');
     expect(runtimeAppCreates).toHaveLength(previewCreateCount);
     expect(runtimeAppCreates.filter((candidate) => candidate.response !== undefined)).toHaveLength(previewCreateCount);
-    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'attached', timeout: 15_000 });
+    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'attached', timeout: browserTimeout });
     expect(await page.locator('.runtime-stage .mcp-app-preview iframe').count()).toBe(1);
     return Object.freeze({ binding: binding(previewCreateCount - 1), run: outcome });
   };
@@ -847,7 +847,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     await page.goto(`${fixture.url}#runtime`);
     await expect(page.getByRole('heading', { name: 'Runtime Playground' })).toBeVisible({ timeout: browserTimeout });
     const runtimeIdentity = page.locator('[data-runtime-provider-session]');
-    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: 15_000 });
+    await expect(runtimeIdentity).toHaveAttribute('data-runtime-hmr-ready', 'true', { timeout: browserTimeout });
     await page.getByLabel('Runtime surface').selectOption('mcp.render_edit_timeline');
     await page.getByLabel('Runtime target').selectOption('portable');
     await page.getByRole('radio', { name: 'Raw JSON' }).check();
@@ -876,15 +876,15 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     expect(changedDefinition).not.toBe(definitionSource);
     const definitionEventStart = runtimeEvents.length;
     await replaceWatchedSource(fixture.root, fixture.definitionSource, changedDefinition);
-    await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.restarting', initial), { timeout: 15_000 }).not.toEqual([]);
-    await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.ready', initial), { timeout: 15_000 }).not.toEqual([]);
+    await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.restarting', initial), { timeout: browserTimeout }).not.toEqual([]);
+    await expect.poll(() => eventsSince(definitionEventStart, 'runtime.mcp.ready', initial), { timeout: browserTimeout }).not.toEqual([]);
     expect(runtimeEvents.findIndex((event, index) => index >= definitionEventStart && event.payload.type === 'runtime.mcp.restarting')).toBeLessThan(
       runtimeEvents.findIndex((event, index) => index >= definitionEventStart && event.payload.type === 'runtime.mcp.ready'),
     );
     await expect.poll(() => runtimeEvents.slice(definitionEventStart).find((event) =>
       event.payload.type === 'runtime.app.updated' && event.payload.details?.bindingId === initial.id &&
-      event.payload.details.reason === 'session-restarted' && event.payload.details.state === 'revoked'), { timeout: 15_000 }).toBeDefined();
-    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'detached', timeout: 15_000 });
+      event.payload.details.reason === 'session-restarted' && event.payload.details.state === 'revoked'), { timeout: browserTimeout }).toBeDefined();
+    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'detached', timeout: browserTimeout });
     expect(await page.locator('.runtime-stage .mcp-app-preview iframe').count()).toBe(0);
     expect(runtimeAppRequests.filter((request) => request === `DELETE /api/runtime/apps/${encodeURIComponent(initial.id)}`)).toEqual([]);
     const revokedInitialOperation = await page.evaluate(async ({ body, path, sessionToken }) => {
@@ -926,14 +926,14 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     );
     expect(changedTransport).not.toBe(configSource);
     const transportEventStart = runtimeEvents.length;
-    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: 15_000 })
+    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: browserTimeout })
       .toBe(serverOwnedProjectSubscriptions + 1);
     await page.locator('.connection-content').evaluate((element) => {
       element.setAttribute('data-recovery-probe', 'same-instance');
     });
     await page.context().setOffline(true);
     fixture.disconnectProjectEventStream();
-    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: 15_000 })
+    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: browserTimeout })
       .toBe(serverOwnedProjectSubscriptions);
     await replaceWatchedSource(fixture.root, fixture.configSource, changedTransport);
     const definitionOperationPath = `/api/runtime/apps/${encodeURIComponent(definitionRun.id)}/operations`;
@@ -948,7 +948,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
         method: 'POST',
       });
       return Object.freeze({ body: await response.json(), status: response.status });
-    }, { timeout: 15_000 }).toEqual({
+    }, { timeout: browserTimeout }).toEqual({
       body: { diagnostic: { code: 'AB8022', message: 'Runtime MCP App preview was revoked.' } },
       status: 410,
     });
@@ -959,24 +959,24 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
       if (!response.ok) return false;
       const body = await response.json() as Readonly<{ readonly status?: RuntimeStatus }>;
       return body.status?.state === 'active' && body.status.activeVector?.providerSessionId === initialProviderSession;
-    }, { timeout: 15_000 }).toBe(true);
+    }, { timeout: browserTimeout }).toBe(true);
     const sequenceBeforeReplayNoise = fixture.eventHubState.latestSequence;
     fixture.publishReplayNoise();
     expect(fixture.eventHubState.latestSequence).toBe(sequenceBeforeReplayNoise + 257);
     await page.context().setOffline(false);
-    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: 15_000 })
+    await expect.poll(() => fixture.eventHubState.subscriptionCount, { timeout: browserTimeout })
       .toBe(serverOwnedProjectSubscriptions + 1);
-    await expect.poll(() => projectEventStreams, { timeout: 15_000 }).toEqual([
+    await expect.poll(() => projectEventStreams, { timeout: browserTimeout }).toEqual([
       'GET /api/project/events',
       'GET /api/project/events',
     ]);
-    await expect.poll(() => projectEventStreamCursors.size, { timeout: 15_000 }).toBe(2);
+    await expect.poll(() => projectEventStreamCursors.size, { timeout: browserTimeout }).toBe(2);
     expect(projectEventStreamCursors.get(0)).toBe('');
     const reconnectCursor = projectEventStreamCursors.get(1);
     if (reconnectCursor === undefined || !/^(0|[1-9]\d*)$/u.test(reconnectCursor)) {
       throw new Error('Replacement EventSource did not carry a canonical replay cursor.');
     }
-    await expect.poll(() => replayGaps.length, { timeout: 15_000 }).toBe(1);
+    await expect.poll(() => replayGaps.length, { timeout: browserTimeout }).toBe(1);
     const replayGap = replayGaps[0];
     if (replayGap === undefined) throw new Error('Project EventSource did not deliver a replay gap.');
     // The replacement source is seeded by its query, while an id-less gap leaves the
@@ -987,7 +987,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
       requestedAfterSequence: Number(reconnectCursor),
       type: 'replay.gap',
     });
-    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'detached', timeout: 15_000 });
+    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'detached', timeout: browserTimeout });
     expect(await page.locator('.runtime-stage .mcp-app-preview iframe').count()).toBe(0);
     await expect(page.locator('.connection-content')).toHaveAttribute('data-recovery-probe', 'same-instance');
     // Scaled budget: the fallback section renders after the invalidation
@@ -1009,7 +1009,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
       const uiGeneration = await runtimeIdentity.getAttribute('data-runtime-generation');
       return (await runButton.isEnabled()) && statusGeneration !== undefined && statusGeneration === uiGeneration &&
         (activatedGeneration === undefined || activatedGeneration === statusGeneration);
-    }, { timeout: 15_000 }).toBe(true);
+    }, { timeout: browserTimeout }).toBe(true);
     const authoritativeStatus = await readRuntimeStatus();
     const activeGenerationId = authoritativeStatus.activeVector?.runtimeGenerationId;
     if (typeof activeGenerationId !== 'string') throw new Error('Transport restart did not expose an active runtime generation.');
@@ -1044,7 +1044,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
         stableSnapshots = stableGenerationId === generationId ? stableSnapshots + 1 : 1;
         stableGenerationId = generationId;
         return stableSnapshots;
-      }, { interval: 200, timeout: 15_000 }).toBeGreaterThanOrEqual(3);
+      }, { interval: 200, timeout: browserTimeout }).toBeGreaterThanOrEqual(3);
       expect(stableGenerationId).toBe(failedGenerationId);
       const retryResult = await run(4, 3);
       expect(retryResult.run.status).toBe('succeeded');
@@ -1059,7 +1059,7 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
       const status = await readRuntimeStatus();
       return status.activeVector?.runtimeGenerationId === transportRun.runVector.runtimeGenerationId &&
         await runtimeIdentity.getAttribute('data-runtime-generation') === transportRun.runVector.runtimeGenerationId;
-    }, { timeout: 15_000 }).toBe(true);
+    }, { timeout: browserTimeout }).toBe(true);
     const finalRuntimeStatus = await readRuntimeStatus();
     expect(transportRun.runVector.runtimeGenerationId).toBe(finalRuntimeStatus.activeVector?.runtimeGenerationId);
     expect(transportRun.definitionDigest).toBe(definitionRun.definitionDigest);
@@ -1239,7 +1239,7 @@ e2e('opens one real epoch MCP session and keeps its playground operations respon
       return next.state === 'active' && next.activeEpoch.id !== epochId && next.activeEpoch.modelDigest !== modelDigest
         ? next.activeEpoch
         : undefined;
-    }, { timeout: 15_000 }).toEqual(expect.objectContaining({ modelDigest: expect.any(String) }));
+    }, { timeout: browserTimeout }).toEqual(expect.objectContaining({ modelDigest: expect.any(String) }));
     const changedArtifact = server.status().artifact;
     if (changedArtifact.state === 'missing') throw new Error('Registered extension update removed the active artifact epoch.');
     expect(changedArtifact.activeEpoch.id).not.toBe(epochId);

--- a/packages/workbench/tests/overview.e2e.test.ts
+++ b/packages/workbench/tests/overview.e2e.test.ts
@@ -839,8 +839,11 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     if (previewCreateCount === undefined) throw new Error('Runtime App preview response lacks a create count.');
     expect(runtimeAppCreates).toHaveLength(previewCreateCount);
     expect(runtimeAppCreates.filter((candidate) => candidate.response !== undefined)).toHaveLength(previewCreateCount);
-    await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'attached', timeout: browserTimeout });
-    expect(await page.locator('.runtime-stage .mcp-app-preview iframe').count()).toBe(1);
+    // A restart can satisfy waitFor(attached) with the outgoing binding's
+    // iframe and then unmount it before the replacement mounts, so an instant
+    // count() reads a transient 0 on contended runners. toHaveCount retries
+    // until exactly one preview iframe is attached (still failing duplicates).
+    await expect(page.locator('.runtime-stage .mcp-app-preview iframe')).toHaveCount(1, { timeout: browserTimeout });
     return Object.freeze({ binding: binding(previewCreateCount - 1), run: outcome });
   };
   try {

--- a/packages/workbench/tests/overview.e2e.test.ts
+++ b/packages/workbench/tests/overview.e2e.test.ts
@@ -422,10 +422,14 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     const finiteConfig = sourceConfig.replace('  codex: {},', `  codex: { configReconcileMarker: '${finiteConfigMarker}' },`);
     expect(finiteConfig).not.toBe(sourceConfig);
     await replaceWatchedSource(fixture.root, fixture.configSource, finiteConfig);
+    // Config reconcile polls scale with contention: each reconcile recompiles
+    // the config plus the rsc/widget/app bundles (~4s apiece on a pinned
+    // two-core runner), so a raw 15s budget fails deterministically under
+    // taskset -c 0,1 while the change itself is delivered fine.
     await expect.poll(async () => {
       const source = await readProjectSource();
       return source.state === 'ready' && source.revision !== sourceRevision ? source.revision : undefined;
-    }, { timeout: 15_000 }).toEqual(expect.any(String));
+    }, { timeout: browserTimeout }).toEqual(expect.any(String));
     const finiteSource = await readProjectSource();
     const finiteSourceRevision = finiteSource.revision;
     if (finiteSourceRevision === undefined) throw new Error('Finite configuration update did not expose a source revision.');
@@ -443,7 +447,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
       return source.state === 'invalid' && diagnostic?.message === 'A registered config extension must contain strict finite JSON data.'
         ? source
         : undefined;
-    }, { timeout: 15_000 }).toMatchObject({
+    }, { timeout: browserTimeout }).toMatchObject({
       diagnostics: [expect.objectContaining({
         code: 'AB4500',
         message: 'A registered config extension must contain strict finite JSON data.',
@@ -520,7 +524,7 @@ e2e('offers the host-owned MCP playground handoff only after a selected Runtime 
     await expect.poll(async () => {
       const source = await readProjectSource();
       return source.state === 'ready' && source.revision !== finiteSourceRevision ? source.revision : undefined;
-    }, { timeout: 15_000 }).toEqual(expect.any(String));
+    }, { timeout: browserTimeout }).toEqual(expect.any(String));
     const repairedSource = await readProjectSource();
     const repairedSourceRevision = repairedSource.revision;
     if (repairedSourceRevision === undefined) throw new Error('Repaired configuration update did not expose a source revision.');
@@ -986,7 +990,11 @@ e2e('restarts the real Runtime MCP App session when definition or transport auth
     await page.locator('.runtime-stage .mcp-app-preview iframe').waitFor({ state: 'detached', timeout: 15_000 });
     expect(await page.locator('.runtime-stage .mcp-app-preview iframe').count()).toBe(0);
     await expect(page.locator('.connection-content')).toHaveAttribute('data-recovery-probe', 'same-instance');
-    await expect(page.getByText('Interactive App rendering is unavailable (registry-replay-gap). Showing the ordinary tool result instead.')).toBeVisible();
+    // Scaled budget: the fallback section renders after the invalidation
+    // cleanup settles, which lags the iframe detach on a contended runner.
+    // toHaveText also reports the actual reason if the wrong invalidation won.
+    await expect(page.locator('.runtime-stage .mcp-app-preview__fallback > p[role="status"]'))
+      .toHaveText('Interactive App rendering is unavailable (registry-replay-gap). Showing the ordinary tool result instead.', { timeout: browserTimeout });
     expect(runtimeAppRequests.filter((request) => request.startsWith('DELETE /api/runtime/apps/'))).toEqual([]);
     await expect.poll(() => runtimeAppCreates.length, { timeout: 1_000 }).toBe(2);
 

--- a/packages/workbench/tests/packed-release.e2e.test.ts
+++ b/packages/workbench/tests/packed-release.e2e.test.ts
@@ -31,6 +31,7 @@ import {
   workspaceRoot,
   writeFakeClaude,
 } from './support/packed-release-harness.ts';
+import { replaceWatchedSource } from './support/watched-files.ts';
 import { workbenchUrl } from './support/workbench-e2e.ts';
 
 const fixtureRoot = join(workspaceRoot, 'fixtures', 'integration', 'packed-release');
@@ -558,7 +559,7 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 *
 
       phase = 'good edit rebuild B';
       const epochBMarker = 'Epoch B changed the packed review guidance.';
-      await writeFile(skillSource, `${originalSkill}\n\n${epochBMarker}\n`);
+      await replaceWatchedSource(project, skillSource, `${originalSkill}\n\n${epochBMarker}\n`);
       await page.getByRole('link', { name: 'Overview', exact: true }).click();
       await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
       await rebuildFromOverview('epoch B');
@@ -611,7 +612,7 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 *
       await expectGeneratedSkill('last-good epoch B', lastGoodEpochB, epochBMarker);
       const invalidConfig = originalConfig.replace('ui://packed-release/dashboard.html', 'https://packed-release.example/dashboard.html');
       if (invalidConfig === originalConfig) throw new Error('The packed fixture did not contain the resource URI used for the invalid rebuild.');
-      await writeFile(configSource, invalidConfig);
+      await replaceWatchedSource(project, configSource, invalidConfig);
       await page.getByRole('link', { name: 'Overview', exact: true }).click();
       await expect(page.getByRole('heading', { name: 'Bundle dashboard' })).toBeVisible({ timeout: browserTimeout });
       await rebuildFromOverview('invalid epoch B');
@@ -627,8 +628,8 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 *
       phase = 'repaired edit rebuild C';
       const epochCMarker = 'Epoch C repaired the packed review guidance.';
       await Promise.all([
-        writeFile(configSource, originalConfig),
-        writeFile(skillSource, `${originalSkill}\n\n${epochCMarker}\n`),
+        replaceWatchedSource(project, configSource, originalConfig),
+        replaceWatchedSource(project, skillSource, `${originalSkill}\n\n${epochCMarker}\n`),
       ]);
       await rebuildFromOverview('epoch C');
       const epochCStatus = activeEpochFrom(await call('project_status'), 'epoch C');

--- a/packages/workbench/tests/runtime-app-bridge.test.ts
+++ b/packages/workbench/tests/runtime-app-bridge.test.ts
@@ -100,6 +100,7 @@ const runtimeFactory = (
     readonly installedHandlers?: Parameters<typeof createRuntimeAppBridgeFactory>[0]['installedHandlers'];
     readonly policy?: Readonly<{ readonly bindingId: string; readonly snapshot: Readonly<{ readonly allow: string; readonly approvedPermissions: Readonly<Record<string, unknown>>; readonly revision: number; readonly warnings: readonly unknown[] }> }>;
     readonly requestConsent?: Parameters<typeof createRuntimeAppBridgeFactory>[0]['requestConsent'];
+    readonly teardownAckTimeoutMs?: number;
   }> = {},
 ): RuntimeAppBridgeFactory => {
   const policy = options.policy ?? Object.freeze({
@@ -134,6 +135,7 @@ const runtimeFactory = (
     }) as never,
     requestConsent: options.requestConsent ?? (async () => 'deny'),
     simulationFeatures: Object.freeze({ chatGptWidgetState: 'disabled' as const }),
+    ...(options.teardownAckTimeoutMs === undefined ? {} : { teardownAckTimeoutMs: options.teardownAckTimeoutMs }),
   });
 };
 
@@ -533,7 +535,10 @@ it('keeps inbound App messages at 256 KiB while admitting a 1 MiB host result en
 it('bounds an unresponsive resource-teardown before the factory releases transport and access', async () => {
   await withBrowser(async (browser) => {
     let accessCloses = 0;
-    const factory = runtimeFactory(async () => appAccess(async () => { accessCloses += 1; }));
+    // The production ack budget is deliberately generous (a contended runner
+    // must not permanently lose the ack); the seam keeps this bounded-timeout
+    // proof fast without weakening the production window.
+    const factory = runtimeFactory(async () => appAccess(async () => { accessCloses += 1; }), { teardownAckTimeoutMs: 500 });
     const bridge = await invokeBridgeFactory(factory, browser);
     const started = Date.now();
     const teardown = bridge.teardownResource({});

--- a/packages/workbench/tests/runtime-playground-hmr.e2e.test.ts
+++ b/packages/workbench/tests/runtime-playground-hmr.e2e.test.ts
@@ -1,29 +1,13 @@
-import { readFile, rename, writeFile } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 import { expect, test, type PlaywrightOptions } from '@rstest/playwright';
 
 import { startRuntimePlaygroundFixture } from './helpers/runtime-playground-fixture.ts';
+import { replaceWatchedSource } from './support/watched-files.ts';
 import { workbenchUrl } from './support/workbench-e2e.ts';
 import { timeScale } from '../../agent-bundle/tests/support/time-scale.ts';
 
 const browserTimeout = 30_000 * timeScale;
-
-/**
- * Replaces a watched source atomically through a rename staged OUTSIDE the
- * watched project. An in-place write is truncate-then-append: the dev
- * compiler can start a compile off the truncation event, read incomplete
- * content, and then drop the append event because both operations land
- * within the same mtime tick, so the final content never compiles and the
- * expected generation never activates. The temp file lives in the project's
- * parent (same filesystem, never watched) so the rename into place is the
- * only event the watcher observes.
- */
-const replaceWatchedSource = async (projectRoot: string, path: string, content: string): Promise<void> => {
-  const temporary = join(projectRoot, '..', `.${basename(path)}.${process.pid}.tmp`);
-  await writeFile(temporary, content);
-  await rename(temporary, path);
-};
 
 const e2e = test.extend({
   playwright: {

--- a/packages/workbench/tests/support/watched-files.ts
+++ b/packages/workbench/tests/support/watched-files.ts
@@ -1,0 +1,18 @@
+import { rename, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+/**
+ * Replaces a watched source atomically through a rename staged OUTSIDE the
+ * watched project. An in-place write is truncate-then-append: the dev
+ * compiler can start a compile off the truncation event, read incomplete
+ * content, and then drop the append event because both operations land
+ * within the same mtime tick, so the final content never compiles and the
+ * expected revision never activates. The temp file lives in the project's
+ * parent (same filesystem, never watched) so the rename into place is the
+ * only event the watcher observes.
+ */
+export const replaceWatchedSource = async (projectRoot: string, path: string, content: string): Promise<void> => {
+  const temporary = join(projectRoot, '..', `.${basename(path)}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`);
+  await writeFile(temporary, content);
+  await rename(temporary, path);
+};


### PR DESCRIPTION
## Summary

Applies the PR #31 root cause and fix pattern — in-place truncate-then-append writes to watched source files can race the dev compiler's watcher (compile off the truncation event, drop the append event within the same mtime tick) — to the remaining e2e suites that shared it, two of which flaked on recent Verify runs (`overview` and `mcp-app-real` on PR #29's Node 24 legs).

### Watched-file writes replaced with atomic staged-rename

New shared helper `packages/workbench/tests/support/watched-files.ts` (`replaceWatchedSource`: stage the temp file in the unwatched project parent, then `rename` into place — same pattern as #31). The HMR suite's local copy from #31 now imports the shared helper too.

- **`overview.e2e.test.ts`** — 9 in-place writes: widget app source + styles (paired `Promise.all`), config source (finite → invalid → repaired transitions and transport-authority change), server definition source, project config in the packed-project test, and `SKILL.md`.
- **`packed-release.e2e.test.ts`** — 4 in-place writes: `SKILL.md` edit, invalid-config write, and the paired config+skill restore.
- **`mcp-app-real.e2e.test.ts`** — no watched-file writes (all project writes happen before the dev server starts).

### The mcp-app-real teardown-ack flake was real — two root causes

Reproduced under `taskset -c 0,1` and instrumented. The failing poll ("third Runtime App teardown never acknowledged") had two independent causes:

1. **Host messages dropped during the App handshake** (`packages/agent-bundle/src/dev/runtime-client-surface-proxy.ts`): the proxy shell silently dropped host→app messages that arrived after the initialize response but before the app posted `ui/notifications/initialized`. A `ui/resource-teardown` landing in that window was lost forever. The shell now queues host messages (bounded, 32) and flushes them on `initialized`.
2. **Unscaled 1s teardown-ack budget** (`packages/workbench/src/mcp/runtime-app-bridge.ts`): `gracefulTeardownTimeoutMs` was 1s; missing it is unrecoverable because the frame is unmounted, so a late ack can never arrive. A contended two-core runner was observed missing the window during a dev-compile storm. Raised to 10s (only bounds an app that can never answer; a healthy app acks in milliseconds) with a `teardownAckTimeoutMs` test seam so the unit test stays fast.

It was **not** the `closeServer`/connection-ordering race from #24/#30 — #30's `closeAllConnections` ordering fix already covers that path.

### Additional contended-runner fixes the stress runs exposed

- `overview.e2e.test.ts` used literal `15_000` poll/locator timeouts that don't scale with `timeScale`; on two cores the config-reconcile compile storms legitimately exceed them. All are now `browserTimeout`.
- `mcp-app-real.e2e.test.ts` now waits for the third app frame's `ui/initialize` before navigating away, and the teardown-ack poll reports a full diagnostic payload on failure.

## Verification

- `pnpm typecheck`, `pnpm --filter agent-bundle-workbench build`, unit suites for the bridge and proxy shell.
- Each changed e2e file run individually with `AGENT_BUNDLE_PACKAGE_PREBUILT=1 AGENT_BUNDLE_WORKBENCH_PREBUILT=1` (including `runtime-playground-hmr` after the helper consolidation).
- Stress under `taskset -c 0,1` after the fixes: overview 5/5, mcp-app-real 5/5, packed-release 5/5 (earlier packed-release noise — a Chrome OOM crash and leaked-temp-root false positives — traced to ambient machine load from concurrent runs, not these changes).

Pattern source: #31. Flakes referenced: overview + mcp-app-real on recent Verify runs (PR #29).

### Issue closure

Closes #23. That issue tracks exactly this failure: `mcp-app-real.e2e.test.ts > opens the real RSC runtime timeline App from provider-owned run evidence` timing out on the third teardown acknowledgement poll under slow CI runners. The issue's hypothesis (frame unmounted before the App posts its response) was close but not the mechanism: the acknowledgement was never produced because the client-surface relay dropped the `ui/resource-teardown` request itself when it arrived inside the App's initialize handshake window, and the test additionally navigated away before the third App's transport could connect. With the relay queue fix plus the test's `ui/initialize` gate, the pinned two-core stress that previously failed 2/8 (budget-independent, even at a 30s grace) passes 8/8, and full-suite stress passes 5/5 per suite.

A patch changeset for `agent-bundle` covers the relay behavior change.


### Recovery-verification addendum

Full verification re-run on the final tree: `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test:unit`, each changed e2e file individually (overview 13/13, mcp-app-real 4/4, packed-release 1/1, runtime-playground-hmr 1/1 after the helper consolidation), and a 5-iteration full-file stress (iterations 1–2 under `taskset -c 0,1` with `CI=1`): unit 5/5, mcp-app-real 5/5, packed-release 5/5, overview 4/5. The one overview failure exposed another latent contended-runner race in the restart test — `waitFor(attached)` can resolve against the outgoing binding's preview iframe, which unmounts before its replacement mounts, so the instant `count()` reads a transient 0 — fixed by an auto-retrying `toHaveCount(1)`; the fixed test then passed 5/5 single-test under two-core pinning.
