### PR TITLE
chore(examples/rsc-agent-runtime): drop skills boilerplate, add validate script, document why the empty target sections stay

### DIFF
--- a/examples/rsc-agent-runtime/agent-bundle.config.ts
+++ b/examples/rsc-agent-runtime/agent-bundle.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'agent-bundle/config';
 
 export default defineConfig({
+  // Kept deliberately: the empty per-target sections are not redundant with
+  // `targets:` — normalization materializes each one as a `model.extensions`
+  // entry with config provenance, and dropping them changes the inspect model.
   claude: {},
   codex: {},
   dev: { runtime: { provider: './src/dev/provider.ts' } },
@@ -36,6 +39,5 @@ export default defineConfig({
     name: 'rsc-agent-runtime-demo',
     version: '1.0.0',
   },
-  skills: [],
   targets: ['portable', 'claude', 'codex'],
 });

--- a/examples/rsc-agent-runtime/package.json
+++ b/examples/rsc-agent-runtime/package.json
@@ -7,6 +7,7 @@
     "package:hosts": "node scripts/package-hosts.mjs",
     "test": "rstest --config rstest.config.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "validate": "agent-bundle validate",
     "check": "pnpm build && pnpm test && pnpm typecheck",
     "eval:hosts": "node scripts/eval-hosts.mjs",
     "capture:widget": "node scripts/capture-widget.mjs"


### PR DESCRIPTION
## Summary

Wave A3 of the examples refresh plan (audit §5, executable-now items) — scoped to `examples/rsc-agent-runtime` only.

- **Dropped `skills: []`** from `agent-bundle.config.ts`. The example has no `skills/` directory, so the empty list was boilerplate that post-RFC-#63 would read as a deliberate opt-out it isn't. Inspect parity verified: with only this drop, `agent-bundle inspect --json` before/after is identical in `model`, `plans`, `diagnostics`, `state`, and `modelDigest` (only `configDigest`/`revision` move, tracking the config file bytes).
- **Kept the empty `claude: {}` / `codex: {}` / `portable: {}` sections**, per the audit's verify-first instruction. They are *not* redundant with `targets:`: dropping them empties `model.extensions` — normalization materializes each section as an `extension:<target>` entry with config provenance, and `modelDigest` changes. Plans/diagnostics stay identical, but the inspect model does not, so the audit's parity bar fails and the sections stay, now with a config comment explaining why.
- **Added the missing `validate` script** (`agent-bundle validate`) to `package.json` for cross-example parity (verified: "Validation succeeded", exit 0). The `check`-chain shape is left untouched for the Wave A4 consistency sweep.
- **No README edits**, so `tests/docs-contract.test.ts` needs no lockstep change; no files moved, so `docs/architecture/rsc-runtime-workbench.md` needs no regeneration (`pnpm check:runtime-topology` passes).

## Owner decision requested (flagged, not fixed)

This example's `README.md` self-declares (line 3) that it is a "private, opt-in… architecture experiment, not an `agent-bundle` public API", and the body is dense with internal jargon ("skip-gated", "schema-v2 evidence envelope", "value-free hook launch probe"). That is in tension with the repository rule that `examples/*` are user-facing products; the root README's examples table already omits this example. Two ways to resolve it: (1) promote the example to product-quality documentation so it meets the `examples/*` bar, or (2) formally mark it internal — carve out an explicit exemption in AGENTS.md or relocate it outside `examples/` — so the rule and the tree agree. This PR deliberately does not change the example's status either way; the choice is left to the owner.

## Test plan

- [x] `pnpm --filter @agent-bundle/rsc-agent-runtime-demo check` — 0 failures, 6 skips (the six Windows-only Job Object tests; known platform skips)
- [x] `pnpm check:runtime-topology`
- [x] `pnpm eval:spot`
- [x] Root `pnpm typecheck` and `pnpm lint`
- [x] `agent-bundle inspect --json` before/after parity check (see above)