### PR TITLE
refactor(examples/hooks-and-scripts): export main and let the generated envelope own the process (RFC #50 Phase 2)

### DIFF
--- a/examples/hooks-and-scripts/README.md
+++ b/examples/hooks-and-scripts/README.md
@@ -9,7 +9,9 @@ pnpm example:hooks
 The example is credential-free. It models a release preparation session with a
 session-start Hook, a manifest-backed packaging check, and a risk-register
 check so the Workbench can show canonical Hook simulation, successful and
-blocking script traces, and live Logs.
+blocking script traces, and live Logs. Both scripts export `main` and return
+their exit codes; the build generates the process envelope that owns argv,
+awaiting, and exit-code adoption.
 
 ## Workbench walkthrough
 

--- a/examples/hooks-and-scripts/src/scripts/detect-risk.ts
+++ b/examples/hooks-and-scripts/src/scripts/detect-risk.ts
@@ -13,20 +13,22 @@ interface RiskRegister {
 
 const registerPath = new URL('../assets/release/risk-register.json', import.meta.url);
 
-try {
-  const register = JSON.parse(await readFile(registerPath, 'utf8')) as RiskRegister;
-  if (!Array.isArray(register.risks)) throw new Error('risk register must contain a risks array');
+export const main = async (): Promise<number> => {
+  try {
+    const register = JSON.parse(await readFile(registerPath, 'utf8')) as RiskRegister;
+    if (!Array.isArray(register.risks)) throw new Error('risk register must contain a risks array');
 
-  const blockers = register.risks.filter((risk) => risk.status === 'open' && risk.severity === 'high');
-  if (blockers.length === 0) {
-    process.stdout.write('No open high-severity release risks found.\n');
-  } else {
+    const blockers = register.risks.filter((risk) => risk.status === 'open' && risk.severity === 'high');
+    if (blockers.length === 0) {
+      process.stdout.write('No open high-severity release risks found.\n');
+      return 0;
+    }
     for (const risk of blockers) {
       process.stderr.write(`${typeof risk.id === 'string' ? risk.id : 'UNIDENTIFIED'}: ${typeof risk.summary === 'string' ? risk.summary : 'Open high-severity release risk'}\n`);
     }
-    process.exitCode = 2;
+    return 2;
+  } catch (error) {
+    process.stderr.write(`Unable to detect release risks: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
   }
-} catch (error) {
-  process.stderr.write(`Unable to detect release risks: ${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
-}
+};

--- a/examples/hooks-and-scripts/src/scripts/verify-release.ts
+++ b/examples/hooks-and-scripts/src/scripts/verify-release.ts
@@ -35,16 +35,18 @@ const validationErrors = (manifest: ReleaseManifest): readonly string[] => {
   return errors;
 };
 
-try {
-  const manifest = await readManifest();
-  const errors = validationErrors(manifest);
-  if (errors.length > 0) {
-    process.stderr.write(`Release manifest is incomplete:\n${errors.map((error) => `- ${error}`).join('\n')}\n`);
-    process.exitCode = 1;
-  } else {
+export const main = async (): Promise<number> => {
+  try {
+    const manifest = await readManifest();
+    const errors = validationErrors(manifest);
+    if (errors.length > 0) {
+      process.stderr.write(`Release manifest is incomplete:\n${errors.map((error) => `- ${error}`).join('\n')}\n`);
+      return 1;
+    }
     process.stdout.write(`Release ${manifest.version} is ready for packaging.\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`Unable to verify release manifest: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
   }
-} catch (error) {
-  process.stderr.write(`Unable to verify release manifest: ${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
-}
+};


### PR DESCRIPTION
## Summary

Phase-2 wave (RFC #50, plan §1.2 — executable-envelope witness), on top of the merged Phase-1 implementation (#52).

- `src/scripts/verify-release.ts` and `src/scripts/detect-risk.ts` drop the top-level self-executing try/catch rituals and instead `export const main = async (): Promise<number>`; the framework's generated executable envelope (`build/entry-shell.ts`) owns argv, awaiting, and numeric exit-code adoption.
- `detect-risk`'s blocking path now `return 2` — the wave's non-trivial exit-code witness: the envelope adopts the numeric return verbatim (`process.exitCode = code`), verified end-to-end (built `.mjs` exits 2 with `REL-204` on stderr from an unrelated cwd).
- Asset-relative `new URL('../assets/…', import.meta.url)` resolution is unchanged: the envelope is a virtual wrapper bundled into the same emitted `scripts/<name>.mjs`, so module-URL semantics are identical to today's direct bundle.
- `src/hooks/session-start.ts` untouched (already the convention). README gains one line noting the scripts export `main` with a generated process envelope; walkthrough sections unchanged.
- Zero edits to `examples-contract.test.ts` — all pinned assertions (`compiledEntries` names, verify stdout, detect-risk exit 2 + REL-204) hold as-is.

## Q5 resolution (verified against shipped Phase-1 source)

- Artifact Scripts take the envelope on a `main` export only (`build/entries.ts` wraps iff `hasMainExport`); `default` is reserved for bin entries (`build/package-build.ts`).
- Numeric return of 2 is adopted verbatim by the generated wrapper.
- `import.meta.url` semantics unchanged under the wrapper (empirically: built script resolves packaged assets from an unrelated cwd).

## Verification

- `pnpm --filter @agent-bundle-example/hooks-and-scripts check` — pass, zero diagnostics.
- `AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest --config rstest.integration.config.ts packages/agent-bundle/tests/examples-contract.test.ts` — all 3 examples pass, no assertion changes.
- Root `pnpm typecheck` + `pnpm lint` — clean.
- Skills-starter sentinel (plan §1.1/Q10, read-only): `check` passes, `inspect` shows `packageBuild` absent and `scripts: []`, default-`dist` artifact manifest intact, zero drift.