### PR TITLE
fix(mcp-apps): throw the intended stub error from the built entrypoint instead of a TDZ ReferenceError

### DIFF
--- a/.changeset/mcp-apps-stub-error.md
+++ b/.changeset/mcp-apps-stub-error.md
@@ -1,0 +1,13 @@
+---
+"agent-bundle": patch
+---
+
+Throw the intended unavailable-entrypoint error from the built
+`agent-bundle/mcp-apps` stub. The rslib bundle reorders module statements so
+the emitted `export default` binding was read before its `const` initializer
+ran, surfacing a TDZ `ReferenceError` ("Cannot access 'mcp_apps' before
+initialization") on import instead of the stub's message. The stub now throws
+through a hoisted function declaration, which survives the bundler's
+statement reordering, so importing the built entrypoint reports
+"agent-bundle/mcp-apps is available only while Agent Bundle compiles a local
+MCP server." as intended.

--- a/packages/agent-bundle/src/mcp-apps.ts
+++ b/packages/agent-bundle/src/mcp-apps.ts
@@ -11,10 +11,18 @@ export interface McpAppResource {
   readonly resourceUri: string;
 }
 
-export const mcpApps: readonly McpAppResource[] = Object.freeze([]);
+/**
+ * Every export must throw through a hoisted function declaration: the rslib
+ * bundle emits `export default <binding>;` above the const initializers, so a
+ * top-level `throw` or a `const`-backed default export surfaces a TDZ
+ * ReferenceError instead of this message (see the mcp-apps dist test).
+ */
+function throwUnavailableEntrypoint(): readonly McpAppResource[] {
+  throw new Error(
+    'agent-bundle/mcp-apps is available only while Agent Bundle compiles a local MCP server.',
+  );
+}
 
-export default mcpApps;
+export const mcpApps: readonly McpAppResource[] = throwUnavailableEntrypoint();
 
-throw new Error(
-  'agent-bundle/mcp-apps is available only while Agent Bundle compiles a local MCP server.',
-);
+export default throwUnavailableEntrypoint();

--- a/packages/agent-bundle/tests/helpers/workspace-paths.ts
+++ b/packages/agent-bundle/tests/helpers/workspace-paths.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 
 const workspaceRoot = join(import.meta.dirname, '..', '..', '..', '..');
 
-export const agentBundleNodeModules = join(workspaceRoot, 'packages', 'agent-bundle', 'node_modules');
+export const agentBundlePackageRoot = join(workspaceRoot, 'packages', 'agent-bundle');
+export const agentBundleNodeModules = join(agentBundlePackageRoot, 'node_modules');
 export const workbenchNodeModules = join(workspaceRoot, 'packages', 'workbench', 'node_modules');
 export const workspaceNodeModules = join(workspaceRoot, 'node_modules');

--- a/packages/agent-bundle/tests/mcp.test.ts
+++ b/packages/agent-bundle/tests/mcp.test.ts
@@ -1,6 +1,8 @@
+import { spawn } from 'node:child_process';
 import { access, cp, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { expect, it } from '@rstest/core';
 import { Client } from '@modelcontextprotocol/client';
@@ -19,7 +21,7 @@ import {
   type NormalizationTargetRegistry,
 } from '../src/core/types.ts';
 
-import { agentBundleNodeModules, workbenchNodeModules } from './helpers/workspace-paths.ts';
+import { agentBundleNodeModules, agentBundlePackageRoot, workbenchNodeModules } from './helpers/workspace-paths.ts';
 import { loadedProject } from './support/loaded-project.ts';
 
 const registry: NormalizationTargetRegistry = {
@@ -792,6 +794,34 @@ it('rejects the MCP Apps virtual module outside Agent Bundle compilation', async
   await expect(import('../src/mcp-apps.ts')).rejects.toThrow(
     'agent-bundle/mcp-apps is available only while Agent Bundle compiles a local MCP server.',
   );
+});
+
+it('rejects the built MCP Apps entrypoint with the intended error, not a TDZ ReferenceError', async () => {
+  // The rslib bundle reorders module statements (`export default` above the
+  // const initializers), so the stub's contract must hold against dist, not
+  // just src. Import in a child process: module evaluation errors are cached
+  // per realm, so an in-process import could observe another test's result.
+  const distEntry = join(agentBundlePackageRoot, 'dist', 'mcp-apps.js');
+  const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((resolve) => {
+    const child = spawn(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      `await import(${JSON.stringify(pathToFileURL(distEntry).href)});`,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let output = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      output += chunk;
+    });
+    child.on('close', (exitCode) => {
+      resolve({ code: exitCode, stderr: output });
+    });
+  });
+  expect(code).toBe(1);
+  expect(stderr).toContain(
+    'agent-bundle/mcp-apps is available only while Agent Bundle compiles a local MCP server.',
+  );
+  expect(stderr).not.toContain('ReferenceError');
 });
 
 it('uses the selected streamable HTTP manifest with propagated cancellation and cleans data before rejecting tampering', async () => {


### PR DESCRIPTION
## Summary

- Importing the built `agent-bundle/mcp-apps` stub surfaced `ReferenceError: Cannot access 'mcp_apps' before initialization` instead of the intended "available only while Agent Bundle compiles a local MCP server" error. The rslib/rspack bundle reorders module statements — the emitted `export default mcp_apps;` line ran before the `const mcp_apps` initializer, hitting the temporal dead zone before the source's top-level `throw` executed.
- Restructure the stub so every export evaluates through a hoisted function declaration that throws the intended error; function hoisting makes the message correct regardless of how the bundler orders the emitted statements (verified against the actual `dist/mcp-apps.js` output).
- Add a regression test in `mcp.test.ts` that imports the BUILT dist entrypoint in a child process and asserts the intended message and the absence of a ReferenceError. The existing test only imported the source file, which is why the dist-only regression went unnoticed.
- Patch changeset included (published package behavior: error message correctness).

## Test plan

- [x] `pnpm build` — emitted `dist/mcp-apps.js` throws the intended error on import
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm lint:package`
- [x] `pnpm test:unit` (one unrelated `native-claude-contract` timeout flake, passed on rerun)
- [x] `rstest --config rstest.integration.config.ts packages/agent-bundle/tests/mcp.test.ts` — 16/16 pass, including the new dist-contract test