### PR TITLE
fix(release): rewrite preview peer ranges via --peerDeps so npm installs matched pkg.pr.new pairs cleanly

### DIFF
--- a/docs/preview-packages.md
+++ b/docs/preview-packages.md
@@ -33,17 +33,22 @@ npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/rsc-runtime@
 
 pnpm and yarn accept the same URLs (`pnpm add <url>`, `yarn add agent-bundle@<url>`).
 
-Previews carry the version string `0.0.0-preview-<sha>`, which does not satisfy
-the `agent-bundle@^0.1.0` peer range declared by `@agent-bundle/rsc-runtime`.
-When installing both previews into the same project with npm, add
-`--legacy-peer-deps`; pnpm reports the mismatch as a warning and proceeds.
+Previews carry the version string `0.0.0-preview-<sha>`, and the publish
+rewrites the `agent-bundle` peer range inside the `@agent-bundle/rsc-runtime`
+preview tarball to that exact preview version (`--peerDeps`). Installing both
+packages from the same sha therefore works with stock npm — no
+`--legacy-peer-deps` needed. Mixing two different shas fails with `ERESOLVE`
+by design; use one sha (or one PR number) for both URLs. Previews published
+before the peer rewrite landed (PR #46) still carry the original
+`agent-bundle@^0.1.0` range, so pair-installing those older shas with npm
+still requires `--legacy-peer-deps`.
 
 ## Where previews come from
 
 `.github/workflows/package-preview.yml` runs
-`pnpm preview:publish` (`pkg-pr-new publish --previewVersion --no-compact
---no-template './packages/agent-bundle' './packages/rsc-runtime'`) after a
-full build, on every pull request and on every push to `main`. Runs for
+`pnpm preview:publish` (`pkg-pr-new publish --previewVersion --peerDeps
+--no-compact --no-template './packages/agent-bundle' './packages/rsc-runtime'`)
+after a full build, on every pull request and on every push to `main`. Runs for
 `main` pushes use a per-commit concurrency group, so overlapping pushes
 cannot cancel one another and every `main` commit has an installable
 snapshot. (PR runs cancel superseded builds for the same PR — only the

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
-    "preview:publish": "pkg-pr-new publish --previewVersion --no-compact --no-template './packages/agent-bundle' './packages/rsc-runtime'",
+    "preview:publish": "pkg-pr-new publish --previewVersion --peerDeps --no-compact --no-template './packages/agent-bundle' './packages/rsc-runtime'",
     "pack:dry-run": "pnpm build && npm pack ./packages/agent-bundle --dry-run --json",
     "audit:release": "pnpm lint:package && attw --pack --profile esm-only packages/agent-bundle && node scripts/audit-packed-release.mjs",
     "check:release": "pnpm pack:dry-run && pnpm audit:release && pnpm test:packed",


### PR DESCRIPTION
## Summary

Installing both pkg.pr.new previews with npm hard-fails with `ERESOLVE`: previews are versioned `0.0.0-preview-<sha>`, which does not satisfy the `agent-bundle@^0.1.0` peer range that `@agent-bundle/rsc-runtime` ships even in its preview tarball. This lands **direction 1** from the issue: add `--peerDeps` to `preview:publish`.

Per the pinned `pkg-pr-new@0.0.88` source, `--previewVersion` alone only rewrites the `version` field — its help text claims cross-package peerDependencies are updated to match, but peer rewriting (`hijackDeps(realDeps, pJson.peerDependencies)`) only runs when `--peerDeps` is set, which is what builds the `realDeps` map. With both flags, the preview tarball's `agent-bundle` peer range becomes the exact `0.0.0-preview-<sha>` of the same run, so a matched pair installs cleanly with stock npm, and a mixed-sha pair now fails loudly instead of being silently accepted. Preview tarballs only; the manifests destined for npm are untouched (`writeDeps` restores the source `package.json` after packing).

## Verification

Smoke-tested against this PR's own preview publish: plain `npm install` (no `--legacy-peer-deps`) of both preview URLs into a clean temp project, then import both entrypoints. Results in the PR conversation.

Closes #45