### PR TITLE
refactor(examples/mcp-app): factory entry, src/mcp/<server-id>.ts convention, and the mcp run doc flow (RFC #50 Phase 2)

### DIFF
--- a/examples/mcp-app/README.md
+++ b/examples/mcp-app/README.md
@@ -18,8 +18,13 @@ and Claude artifacts; the App resource remains portable.
 - `src/hooks/session-start.ts` adds the readiness workflow to compatible host
   sessions, while `check-service-fixture` validates the checked-in compiler
   fixture before a release walkthrough.
-- `src/mcp-server.ts` serves immutable `compiler` and `payments-api` health
-  records. `payments-api` deliberately returns degraded latency evidence.
+- `src/mcp/status.ts` default-exports the `status` server factory serving
+  immutable `compiler` and `payments-api` health records; `payments-api`
+  deliberately returns degraded latency evidence. The build discovers the
+  entry through the `src/mcp/<server-id>.ts` convention — the config declares
+  no `entry` — and wraps the factory in the generated stdio lifecycle shell
+  (console-to-stderr guard, signal handling, stdin-EOF exit, bounded
+  shutdown, heartbeat).
 
 ## Workbench walkthrough
 
@@ -71,6 +76,18 @@ pnpm build
 pnpm exec agent-bundle eval --case status-is-healthy --trials 1
 pnpm dev
 ```
+
+Run the built `status` server in the foreground on stdio:
+
+```bash
+pnpm exec agent-bundle mcp run --server status --target portable
+```
+
+The command resolves the generated entry from the portable target's MCP
+manifest, building a temporary artifact first; pass `--artifact dist` to
+reuse the `pnpm build` output instead. Closing stdin exits 0 and Ctrl-C
+exits 130, and per-server state persists under
+`.agent-bundle/mcp-run/portable/status`.
 
 Use `pnpm check` for validation and build without opening the Workbench. The
 deterministic portable eval and fixture check read only checked-in data and

--- a/examples/mcp-app/agent-bundle.config.ts
+++ b/examples/mcp-app/agent-bundle.config.ts
@@ -16,7 +16,6 @@ export default defineConfig({
             template: './views/status-panel.html',
           },
         },
-        entry: './src/mcp-server.ts',
       },
     },
   },

--- a/examples/mcp-app/src/mcp-server.ts
+++ b/examples/mcp-app/src/mcp-server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from '@modelcontextprotocol/server';
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import apps from 'agent-bundle/mcp-apps';
 import { z } from 'zod';
 
@@ -7,8 +6,6 @@ import { healthyCompilerStatus } from './compiler-status-contract.ts';
 
 const app = apps[0];
 if (app === undefined) throw new Error('Expected the status MCP App.');
-
-const server = new McpServer({ name: 'mcp-app-example', version: '1.0.0' });
 
 const serviceCatalog = Object.freeze({
   compiler: healthyCompilerStatus,
@@ -23,24 +20,35 @@ const serviceCatalog = Object.freeze({
   }),
 });
 
-server.registerResource(app.name, app.resourceUri, {
-  _meta: { ui: { resourceUri: app.resourceUri } },
-  mimeType: app.mimeType,
-}, async (uri) => ({
-  contents: [{ mimeType: app.mimeType, text: app.html, uri: uri.href }],
-}));
+export const createStatusServer = (): McpServer => {
+  const server = new McpServer({ name: 'mcp-app-example', version: '1.0.0' });
 
-server.registerTool('show-status', {
-  _meta: { ui: { resourceUri: app.resourceUri } },
-  description: 'Show the health of one example service.',
-  inputSchema: z.object({ service: z.enum(['compiler', 'payments-api']) }),
-}, async ({ service }) => {
-  const result = serviceCatalog[service];
-  return {
+  server.registerResource(app.name, app.resourceUri, {
     _meta: { ui: { resourceUri: app.resourceUri } },
-    content: [{ text: result.summary, type: 'text' }],
-    structuredContent: result,
-  };
-});
+    mimeType: app.mimeType,
+  }, async (uri) => ({
+    contents: [{ mimeType: app.mimeType, text: app.html, uri: uri.href }],
+  }));
 
-await server.connect(new StdioServerTransport());
+  server.registerTool('show-status', {
+    _meta: { ui: { resourceUri: app.resourceUri } },
+    description: 'Show the health of one example service.',
+    inputSchema: z.object({ service: z.enum(['compiler', 'payments-api']) }),
+  }, async ({ service }) => {
+    const result = serviceCatalog[service];
+    return {
+      _meta: { ui: { resourceUri: app.resourceUri } },
+      content: [{ text: result.summary, type: 'text' }],
+      structuredContent: result,
+    };
+  });
+
+  return server;
+};
+
+/**
+ * Default-exported server factory: `agent-bundle build` detects it and wraps
+ * this entry in the framework stdio lifecycle shell (console-to-stderr guard,
+ * SIGINT/SIGTERM handling, stdin-EOF exit, bounded shutdown, heartbeat).
+ */
+export default createStatusServer;

--- a/examples/mcp-app/src/mcp/status.ts
+++ b/examples/mcp-app/src/mcp/status.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/server';
 import apps from 'agent-bundle/mcp-apps';
 import { z } from 'zod';
 
-import { healthyCompilerStatus } from './compiler-status-contract.ts';
+import { healthyCompilerStatus } from '../compiler-status-contract.ts';
 
 const app = apps[0];
 if (app === undefined) throw new Error('Expected the status MCP App.');

--- a/examples/mcp-app/src/scripts/check-service-fixture.ts
+++ b/examples/mcp-app/src/scripts/check-service-fixture.ts
@@ -4,13 +4,20 @@ import { isHealthyCompilerFixture } from '../compiler-status-contract.ts';
 
 const fixturePath = new URL('../assets/evals/fixtures/status/result.json', import.meta.url);
 
-try {
-  const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as unknown;
-  if (!isHealthyCompilerFixture(fixture)) {
-    throw new Error('compiler fixture must contain the exact healthy compiler status');
+/**
+ * `agent-bundle build` detects the `main` export and generates the process
+ * envelope (argv, awaiting, numeric-return exit-code adoption) around it.
+ */
+export const main = async (): Promise<number> => {
+  try {
+    const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as unknown;
+    if (!isHealthyCompilerFixture(fixture)) {
+      throw new Error('compiler fixture must contain the exact healthy compiler status');
+    }
+    process.stdout.write('Compiler fixture is healthy.\n');
+    return 0;
+  } catch (error) {
+    process.stderr.write(`Unable to verify service fixture: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
   }
-  process.stdout.write('Compiler fixture is healthy.\n');
-} catch (error) {
-  process.stderr.write(`Unable to verify service fixture: ${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
-}
+};


### PR DESCRIPTION
## Summary

Phase-2 migration of `examples/mcp-app` onto the RFC #50 Phase-1 surface merged in #52. mcp-app is the raw v2-SDK witness for the generated stdio shell (audiobook-curator covers the RSC path), the only in-repo witness for the `src/mcp/<server-id>.ts` entry convention, and now the doc witness for `agent-bundle mcp run`.

- **Factory conversion** — `src/mcp-server.ts` drops its self-connecting bootstrap (`StdioServerTransport` import + top-level `await server.connect(...)`) for a default-exported factory. The generated shell now owns the transport, console-to-stderr guard, SIGINT/SIGTERM (130/143), stdin-EOF exit 0, 5 s bounded shutdown, and heartbeat.
- **Entry convention** — the file moves to `src/mcp/status.ts` (the declared server id) and the config drops its `entry:` line. `agent-bundle inspect` now reports the server with `provenance: { kind: 'conventional' }`; `packageBuild` stays absent so the default `dist` artifact output is untouched (no AB4706).
- **Script envelope** — `src/scripts/check-service-fixture.ts` rewrites its self-executing try/catch to `export const main` returning 0/1; the generated process envelope owns argv and exit-code adoption. Stdout/stderr/exit contracts are byte-identical.
- **README** — the authored-files prose names the new path, factory shape, and framework lifecycle; Noninteractive checks documents the verified `agent-bundle mcp run --server status --target portable` foreground flow (temp artifact when `--artifact` is absent, `--artifact dist` reuse, EOF → 0, Ctrl-C → 130, state under `.agent-bundle/mcp-run/portable/status`).

`packages/agent-bundle/tests/examples-contract.test.ts` needed **zero edits** — all migrations are behavior-preserving.

## Verification

- `pnpm --filter @agent-bundle-example/mcp-app check` — validate + build, zero diagnostics; all three targets emit the wrapped entry from `src/mcp/status.ts`.
- `agent-bundle eval --case status-is-healthy --trials 1` — 1 passed.
- Examples-contract integration file (prebuilt flags) — all three `it` blocks pass untouched, including listMcp/invokeMcp through the wrapped factory, the inspect shape, `payments-api` present in every compiled MCP entry, and both script contracts (exact stdout; stale fixture exits 1 with the pinned stderr).
- `pnpm test:examples:browser` — 4/4 pass in real Chrome, including the full MCP App workflow tour (App preview, protocol trace, session restart).
- Root `pnpm typecheck` and `pnpm lint` — clean.
- `mcp run` smoked three ways: against `--artifact dist` (initialize handshake on stdout, `[status]` heartbeat on stderr), without `--artifact` (temp artifact built in-project and removed), and SIGINT (exit 130).

Refs RFC #50 (Phase 2); builds on #52.