### PR TITLE
docs(examples/audiobook-curator): launcher opener, mcp run section, canonical check chain

### DIFF
--- a/examples/audiobook-curator/README.md
+++ b/examples/audiobook-curator/README.md
@@ -1,5 +1,11 @@
 # Audiobook Curator
 
+From the repository root, launch this example with:
+
+```bash
+pnpm example:audiobook
+```
+
 A complete TypeScript recreation of the original `audiobook-curator`, authored
 as one React Server Component plugin application. The same typed operation tree
 produces a globally installable CLI, one stdio MCP server, one Skill, and native
@@ -87,6 +93,20 @@ The original thirteen commands are present:
 operation also has an MCP tool with the same implementation and result renderer;
 run `audiobook-curator --help` for exact CLI forms.
 
+## Run the MCP server
+
+Run the built `curator` server in the foreground on stdio:
+
+```bash
+pnpm exec agent-bundle mcp run --server curator --target claude
+```
+
+The command resolves the generated entry from the Claude target's MCP
+manifest, building a temporary artifact first; pass `--artifact artifact` to
+reuse the `pnpm build` output instead. Closing stdin exits 0 and Ctrl-C
+exits 130, and per-server state persists under
+`.agent-bundle/mcp-run/claude/curator`.
+
 ## Safety
 
 Sources are immutable. Planning never mutates media. Conversion publishes a
@@ -106,9 +126,5 @@ This example is the reference consumer of the framework-owned package build
 ("one config, agent-bundle owns the build"): `agent-bundle.config.ts` is a
 pure pass-through of the RSC application's config, and the `src/cli.ts` /
 `src/index.ts` conventions provide the npm bin and library outputs under
-`dist/`. The former second bundler config (`rslib.config.ts`), its
-`tsconfig.build.json`, the hand-written `bin/audiobook-curator.js` shim, the
-self-executing `src/cli-entry.ts`, and the dual `build:cli`/`build:bundle`
-script chain were all deleted when the framework took ownership. See
-[`docs/entry-conventions.md`](../../docs/entry-conventions.md) for the
-contract.
+`dist/`. See [`docs/entry-conventions.md`](../../docs/entry-conventions.md)
+for the contract.

--- a/examples/audiobook-curator/README.md
+++ b/examples/audiobook-curator/README.md
@@ -95,9 +95,11 @@ run `audiobook-curator --help` for exact CLI forms.
 
 ## Run the MCP server
 
-Run the built `curator` server in the foreground on stdio:
+From this example's directory, run the built `curator` server in the
+foreground on stdio:
 
 ```bash
+cd examples/audiobook-curator
 pnpm exec agent-bundle mcp run --server curator --target claude
 ```
 

--- a/examples/audiobook-curator/package.json
+++ b/examples/audiobook-curator/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "agent-bundle build --json --output artifact",
-    "check": "pnpm test && pnpm typecheck && pnpm build",
+    "check": "pnpm validate && pnpm build && pnpm typecheck && pnpm test",
     "dev": "agent-bundle dev",
     "test": "rstest tests",
     "typecheck": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
## Summary

Wave A1 of the examples refresh audit — scoped to `examples/audiobook-curator/{README.md,package.json}` only.

- **README**: adds the shared "From the repository root… `pnpm example:audiobook`" opener the other product examples carry (the root `package.json` and README already advertise the script; this README never mentioned it).
- **README**: adds a `Run the MCP server` section for the `curator` server, mirroring the canonical `mcp run` doc flow in `examples/mcp-app/README.md` — this is the only example that ships an MCP server and didn't document it. Uses `--target claude` (this example builds claude/codex, no portable) and `--artifact artifact` (this example's build output lands under `artifact/`, not `dist/`).
- **README**: prunes the maintainer-notes refactor-archaeology sentence naming deleted files (`rslib.config.ts`, `tsconfig.build.json`, the bin shim, `src/cli-entry.ts`, `build:cli`/`build:bundle`), keeping the forward-looking `docs/entry-conventions.md` link.
- **package.json**: aligns `check` to the canonical `validate && build && typecheck && test` chain (matching the create-agent-bundle templates); `--output artifact` on `build` is kept — it's required here, not redundant (AB4706).

Deliberately untouched: the `<AgentBundle>` JSX-tree description in the source-layout section (rewritten by the in-flight RFC #63 framework-mode arc) and the `--json` build flags (Wave A4 cross-example sweep).

## Test plan

- [x] `pnpm --filter @agent-bundle-example/audiobook-curator check` — validate, build, typecheck, test all green
- [x] `packages/agent-bundle/tests/examples-contract.test.ts` — passes
- [x] Root `pnpm typecheck` + `pnpm lint` — clean