### PR TITLE
chore(release): make pkg.pr.new the interim channel and pre-wire npm provenance

### DIFF
--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -7,8 +7,11 @@ on:
 
 permissions: {}
 
+# PR builds cancel superseded runs (only the latest preview matters), but each
+# push to main gets a SHA-keyed group so overlapping pushes never cancel a
+# main preview publish — every main commit must stay installable by SHA.
 concurrency:
-  group: package-preview-${{ github.event.pull_request.number || github.ref }}
+  group: package-preview-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - main
 
+# id-token is required for npm package provenance once publishing starts; it is
+# inert while the NPM_TOKEN gate below keeps the publish steps skipped.
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -318,4 +318,6 @@ Repository-owned Chromium E2E runs independently of a connected ChatGPT Chrome e
 extension is for the separate final manual visual pass, not a substitute for repository or packed
 consumer verification. Package versions and release PRs use Changesets. Add a changeset with
 `pnpm changeset`; merges to `main` update or publish through the standard Changesets action. Pull
-requests publish `agent-bundle` and `@agent-bundle/rsc-runtime` canaries through pkg.pr.new.
+requests and every push to `main` publish `agent-bundle` and `@agent-bundle/rsc-runtime` canaries
+through pkg.pr.new — the interim release channel while npm publishing waits on the final package
+name (see [Preview packages](docs/preview-packages.md)).

--- a/docs/preview-packages.md
+++ b/docs/preview-packages.md
@@ -43,8 +43,11 @@ When installing both previews into the same project with npm, add
 `.github/workflows/package-preview.yml` runs
 `pnpm preview:publish` (`pkg-pr-new publish --previewVersion --no-compact
 --no-template './packages/agent-bundle' './packages/rsc-runtime'`) after a
-full build, on every pull request and on every push to `main`, so every
-`main` commit has an installable snapshot. The "Publish pkg.pr.new preview"
+full build, on every pull request and on every push to `main`. Runs for
+`main` pushes use a per-commit concurrency group, so overlapping pushes
+cannot cancel one another and every `main` commit has an installable
+snapshot. (PR runs cancel superseded builds for the same PR — only the
+latest preview of a PR matters.) The "Publish pkg.pr.new preview"
 check on a PR or commit links to the exact URLs for that build. Previews are
 built from the same `pnpm build` output the release gates verify; they are
 not npm releases and carry preview version strings.

--- a/docs/preview-packages.md
+++ b/docs/preview-packages.md
@@ -1,6 +1,10 @@
 # Preview packages (pkg.pr.new)
 
-Nothing is published to npm yet. Every CI package-preview run publishes real,
+Nothing is published to npm yet, deliberately: the current package names are
+placeholders, and npm publishing is deferred until the final name is chosen
+(it will then use [npm package provenance](https://docs.npmjs.com/generating-provenance-statements);
+the manifests and release workflow are already wired for it). Until then
+pkg.pr.new is the release channel. Every CI package-preview run publishes real,
 installable tarballs of both workspace packages to [pkg.pr.new](https://pkg.pr.new)
 — a free continuous-release registry keyed by commit SHA and pull request.
 These are the packages to install until a first npm release is cut.
@@ -29,12 +33,18 @@ npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/rsc-runtime@
 
 pnpm and yarn accept the same URLs (`pnpm add <url>`, `yarn add agent-bundle@<url>`).
 
+Previews carry the version string `0.0.0-preview-<sha>`, which does not satisfy
+the `agent-bundle@^0.1.0` peer range declared by `@agent-bundle/rsc-runtime`.
+When installing both previews into the same project with npm, add
+`--legacy-peer-deps`; pnpm reports the mismatch as a warning and proceeds.
+
 ## Where previews come from
 
 `.github/workflows/package-preview.yml` runs
-`pnpm preview:publish` (`pkg-pr-new publish './packages/agent-bundle'
-'./packages/rsc-runtime'`) after a full build, on every pull request and on
-every push to `main`. The "Publish pkg.pr.new preview" check on a PR or commit
-links to the exact URLs for that build. Previews are built from the same
-`pnpm build` output the release gates verify; they are not npm releases and
-carry preview version strings.
+`pnpm preview:publish` (`pkg-pr-new publish --previewVersion --no-compact
+--no-template './packages/agent-bundle' './packages/rsc-runtime'`) after a
+full build, on every pull request and on every push to `main`, so every
+`main` commit has an installable snapshot. The "Publish pkg.pr.new preview"
+check on a PR or commit links to the exact URLs for that build. Previews are
+built from the same `pnpm build` output the release gates verify; they are
+not npm releases and carry preview version strings.

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -236,5 +236,6 @@ Run the complete local delivery gate with `pnpm check && pnpm check:release`.
 `pnpm pack:dry-run`, `pnpm audit:release`, and `pnpm test:packed`, and it does not replace
 `pnpm check`.
 Native Claude/Codex smokes stay intentionally opt-in and skipped in ordinary CI.
-Publication is deliberately not scripted here: the release owner must decide the npm package
-name/scope, license, and `publishConfig` before publishing.
+npm publishing is deferred until the release owner picks the final package name/scope and
+license; pkg.pr.new previews are the interim channel, and the first npm release will use npm
+package provenance (`publishConfig.provenance` is already set).

--- a/packages/agent-bundle/package.json
+++ b/packages/agent-bundle/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git+https://github.com/ScriptedAlchemy/agent-bundle.git"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/packages/rsc-runtime/README.md
+++ b/packages/rsc-runtime/README.md
@@ -1,6 +1,8 @@
 # `@agent-bundle/rsc-runtime`
 
 Small React primitives for producing Agent Bundle hook and MCP protocol results with JSX.
+No npm release is cut yet; install the pkg.pr.new preview of any `main` commit or pull
+request — see [Preview packages](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/docs/preview-packages.md).
 
 ```tsx
 import { Mcp, lowerMcpResult } from '@agent-bundle/rsc-runtime';

--- a/packages/rsc-runtime/package.json
+++ b/packages/rsc-runtime/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/rsc-runtime"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Owner decision: npm publishing stays off until the packages get their final names (current names are placeholders); pkg.pr.new is the release channel in the meantime, and the first npm releases will use npm package provenance. This PR makes the repo reflect that deliberately.

- **Audit result**: `package-preview.yml` already publishes both `agent-bundle` and `@agent-bundle/rsc-runtime` on every pull request *and* every push to `main` (verified in run history), so every main commit already gets an installable snapshot — no trigger change needed. A real `npm install` smoke of the latest main preview (`d708d94`) into a fresh consumer succeeded for both packages: all supported entrypoints import and the CLI bin runs.
- **Pre-wired provenance, dormant**: `"publishConfig": { "provenance": true }` on both publishable manifests and `id-token: write` on the release workflow. The existing no-`NPM_TOKEN` gate still skips every publish step (no repo secrets exist), so nothing activates now.
- **Docs**: `docs/preview-packages.md` now states the deferral decision, matches the actual `preview:publish` flags, and documents the `--legacy-peer-deps` caveat the smoke surfaced (previews are `0.0.0-preview-<sha>`, which doesn't satisfy rsc-runtime's `agent-bundle@^0.1.0` peer range). One-line pointers added to the root README, `packages/agent-bundle/README.md`, and `packages/rsc-runtime/README.md`.

No changeset: workflow, manifest metadata, and docs only — no published runtime behavior changes.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit`: green
- `pnpm lint:package` (publint) and `packages/agent-bundle/tests/release-audit.test.ts` (asserts packed manifest shape): green with the new `publishConfig` key
- Live smoke: `npm i --legacy-peer-deps https://pkg.pr.new/ScriptedAlchemy/agent-bundle/{agent-bundle,@agent-bundle/rsc-runtime}@d708d94` → all entrypoints import, CLI `--help` works