### PR TITLE
fix(examples/rsc-agent-runtime): honor AGENT_BUNDLE_TEST_TIME_SCALE in every test budget

### DIFF
--- a/examples/rsc-agent-runtime/rstest.config.ts
+++ b/examples/rsc-agent-runtime/rstest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from '@rstest/core';
 
+import { timeScale } from './tests/support/time-scale.ts';
+
 export default defineConfig({
   include: ['tests/**/*.test.{ts,tsx}'],
   pool: { maxWorkers: 1 },
   testEnvironment: 'node',
+  // Every suite here runs real rsbuild compiles and spawned children, which a
+  // loaded host pushes past the 5s default long before anything is actually
+  // wedged. The default scales with the same knob as the polling budgets (see
+  // tests/support/time-scale.ts); explicit per-test timeouts still win.
+  testTimeout: 30_000 * timeScale,
 });

--- a/examples/rsc-agent-runtime/tests/dev-invocation.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/dev-invocation.integration.test.ts
@@ -8,6 +8,7 @@ import { createRsbuild } from '@rsbuild/core';
 import { expect, test } from '@rstest/core';
 
 import { copyExample } from './support/copy-example.ts';
+import { timeScale } from './support/time-scale.ts';
 import { createElement, type ReactNode } from 'react';
 
 import { ProjectService } from '../../../packages/agent-bundle/src/dev/index.ts';
@@ -84,7 +85,7 @@ process.stdout.end(JSON.stringify({
   } finally {
     await rm(compilerRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 const invoke = async (entry: string, request: Record<string, unknown>) => startInvocation(entry, request).completed;
 
@@ -97,8 +98,11 @@ const buildInvocationEntry = async (compilerRoot: string, cwd = process.cwd()): 
   return join(compilerRoot, 'rsc', 'dev', 'invoke.js');
 };
 
+// Budgets stay unscaled at the call sites and are scaled here, so a contended
+// host widens every deadline instead of only the ones a caller remembered to
+// multiply (see tests/support/time-scale.ts).
 const waitFor = async (condition: () => boolean, message: string, timeoutMs = 4_000): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
+  const deadline = Date.now() + timeoutMs * timeScale;
   while (!condition()) {
     if (Date.now() >= deadline) throw new Error(message);
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
@@ -241,7 +245,7 @@ test('lowers the hook state version from durable state when copied RSC output gr
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('builds a generation-contained inspection entry for Claude, Codex, and MCP fixtures', async () => {
   const compilerRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-invoke-'));
@@ -592,7 +596,7 @@ test('bounds Flight output and waits for a SIGKILL cleanup when the RSC child ig
     if (childPid !== undefined && isProcessAlive(childPid)) process.kill(childPid, 'SIGKILL');
     await rm(compilerRoot, { force: true, recursive: true });
   }
-}, 6_000);
+}, 6_000 * timeScale);
 
 test('forwards dev invocation termination through a SIGKILL cleanup of its RSC child', async () => {
   const compilerRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-invoke-'));
@@ -623,7 +627,7 @@ test('forwards dev invocation termination through a SIGKILL cleanup of its RSC c
     if (childPid !== undefined && isProcessAlive(childPid)) process.kill(childPid, 'SIGKILL');
     await rm(compilerRoot, { force: true, recursive: true });
   }
-}, 6_000);
+}, 6_000 * timeScale);
 
 test('keeps each concurrent hook run bound to its rendered durable snapshot', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-exact-snapshot-'));
@@ -707,7 +711,7 @@ test('keeps each concurrent hook run bound to its rendered durable snapshot', as
     await session.close();
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('runs an exact generation-contained hook invocation and retains its immutable Flight asset', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-'));
@@ -797,7 +801,7 @@ test('runs an exact generation-contained hook invocation and retains its immutab
     await session.close();
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('preserves the Claude fixture seed in post-state while exact replay stays valid', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-fixture-seed-'));
@@ -1055,7 +1059,7 @@ test('preserves the Claude fixture seed in post-state while exact replay stays v
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('does not spawn an invocation worker when runtime.run.started closes the session', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-started-close-'));
@@ -1092,7 +1096,7 @@ test('does not spawn an invocation worker when runtime.run.started closes the se
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('refuses to adopt an existing or symbolic provider run root', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-run-root-'));
@@ -1117,7 +1121,7 @@ test('refuses to adopt an existing or symbolic provider run root', async () => {
     await rm(storageRoot, { force: true, recursive: true });
     await rm(external, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('refreshes a failed run vector after its generation-contained hook mutates durable state', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-failed-vector-'));
@@ -1171,7 +1175,7 @@ require(${JSON.stringify(original)});
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('pins an overlapping g1 invocation while exact replay stays on g1 and latest replay advances to g2', async () => {
   const copied = await copyInvocationExample();
@@ -1223,7 +1227,7 @@ setInterval(() => undefined, 1_000);
     await blocked?.catch(() => undefined);
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 60_000);
+}, 60_000 * timeScale);
 
 test('replays an exact historical surface after generation two removes it', async () => {
   const copied = await copyInvocationExample();
@@ -1272,7 +1276,7 @@ test('replays an exact historical surface after generation two removes it', asyn
     await session.close().catch(() => undefined);
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 60_000);
+}, 60_000 * timeScale);
 
 test('releases an exact historical lease when four active workers reject its admission', async () => {
   const copied = await copyInvocationExample();
@@ -1302,10 +1306,13 @@ test('releases an exact historical lease when four active workers reject its adm
     const g2 = session.status().activeVector!.runtimeGenerationId;
     const marker = join(storageRoot, 'blocked-exact-lease-workers.txt');
     const worker = join(storageRoot, 'generation-store', 'generations', g2, 'rsc', 'rsc', 'index.js');
+    // The four workers must still hold capacity when the replay below asks for
+    // a fifth slot; a loaded host can stagger their starts past a fixed second,
+    // so the lifetime scales with the same knob as the waits.
     await writeFile(worker, `
 import { appendFileSync } from 'node:fs';
 appendFileSync(${JSON.stringify(marker)}, 'ready\\n');
-setTimeout(() => process.exit(0), 1_000);
+setTimeout(() => process.exit(0), ${1_000 * timeScale});
 `);
     const workers = Array.from({ length: 4 }, () => session.invoke({
       expectedGenerationId: g2,
@@ -1337,7 +1344,7 @@ setTimeout(() => process.exit(0), 1_000);
     await session.close().catch(() => undefined);
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 90_000);
+}, 90_000 * timeScale);
 
 test('closes the provider-owned invocation process group without orphaning its RSC grandchild', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-close-'));
@@ -1397,7 +1404,7 @@ setInterval(() => undefined, 1000);
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('hard-kills the invocation process group when its leader exits before an RSC grandchild', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-leader-exit-'));
@@ -1438,7 +1445,7 @@ process.exit(0);
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('settles a successful invocation only after its TERM-resistant RSC grandchild exits', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-success-tree-'));
@@ -1491,7 +1498,7 @@ process.stdout.end(JSON.stringify({
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('keeps a detached successful worker grandchild in its Windows Job Object until it dies', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-job-'));
@@ -1548,7 +1555,7 @@ process.stdout.end(JSON.stringify({
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('bounds a hung Windows Job owner before it can arm the invocation wrapper', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-owner-hang-'));
@@ -1569,7 +1576,7 @@ windowsTest('bounds a hung Windows Job owner before it can arm the invocation wr
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('bounds a broken Windows Job owner control pipe and drains its assigned wrapper', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-owner-pipe-'));
@@ -1594,7 +1601,7 @@ setInterval(() => undefined, 1000);
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('forces an ignored Windows Job owner STOP without leaving its wrapper alive', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-owner-stop-'));
@@ -1622,7 +1629,7 @@ setInterval(() => undefined, 1000);
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('fails a nonzero Windows Job owner only after its resistant descendant is drained', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-owner-nonzero-'));
@@ -1662,7 +1669,7 @@ process.stdout.end(JSON.stringify({
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 windowsTest('never invokes taskkill after a Windows Job has owned and drained the wrapper', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-windows-no-taskkill-'));
@@ -1701,7 +1708,7 @@ process.stdout.end(JSON.stringify({
     await rm(storageRoot, { force: true, recursive: true });
     await rm(commandRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('drives the run-eviction window through its happy, held-reader, failed-removal, and failed-release paths', async () => {
   // The retention window is injected small so the suite does not need fifty
@@ -1849,7 +1856,7 @@ test('drives the run-eviction window through its happy, held-reader, failed-remo
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 240_000);
+}, 240_000 * timeScale);
 
 test('retains a failed invocation Flight artifact until its explicit session-close release succeeds', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-artifact-release-'));
@@ -1904,7 +1911,7 @@ test('retains a failed invocation Flight artifact until its explicit session-clo
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 45_000);
+}, 45_000 * timeScale);
 
 test('rejects a fifth blocked generation worker and settles every leased worker on close', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-bound-'));
@@ -1967,7 +1974,7 @@ setInterval(() => undefined, 1000);
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('contains invocation stdout, stderr, and timeout failures without retaining partial run artifacts', async () => {
   const storageRoot = await mkdtemp(join(tmpdir(), 'rsc-agent-runtime-session-output-'));
@@ -2053,4 +2060,4 @@ process.stdout.end(${JSON.stringify(`${JSON.stringify({ flightBytes: 1, inspecti
     await session.close().catch(() => undefined);
     await rm(storageRoot, { force: true, recursive: true });
   }
-}, 45_000);
+}, 45_000 * timeScale);

--- a/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
@@ -23,8 +23,11 @@ import { timeScale } from './support/time-scale.ts';
 
 const exampleRoot = process.cwd();
 
+// Budgets stay unscaled at the call sites and are scaled here, so a contended
+// host widens every deadline instead of only the ones a caller remembered to
+// multiply (see tests/support/time-scale.ts).
 const waitForWithin = async (predicate: () => boolean, budgetMs: number): Promise<void> => {
-  const deadline = Date.now() + budgetMs;
+  const deadline = Date.now() + budgetMs * timeScale;
   while (!predicate()) {
     if (Date.now() >= deadline) throw new Error('Timed out waiting for the RSC runtime provider.');
     await new Promise<void>((resolve) => { setTimeout(resolve, 25); });
@@ -493,7 +496,7 @@ test('declares an optional runtime while keeping Claude and Codex artifacts buil
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('resets state through the dynamically loaded copied provider', async () => {
   const copied = await copyProviderExample();
@@ -523,7 +526,7 @@ test('resets state through the dynamically loaded copied provider', async () => 
     await session?.close();
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('rejects an already-aborted provider start before creating a runtime session', async () => {
   const copied = await copyProviderExample();
@@ -706,7 +709,7 @@ test('records one failed event when capture and observer finalization both fail 
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('keeps the active generation while publishing a source build diagnostic before its failed event', async () => {
   const copied = await copyProviderExample();
@@ -755,7 +758,7 @@ test('keeps the active generation while publishing a source build diagnostic bef
     await session?.close();
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 60_000);
+}, 60_000 * timeScale);
 
 test('drains a deferred generation pipeline before close without publishing late lifecycle events', async () => {
   const copied = await copyProviderExample();
@@ -810,7 +813,7 @@ test('drains a deferred generation pipeline before close without publishing late
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('binds renamed and added App surfaces to the active generation assets without restoring removed surfaces', async () => {
   const copied = await copyProviderExample();
@@ -878,7 +881,7 @@ test('binds renamed and added App surfaces to the active generation assets witho
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('rebinds current App surfaces across retained generations after a later configuration reconcile', async () => {
   const copied = await copyProviderExample();
@@ -930,7 +933,7 @@ test('rebinds current App surfaces across retained generations after a later con
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('keeps the same MCP session and revision across an implementation-only generation', async () => {
   const copied = await copyProviderExample();
@@ -973,7 +976,7 @@ test('keeps the same MCP session and revision across an implementation-only gene
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('restarts and relists an open MCP session after a warm-cache definition change', async () => {
   const copied = await copyProviderExample();
@@ -1011,7 +1014,7 @@ test('restarts and relists an open MCP session after a warm-cache definition cha
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('uses the live registry authority after a transport-only runtime MCP reconciliation', async () => {
   const copied = await copyProviderExample();
@@ -1142,7 +1145,7 @@ test('uses the live registry authority after a transport-only runtime MCP reconc
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('rejects MCP admission until a deferred public prepared-config restart has relisted', async () => {
   const copied = await copyProviderExample();
@@ -1207,7 +1210,7 @@ test('rejects MCP admission until a deferred public prepared-config restart has 
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 30_000);
+}, 30_000 * timeScale);
 
 test('aborts stale activation transactions at both private preparation boundaries', async () => {
   for (const phase of ['store', 'registry'] as const) {
@@ -1283,7 +1286,7 @@ test('aborts stale activation transactions at both private preparation boundarie
       await rm(copied.workspaceRoot, { force: true, recursive: true });
     }
   }
-}, 60_000);
+}, 60_000 * timeScale);
 
 test('commits a compiled generation across an equivalent prepared-runtime revision', { timeout: 0 }, async () => {
   const copied = await copyProviderExample();
@@ -1345,7 +1348,7 @@ test('commits a compiled generation across an equivalent prepared-runtime revisi
   }
 });
 
-test('commits an activation while a later attempt is still live at the commit check', { timeout: 90_000 }, async () => {
+test('commits an activation while a later attempt is still live at the commit check', { timeout: 90_000 * timeScale }, async () => {
   const copied = await copyProviderExample();
   try {
     const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
@@ -1400,7 +1403,7 @@ test('commits an activation while a later attempt is still live at the commit ch
   }
 });
 
-test('commits an activation after a later broken attempt fails inside the commit window', { timeout: 90_000 }, async () => {
+test('commits an activation after a later broken attempt fails inside the commit window', { timeout: 90_000 * timeScale }, async () => {
   const copied = await copyProviderExample();
   try {
     const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
@@ -1454,14 +1457,14 @@ test('commits an activation after a later broken attempt fails inside the commit
   }
 });
 
-test('fails a wedged activation reconcile within the budget and releases its late reservation', { timeout: 120_000 }, async () => {
+test('fails a wedged activation reconcile within the budget and releases its late reservation', { timeout: 120_000 * timeScale }, async () => {
   const copied = await copyProviderExample();
   try {
     const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
     const wedgeReached = deferred<void>();
     const releaseWedge = deferred<void>();
     let armWedge = false;
-    const activationBudgetMs = 4_000 * timeScale;
+    const activationBudgetMs = 4_000;
     const events: Array<{ readonly runtimeGenerationId?: string; readonly type: string }> = [];
     const session = await RsbuildRuntimeSession.start({
       ...startContext({
@@ -1473,7 +1476,7 @@ test('fails a wedged activation reconcile within the budget and releases its lat
       }),
       emit: (event) => { events.push(event); },
     }, {
-      activationPhaseBudgetMs: activationBudgetMs,
+      activationPhaseBudgetMs: activationBudgetMs * timeScale,
       beforeMcpRelist: async () => {
         if (!armWedge) return;
         wedgeReached.resolve();
@@ -1571,7 +1574,7 @@ test('retains a leased inactive generation through pruning and prunes it after t
   } finally {
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 60_000);
+}, 60_000 * timeScale);
 
 test('aborts a deferred Rsbuild creation before starting its dev server', async () => {
   const copied = await copyProviderExample();
@@ -1919,4 +1922,4 @@ test('drains every live-session cleanup group once when independent closers reje
     await session?.close().catch(() => undefined);
     await rm(copied.workspaceRoot, { force: true, recursive: true });
   }
-}, 45_000);
+}, 45_000 * timeScale);


### PR DESCRIPTION
Follows up the Wave A3 finding in the #65 report: `tests/dev-invocation.integration.test.ts` had a `waitFor` helper whose 4s default deadline ignored the example's documented `AGENT_BUNDLE_TEST_TIME_SCALE` knob. Sweeping for the class rather than the single instance turned up four more members, all in the same shape — a fixed budget that expires real work on a loaded host instead of bounding a hang.

## The class, as found

| Instance | Before |
|---|---|
| `dev-invocation` `waitFor` | 4s default plus ~20 explicit call-site budgets, none scaled; file never imported `timeScale` |
| `dev-provider` `waitForWithin` | 15s default and every explicit budget unscaled, though the file already imported `timeScale` for one session option |
| Per-test timeouts in both files | 43 literals (6s–240s) unscaled, so a scaled poll budget could not outlive its own test |
| `examples/rsc-agent-runtime/rstest.config.ts` | no `testTimeout`, leaving rstest's 5s default as a hard cliff for every test in the example that does not declare its own |
| Capacity fixture worker in `dev-invocation` | `setTimeout(() => process.exit(0), 1_000)` — the four workers must still hold capacity when the fifth admission is attempted |

`tests/state-and-definition.test.ts` was already correct (`Date.now() + 15_000 * timeScale`, `{ timeout: 30_000 * timeScale }`) and is the pattern this follows.

## The fix

Budgets stay unscaled at the call sites and are scaled once inside each helper's deadline, so a contended host widens every wait rather than only the ones a caller remembered to multiply. Per-test timeouts, the example's shared default, and the fixture worker lifetime scale with the same knob. `dev-provider`'s wedged-reconcile test keeps its pre-scaled session option and now passes the unscaled base to `waitForWithin`, so nothing is scaled twice. Every value is byte-identical when the knob is unset.

## Verification

The example's suite runs through its own `rstest.config.ts`, not the root integration pool.

| Leg | Result |
|---|---|
| Full example suite, default scale | 170/170 pass |
| `dev-invocation` + `dev-provider`, scale 2 | 60/60 pass |
| `dev-invocation` + `dev-provider`, `taskset -c 0,1`, scale 4 | 60/60 pass |
| Root `pnpm lint`, `pnpm typecheck`, example `typecheck` | clean |

The contended leg is what motivated the sweep beyond the reported helper. On `taskset -c 0,1` with only the helper deadline scaled, six tests failed: two at the hidden 5s config cliff, three on 4s-default `waitFor` budgets, and one where the capacity fixture's workers had already exited before the fifth admission was attempted. All six are green in the final state.

One further flake shape is out of scope here and left alone: the concurrent-hook-run test binds a fixed port 3000, which collides with any other rstest worktree running on the same host.