### PR TITLE
fix(examples/rsc-agent-runtime): bind the dev runtime compiler to an ephemeral port

### DIFF
--- a/examples/rsc-agent-runtime/rsbuild.config.ts
+++ b/examples/rsc-agent-runtime/rsbuild.config.ts
@@ -180,7 +180,12 @@ export const createRscRuntimeRsbuildConfig = (
   return {
     ...(development ? {
       dev: { writeToDisk: true },
-      server: { host: '127.0.0.1', printUrls: false },
+      // Port 0 lets the OS assign the listener. Rsbuild's default (3000 with an
+      // incrementing probe) makes every concurrent runtime session on a host
+      // race for the same first candidate, which surfaces as EADDRINUSE when
+      // suites run in parallel. Consumers read the resolved port back from
+      // `rsbuild.context.devServer`.
+      server: { host: '127.0.0.1', port: 0, printUrls: false },
     } : {}),
     plugins: [
       pluginReact(),

--- a/examples/rsc-agent-runtime/tests/generation-materializer.test.ts
+++ b/examples/rsc-agent-runtime/tests/generation-materializer.test.ts
@@ -240,7 +240,7 @@ test('resolves the coherent development compiler configuration through Rsbuild',
     expect(environments.app?.output.distPath.root).toBe(join(compilerRoot, 'app'));
     expect(inspection.origin.rsbuildConfig.dev.writeToDisk).toBe(true);
     expect(inspection.origin.rsbuildConfig.server.host).toBe('127.0.0.1');
-    expect(inspection.origin.rsbuildConfig.server.port).toBe(3000);
+    expect(inspection.origin.rsbuildConfig.server.port).toBe(0);
     expect(rscBundler?.output?.chunkFilename).toBe('chunks/[name].js');
     expect(rscBundler?.output?.path).toBe(join(compilerRoot, 'rsc'));
     expect(widgetBundler?.output?.path).toBe(join(compilerRoot, 'widget'));


### PR DESCRIPTION
## What

The RSC runtime demo's development Rsbuild config omitted `server.port`, so every `RsbuildRuntimeSession` inherited Rsbuild's default of `3000`. This sets `port: 0` so the OS assigns the listener, matching the ephemeral-port pattern every other suite in this repo already uses.

## Why

Flagged by the report on #70: a contended run of `tests/dev-invocation.integration.test.ts` hit `EADDRINUSE` from an rstest worker in a different worktree on the same host.

The default is not a safe "free port fallback" under contention. Rsbuild's `getPort` probes a candidate with a throwaway listener, closes it, and only binds the real dev server after the first compile. Two sessions starting within that multi-second window both observe `3000` (or the same `3001` fallback) as free, and then race to bind it. Every dev-runtime session in the example suite paid that race; the concurrent-hook-run test just happened to be where it landed in the reported run.

The port was fixed in the config, not in the test, so the fix belongs in the config. The resolved port is already threaded through correctly: `startDevServer` writes the post-resolution value to `rsbuild.context.devServer`, which `RsbuildRuntimeSession#attachServer` reads to build the runtime origin. Nothing downstream assumed `3000`.

## Changes

- `examples/rsc-agent-runtime/rsbuild.config.ts` — development `server.port: 0`, with a comment recording the constraint.
- `examples/rsc-agent-runtime/tests/generation-materializer.test.ts` — the config-inspection assertion now pins `0`, documenting the ephemeral intent.

## Sweep

Swept the repo for other test suites that bind fixed ports. This was the only one. Everything else already uses `listen(0)` or an `availablePort()` helper; the remaining fixed-port literals in tests are mocked-response fixtures and CLI-argument assertions that never bind, and `src/mcp/http.ts`'s `PORT ?? 3000` is a user-facing dev default rather than a suite binding.

## Verification

Baseline (`origin/main`), two worktrees running `dev-invocation.integration.test.ts` simultaneously, 3 attempts: 2 reproduced the reported failure.

- attempt 1: `listen EADDRINUSE: address already in use 127.0.0.1:3001`, failing `does not spawn an invocation worker when runtime.run.started closes the session`
- attempt 3: `listen EADDRINUSE: address already in use 127.0.0.1:3000`, failing `runs an exact generation-contained hook invocation and retains its immutable Flight asset`

Two different tests and both ports in the `3000`/`3001` band, which confirms the shared dev-server bind is the cause rather than anything specific to one test.

With this change, the same simultaneous double-run across two worktrees: 3 attempts, 6 legs, all green, zero `EADDRINUSE`.

Also green: both touched files individually, `dev-provider.integration.test.ts` and `mcp-transports.integration.test.ts` (the other consumers of the config factory), the example typecheck, and root `pnpm typecheck` + `pnpm lint`.