### PR TITLE
refactor(examples): drop explicit skills lists in favor of convention discovery

### DIFF
--- a/examples/mcp-app/agent-bundle.config.ts
+++ b/examples/mcp-app/agent-bundle.config.ts
@@ -27,6 +27,5 @@ export default defineConfig({
   scripts: {
     'check-service-fixture': './src/scripts/check-service-fixture.ts',
   },
-  skills: ['skills/service-readiness'],
   targets: ['portable', 'codex', 'claude'],
 });

--- a/examples/skills-starter/README.md
+++ b/examples/skills-starter/README.md
@@ -12,8 +12,9 @@ required. Both eval suites are deterministic and read only checked-in fixtures.
 
 ## What is authored
 
-- `agent-bundle.config.ts` declares the plugin, its three Skills, and portable, Codex,
-  and Claude targets.
+- `agent-bundle.config.ts` declares the plugin and its portable, Codex, and
+  Claude targets. The Skills are not listed there: every `skills/*/SKILL.md`
+  directory is discovered automatically by convention.
 - `skills/incident-triage/SKILL.md` guides a production incident from first
   signal through containment, evidence collection, and a handoff-ready update.
 - `skills/dependency-upgrade/SKILL.md` plans dependency upgrades with API,

--- a/examples/skills-starter/agent-bundle.config.ts
+++ b/examples/skills-starter/agent-bundle.config.ts
@@ -6,10 +6,5 @@ export default defineConfig({
     name: 'skills-starter',
     version: '1.0.0',
   },
-  skills: [
-    'skills/dependency-upgrade',
-    'skills/incident-triage',
-    'skills/release-review',
-  ],
   targets: ['portable', 'codex', 'claude'],
 });


### PR DESCRIPTION
## Summary

Wave A2 of the examples refresh audit: the explicit `skills:` lists in `examples/skills-starter/agent-bundle.config.ts` and `examples/mcp-app/agent-bundle.config.ts` named exactly the conventional `skills/*/SKILL.md` directories that convention discovery (`config/discover.ts`) finds when the config is silent. Dropping them is behavior-identical and nudge-free (AB4734 only fires for *uncovered* directories). The skills-starter README now teaches the convention instead of narrating the list.

- `examples/skills-starter/agent-bundle.config.ts`: drop the three-entry `skills:` list.
- `examples/mcp-app/agent-bundle.config.ts`: drop `skills: ['skills/service-readiness']`.
- `examples/skills-starter/README.md`: "declares the plugin, its three Skills…" → skills are discovered automatically from `skills/`.

## Verification

- `agent-bundle inspect --json` before/after in both examples: the model is identical except `skills[*].provenance.kind` flipping `explicit` → `conventional` (3 skills in skills-starter, 1 in mcp-app). The only other changed values are the sha256 digests of the edited config/README files themselves and the model/revision digests derived from the provenance-bearing model. No target, script, MCP, or artifact model content changed.
- `pnpm examples:check`: pass (validate + build for all five examples; every validate reports zero diagnostics).
- `examples-contract.test.ts` through the integration config: 3/3 pass with **zero test edits** — it asserts artifact bytes, inspect metadata, and `diagnostics: []`, none of which changed.
- `examples-real.e2e.test.ts` (real Chrome, 1440×900, prebuilt workbench): 4/4 pass, including the populated Skills Starter route and the stale-diagnostic/repair flow.
- Root `pnpm typecheck` and `pnpm lint`: pass.

## User-visible provenance surface

The flip surfaces in exactly one place: the Skills page "Document details" expander now reads `Provenance: conventional` (was `explicit`) for source documents. The heading badge ("Authored") and everything else on the page are unchanged. This is the designed rendering of the model's accurate discovery mode, not a regression; a 1440×900 populated-state capture is attached to the review thread context.