### PR TITLE
fix(dev): #75 — completed MultiStats cohorts are the authoritative compile identity, no FIFO hook pairing

### DIFF
--- a/examples/rsc-agent-runtime/rsbuild.config.ts
+++ b/examples/rsc-agent-runtime/rsbuild.config.ts
@@ -37,7 +37,12 @@ export interface RscRuntimeRsbuildConfigOptions {
    */
   readonly onAppReload?: () => void;
   readonly onCompile?: Readonly<{
-    beforeAttempt(): string;
+    /**
+     * Allocates the monotonic identity for one completed MultiStats cohort.
+     * Called at the start of every global completion callback, in completion
+     * order, so identity never depends on pairing with `onBeforeDevCompile`.
+     */
+    beginCompletedCohort(): string;
     capture(input: {
       readonly attemptId: string;
       readonly cohortChanged: boolean;
@@ -48,6 +53,11 @@ export interface RscRuntimeRsbuildConfigOptions {
     /** Queues provider activation but never blocks the Rsbuild compile hook. */
     enqueue(snapshot: RscRuntimeCompileSnapshot): unknown;
     failAttempt(attemptId: string, error: unknown, kind: RscRuntimeCompileFailureKind): void;
+    /**
+     * Advisory pre-compile observation. It owns no identity, queue, or
+     * activation barrier, and it must never throw or block a compile.
+     */
+    observeCompileStart(): void;
     /**
      * Stages an immutable checkpoint of one environment's completed output
      * root. Awaited inside the environment compiler's `done` hook, where
@@ -111,7 +121,6 @@ const emitRuntimeManifest = (): RsbuildPlugin => ({
 const runtimeCompileObserverPlugin = (
   observer: NonNullable<RscRuntimeRsbuildConfigOptions['onCompile']>,
 ): RsbuildPlugin => {
-  const pendingAttemptIds: string[] = [];
   let capturedCohort: Readonly<{ readonly activationSequence: number; readonly sourceRevision: string }> | undefined;
   let nextActivationSequence = 0;
   return {
@@ -125,7 +134,7 @@ const runtimeCompileObserverPlugin = (
         // environment names, and missing hashes stage nothing here; the
         // global after-compile hook is the loud failure path for those, and
         // rejecting this hook instead would skip that dispatch entirely and
-        // strand the FIFO attempt pairing.
+        // silence the completed-cohort failure lane.
         if (stats === undefined || stats.hasErrors()) return;
         const name = environment.name;
         if (!isCompileEnvironmentName(name)) return;
@@ -137,26 +146,22 @@ const runtimeCompileObserverPlugin = (
         });
       });
       api.onBeforeDevCompile(() => {
-        // Rsbuild documents global hook order, but not one before/after pair
-        // per MultiCompiler cohort. FIFO pairing is only empirical in 2.2.1;
-        // reject identities that cannot be paired unambiguously, while
-        // retaining legitimate overlapping before callbacks in FIFO order.
-        const attemptId = observer.beforeAttempt();
-        if (pendingAttemptIds.includes(attemptId)) {
-          const pairingError = new Error(`RSC runtime compile produced duplicate pending attempt identity ${JSON.stringify(attemptId)}.`);
-          for (const unmatchedAttemptId of [...pendingAttemptIds, attemptId]) {
-            observer.failAttempt(unmatchedAttemptId, pairingError, 'provider-lifecycle');
-          }
-          pendingAttemptIds.length = 0;
-          throw pairingError;
-        }
-        pendingAttemptIds.push(attemptId);
+        // Rsbuild documents global hook order, but not a stable cycle
+        // identity, callback cardinality under coalesced invalidations, or
+        // one-to-one before/after pairing when MultiCompiler children
+        // invalidate at different times. Pre-compile observation is therefore
+        // advisory only: no identity, queue, or activation barrier may derive
+        // from this hook.
+        observer.observeCompileStart();
       });
       api.onAfterDevCompile(async ({ stats }) => {
-        const attemptId = pendingAttemptIds.shift();
-        if (attemptId === undefined) {
-          throw new Error('RSC runtime compile completed without a matching attempt.');
-        }
+        // Each completed MultiStats cohort is the authoritative monotonic
+        // identity: the observer allocates the next ordinal per completion
+        // callback, in completion order. There is no queue pairing this
+        // callback with onBeforeDevCompile, so coalesced, missing,
+        // duplicated, or reordered global callbacks cannot associate Stats
+        // with an older observation.
+        const attemptId = observer.beginCompletedCohort();
         let snapshot: RscRuntimeCompileSnapshot | undefined;
         try {
           if (stats.hasErrors()) {

--- a/examples/rsc-agent-runtime/rsbuild.config.ts
+++ b/examples/rsc-agent-runtime/rsbuild.config.ts
@@ -55,7 +55,11 @@ export interface RscRuntimeRsbuildConfigOptions {
     failAttempt(attemptId: string, error: unknown, kind: RscRuntimeCompileFailureKind): void;
     /**
      * Advisory pre-compile observation. It owns no identity, queue, or
-     * activation barrier, and it must never throw or block a compile.
+     * activation barrier, and it must never throw or block a compile. The
+     * session may use it as a bounded collapse hint (briefly holding an
+     * in-flight activation so the observed compile's completed cohort can
+     * supersede it), but a missing completion can only delay one activation
+     * by that bounded grace - never wedge or fail it.
      */
     observeCompileStart(): void;
     /**

--- a/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
+++ b/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
@@ -680,6 +680,16 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
   #closePromise: Promise<void> | undefined;
   #closed = false;
   #completedCohortSequence = 0;
+  /**
+   * Advisory count of `onBeforeDevCompile` observations that no settled
+   * completion has absorbed yet. It is a collapse hint for the activation
+   * guard, never an identity or a barrier: every settled completion resets it
+   * to zero (Rsbuild coalesces invalidations into the next completion), so a
+   * dangling observation can only delay activation by the bounded grace in
+   * `#activationGuard.wait()` and self-heals at the next settled completion.
+   */
+  #observedCompileStarts = 0;
+  #compileSettleWaiters: Array<() => void> = [];
   #evictionTail: Promise<void> = Promise.resolve();
   #generationSequence = 0;
   #failureTail: Promise<void> = Promise.resolve();
@@ -2198,12 +2208,34 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
       enqueue: (snapshot) => this.#enqueue(snapshot),
       failAttempt: (attemptId, error, kind) => { void this.#failAttempt(attemptId, error, kind); },
       // Advisory only: pre-compile observation carries no identity and owns
-      // no activation barrier, so a before callback with no matching
-      // completion (a coalesced or superseded invalidation) leaves nothing
-      // behind that could wedge a later activation.
-      observeCompileStart: () => undefined,
+      // no activation barrier. It is a collapse hint: an in-flight activation
+      // briefly waits (bounded, never failing) for the observed compile's
+      // completion so the newest completed cohort supersedes it before an
+      // older generation becomes visible. A before callback with no matching
+      // completion (a coalesced or superseded invalidation) can therefore
+      // only delay one activation by the grace budget, never wedge it.
+      observeCompileStart: () => { this.#observeCompileStart(); },
       stageEnvironmentCheckpoint: (input) => this.#stageEnvironmentCheckpoint(input),
     });
+  }
+
+  #observeCompileStart(): void {
+    if (this.#closed) return;
+    this.#observedCompileStarts += 1;
+  }
+
+  /**
+   * Marks one completed-cohort observation as settled: the completion either
+   * captured (bumping the cohort ordinal), settled as a no-op, or failed.
+   * Rsbuild coalesces pending invalidations into the next completion, so a
+   * settled completion absorbs every outstanding pre-compile observation;
+   * the count resets to zero rather than decrementing.
+   */
+  #settleCompileObservation(): void {
+    this.#observedCompileStarts = 0;
+    const waiters = this.#compileSettleWaiters;
+    this.#compileSettleWaiters = [];
+    for (const wake of waiters) wake();
   }
 
   /**
@@ -2280,18 +2312,25 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
       throw new Error('RSC runtime compile capture has no live completed cohort identity.');
     }
     if (input.hasErrors) {
+      this.#settleCompileObservation();
       await this.#failAttempt(input.attemptId, new Error('RSC runtime compilation failed.'), 'source-build');
       return undefined;
     }
     if (input.sourceRevision.length === 0) {
+      this.#settleCompileObservation();
       await this.#failAttempt(input.attemptId, new Error('RSC runtime compilation has no source revision.'));
       return undefined;
     }
-    if (!input.cohortChanged) return undefined;
+    if (!input.cohortChanged) {
+      this.#settleCompileObservation();
+      return undefined;
+    }
     // The completed-cohort ordinal bumps synchronously with the completion
     // callback, so every older activation observes its supersession at the
-    // guard check without waiting on any pre-compile observation.
+    // guard check; the settle below wakes any activation waiting on this
+    // observed compile AFTER the ordinal is authoritative.
     const cohortRevision = ++this.#latestRscCohortRevision;
+    this.#settleCompileObservation();
     const preparedRuntime = this.#latestPreparedRuntime;
     this.#emit(Object.freeze({ runtimeGenerationId: undefined, type: 'runtime.generation.compiling' }));
     try {
@@ -2356,7 +2395,10 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
   ): Promise<void> {
     if (this.#failedAttempts.has(attemptId)) return;
     this.#failedAttempts.add(attemptId);
-    this.#pendingCohortIds.delete(attemptId);
+    // A pending cohort dying before capture (malformed stats, plugin capture
+    // throw) settles its observation here; failures of already-captured
+    // attempts (activation errors) are not completions and settle nothing.
+    if (this.#pendingCohortIds.delete(attemptId)) this.#settleCompileObservation();
     const candidate = this.#candidatesByAttempt.get(attemptId);
     this.#candidatesByAttempt.delete(attemptId);
     if (candidate !== undefined) {
@@ -2388,14 +2430,31 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
         snapshot.rscCohortRevision === this.#latestRscCohortRevision &&
         (this.#active === undefined ||
           preparedAuthorityDigest === preparedRuntimeAuthorityDigest(this.#latestPreparedRuntime)),
-      // Nothing to wait for: supersession keys only on completed cohort
-      // ordinals (bumped synchronously with each completed global callback)
-      // and prepared-runtime authority. Pre-compile observation is advisory
-      // and owns no barrier, so an in-flight compile that never completes -
-      // coalesced, superseded, or dropped by the bundler - cannot delay or
-      // wedge this activation; if it does complete with a changed cohort,
-      // its ordinal supersedes this one at the check.
+      // Supersession keys only on completed cohort ordinals (bumped
+      // synchronously with each completed global callback) and
+      // prepared-runtime authority. Pre-compile observation is advisory and
+      // owns no barrier, but it is honored as a bounded collapse hint: an
+      // observed compile that is still in flight is given a grace window to
+      // complete so its cohort supersedes this activation at the check
+      // instead of committing a doomed older generation first (one visible
+      // activation per settled edit, as before #75). The wait can only
+      // delay - it resolves at the grace deadline and never fails the
+      // activation - so a compile that never completes (coalesced,
+      // superseded, or dropped by the bundler) cannot wedge it, and the
+      // dangling observation self-heals at the next settled completion.
       wait: async () => {
+        const deadline = Date.now() + Math.max(1, Math.floor(this.#activationPhaseBudgetMs / 2));
+        while (!this.#closed && this.#observedCompileStarts > 0) {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) break;
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, Math.min(remaining, 100));
+            this.#compileSettleWaiters.push(() => {
+              clearTimeout(timer);
+              resolve();
+            });
+          });
+        }
         if (this.#closed) throw new Error('RSC runtime session is closed.');
       },
     });
@@ -2692,6 +2751,7 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     this.#hmrReady = false;
     this.#appReloadSubscriptions.clear();
     this.#pendingCohortIds.clear();
+    this.#settleCompileObservation();
     for (const worker of this.#workers.values()) {
       worker.terminate(new Error('RSC runtime session is closing.'));
     }

--- a/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
+++ b/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
@@ -282,14 +282,6 @@ interface ValidatedInvocation {
   readonly surface: DevRuntimeSurface;
 }
 
-interface AttemptBarrier {
-  readonly id: string;
-  readonly sequence: number;
-  candidate: RuntimeGenerationCandidate | undefined;
-  readonly settled: Promise<void>;
-  settle(): void;
-}
-
 export class ResourceLedger {
   readonly #closers: Array<Readonly<{ readonly close: () => Promise<void>; readonly label: string }>> = [];
   readonly #failures: Array<Readonly<{ readonly error: unknown; readonly label: string }>> = [];
@@ -675,7 +667,7 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
   readonly #surfaces = new Map<string, DevRuntimeSurface>();
   readonly #testing: RsbuildRuntimeSessionStartTesting;
   readonly #maximumRunHistory: number;
-  readonly #attempts = new Map<string, AttemptBarrier>();
+  readonly #pendingCohortIds = new Set<string>();
   readonly #workers = new Map<string, InvocationWorker>();
   readonly #failedAttempts = new Set<string>();
   #active: RuntimeGeneration<RscRuntimeGenerationMetadata> | undefined;
@@ -687,11 +679,11 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
   #clientSurface: DevRuntimeClientSurfaceEndpoint | undefined;
   #closePromise: Promise<void> | undefined;
   #closed = false;
+  #completedCohortSequence = 0;
   #evictionTail: Promise<void> = Promise.resolve();
   #generationSequence = 0;
   #failureTail: Promise<void> = Promise.resolve();
   #hmrReady = false;
-  #latestAttemptSequence = 0;
   #latestPreparedRuntime: DevRuntimePreparedProject;
   #latestRscCohortRevision = 0;
   #invocationReservations = 0;
@@ -2201,19 +2193,25 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
 
   #compileObserver(): NonNullable<Parameters<typeof createRscRuntimeRsbuildConfig>[0]['onCompile']> {
     return Object.freeze({
-      beforeAttempt: () => this.#beforeAttempt(),
+      beginCompletedCohort: () => this.#beginCompletedCohort(),
       capture: async (input) => this.#trackCapture(input),
       enqueue: (snapshot) => this.#enqueue(snapshot),
       failAttempt: (attemptId, error, kind) => { void this.#failAttempt(attemptId, error, kind); },
+      // Advisory only: pre-compile observation carries no identity and owns
+      // no activation barrier, so a before callback with no matching
+      // completion (a coalesced or superseded invalidation) leaves nothing
+      // behind that could wedge a later activation.
+      observeCompileStart: () => undefined,
       stageEnvironmentCheckpoint: (input) => this.#stageEnvironmentCheckpoint(input),
     });
   }
 
   /**
    * Never rejects into the compiler's `done` hook: a rejected environment
-   * hook would skip Rsbuild's global after-compile dispatch and strand the
-   * FIFO attempt pairing. Failures are recorded against this (environment,
-   * hash) instead and fail the attempt loudly at cohort acquisition.
+   * hook would skip Rsbuild's global after-compile dispatch, so no completed
+   * cohort would surface the problem. Failures are recorded against this
+   * (environment, hash) instead and fail the attempt loudly at cohort
+   * acquisition.
    */
   async #stageEnvironmentCheckpoint(input: Readonly<{
     readonly distPath: string;
@@ -2257,23 +2255,17 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     return capture;
   }
 
-  #beforeAttempt(): string {
+  /**
+   * Allocates the identity of one completed MultiStats cohort, in global
+   * completion-callback order. This is the only source of compile identity:
+   * nothing pairs it with `onBeforeDevCompile`, so callback cardinality and
+   * ordering between the global hooks cannot misassociate Stats or leave an
+   * unsettled identity behind.
+   */
+  #beginCompletedCohort(): string {
     if (this.#closed) throw new Error('RSC runtime session is closed.');
-    const sequence = ++this.#latestAttemptSequence;
-    const id = `attempt-${String(sequence)}`;
-    let settlePromise!: () => void;
-    const settled = new Promise<void>((resolve) => { settlePromise = resolve; });
-    const barrier: AttemptBarrier = {
-      candidate: undefined,
-      id,
-      sequence,
-      settle: () => {
-        if (!this.#attempts.delete(id)) return;
-        settlePromise();
-      },
-      settled,
-    };
-    this.#attempts.set(id, barrier);
+    const id = `cohort-${String(++this.#completedCohortSequence)}`;
+    this.#pendingCohortIds.add(id);
     return id;
   }
 
@@ -2284,8 +2276,9 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     readonly hasErrors: boolean;
     readonly sourceRevision: string;
   }>): Promise<RscRuntimeCompileSnapshot | undefined> {
-    const barrier = this.#attempts.get(input.attemptId);
-    if (barrier === undefined) throw new Error('RSC runtime compile capture has no live attempt barrier.');
+    if (!this.#pendingCohortIds.delete(input.attemptId)) {
+      throw new Error('RSC runtime compile capture has no live completed cohort identity.');
+    }
     if (input.hasErrors) {
       await this.#failAttempt(input.attemptId, new Error('RSC runtime compilation failed.'), 'source-build');
       return undefined;
@@ -2294,20 +2287,18 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
       await this.#failAttempt(input.attemptId, new Error('RSC runtime compilation has no source revision.'));
       return undefined;
     }
-    if (!input.cohortChanged) {
-      barrier.settle();
-      return undefined;
-    }
+    if (!input.cohortChanged) return undefined;
+    // The completed-cohort ordinal bumps synchronously with the completion
+    // callback, so every older activation observes its supersession at the
+    // guard check without waiting on any pre-compile observation.
     const cohortRevision = ++this.#latestRscCohortRevision;
     const preparedRuntime = this.#latestPreparedRuntime;
-    barrier.settle();
     this.#emit(Object.freeze({ runtimeGenerationId: undefined, type: 'runtime.generation.compiling' }));
     try {
       const candidate = await this.#generationStore.begin({
         id: `generation-${String(++this.#generationSequence)}`,
         sourceRevision: input.sourceRevision,
       });
-      barrier.candidate = candidate;
       this.#candidatesByAttempt.set(input.attemptId, candidate);
       await this.#testing.beforeGenerationCapture?.();
       if (this.#closed) throw new Error('RSC runtime session is closed.');
@@ -2365,9 +2356,8 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
   ): Promise<void> {
     if (this.#failedAttempts.has(attemptId)) return;
     this.#failedAttempts.add(attemptId);
-    const barrier = this.#attempts.get(attemptId);
-    barrier?.settle();
-    const candidate = barrier?.candidate ?? this.#candidatesByAttempt.get(attemptId);
+    this.#pendingCohortIds.delete(attemptId);
+    const candidate = this.#candidatesByAttempt.get(attemptId);
     this.#candidatesByAttempt.delete(attemptId);
     if (candidate !== undefined) {
       const cleanup = this.#failureTail.then(() => this.#generationStore.fail(candidate));
@@ -2386,10 +2376,11 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     return Object.freeze({
       // Supersession tie-breaks on monotonic ordinals only: a newer captured
       // cohort (`#latestRscCohortRevision`) or a prepared-runtime authority
-      // change may discard this activation. Attempts that are merely live, or
-      // that failed or settled as no-ops, never produce a generation, so
-      // judging them as superseding would drop the newest successful compile
-      // with nothing to replace it - the permanent-staleness wedge in #38.
+      // change may discard this activation. In-flight compiles have no
+      // identity at all, and completed cohorts that failed or settled as
+      // no-ops never bump the ordinal; judging either as superseding would
+      // drop the newest successful compile with nothing to replace it - the
+      // permanent-staleness wedge in #38.
       // Before the first generation commits, an updated prepared declaration
       // is reconciled by the queued step after this activation; rejecting the
       // only bootstrap generation would leave that step with no active base.
@@ -2397,14 +2388,15 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
         snapshot.rscCohortRevision === this.#latestRscCohortRevision &&
         (this.#active === undefined ||
           preparedAuthorityDigest === preparedRuntimeAuthorityDigest(this.#latestPreparedRuntime)),
+      // Nothing to wait for: supersession keys only on completed cohort
+      // ordinals (bumped synchronously with each completed global callback)
+      // and prepared-runtime authority. Pre-compile observation is advisory
+      // and owns no barrier, so an in-flight compile that never completes -
+      // coalesced, superseded, or dropped by the bundler - cannot delay or
+      // wedge this activation; if it does complete with a changed cohort,
+      // its ordinal supersedes this one at the check.
       wait: async () => {
-        while (!this.#closed) {
-          const sequence = this.#sequenceFor(snapshot.attemptId);
-          const pending = [...this.#attempts.values()].filter((attempt) => attempt.sequence > sequence);
-          if (pending.length === 0) return;
-          await Promise.all(pending.map((attempt) => attempt.settled));
-        }
-        throw new Error('RSC runtime session is closed.');
+        if (this.#closed) throw new Error('RSC runtime session is closed.');
       },
     });
   }
@@ -2699,7 +2691,7 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     this.#invocationAbort.abort(new Error('RSC runtime session is closing.'));
     this.#hmrReady = false;
     this.#appReloadSubscriptions.clear();
-    for (const attempt of [...this.#attempts.values()]) attempt.settle();
+    this.#pendingCohortIds.clear();
     for (const worker of this.#workers.values()) {
       worker.terminate(new Error('RSC runtime session is closing.'));
     }
@@ -2794,11 +2786,6 @@ export class RsbuildRuntimeSession implements DevRuntimeSession {
     } catch {
       // Runtime listeners cannot affect lifecycle ordering.
     }
-  }
-
-  #sequenceFor(attemptId: string): number {
-    const match = /^attempt-(\d+)$/u.exec(attemptId);
-    return match === null ? Number.MAX_SAFE_INTEGER : Number(match[1]);
   }
 
   #publishActiveStateVersion(generation: RuntimeGeneration<RscRuntimeGenerationMetadata>, stateVersion: number): void {

--- a/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
@@ -1675,6 +1675,124 @@ test('activates from unpaired completion callbacks and never wedges behind a dan
   }
 });
 
+test('collapses an in-flight activation into a compile observed during its guard wait', { timeout: 90_000 * timeScale }, async () => {
+  const copied = await copyProviderExample();
+  try {
+    const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
+    const observer = interceptCompileObserver();
+    const prepareReached = deferred<void>();
+    const allowPrepare = deferred<void>();
+    let armPrepareBarrier = false;
+    const events: Array<{ readonly runtimeGenerationId?: string; readonly type: string }> = [];
+    const session = await RsbuildRuntimeSession.start({
+      ...startContext({
+        projectRoot: copied.projectRoot,
+        preparedRuntime: prepared.devRuntime!,
+        providerSessionId: 'provider-collapse-observed-compile',
+        signal: new AbortController().signal,
+        storageRoot: join(copied.projectRoot, '.agent-bundle', 'runtime-collapse-observed-compile'),
+      }),
+      emit: (event) => { events.push(event); },
+    }, {
+      afterActivationPrepare: async (input) => {
+        if (!armPrepareBarrier || input.phase !== 'registry') return;
+        armPrepareBarrier = false;
+        prepareReached.resolve();
+        await allowPrepare.promise;
+      },
+      createRsbuild: observer.create,
+    });
+    try {
+      await waitFor(() => session.status().state === 'active');
+      const firstGeneration = session.status().activeVector!.runtimeGenerationId;
+      const activatedBefore = events.filter((event) => event.type === 'runtime.generation.activated').length;
+      armPrepareBarrier = true;
+      const storageRoot = join(copied.projectRoot, '.agent-bundle', 'runtime-collapse-observed-compile');
+      const collapseAChildren = await stageSyntheticCohort(observer, storageRoot, 'collapse-a');
+      await observer.completeAttempt({ children: collapseAChildren });
+      await prepareReached.promise;
+      const collapseBChildren = await stageSyntheticCohort(observer, storageRoot, 'collapse-b');
+      // A compile observed while an older cohort's activation is between its
+      // prepared phases and the commit check must collapse that activation:
+      // the guard waits (bounded) for the observed compile, whose completed
+      // cohort bumps the ordinal and supersedes the older activation before
+      // an already-doomed generation becomes visible. Exactly one generation
+      // activates per settled edit, as before the completed-cohort identity.
+      observer.observeCompileStart();
+      allowPrepare.resolve();
+      await observer.completeAttempt({ children: collapseBChildren });
+      await waitFor(() => session.status().activeVector?.runtimeGenerationId !== firstGeneration && session.status().state === 'active');
+      await waitFor(() => events.some((event) => event.type === 'runtime.generation.failed'));
+      const activatedAfter = events.filter((event) => event.type === 'runtime.generation.activated');
+      // Initial generation plus exactly one for the collapsed pair: the
+      // superseded older cohort is discarded (one transient failed event),
+      // never committed.
+      expect(activatedAfter.length - activatedBefore).toBe(1);
+      expect(events.filter((event) => event.type === 'runtime.generation.failed')).toHaveLength(1);
+      expect(session.status()).toMatchObject({ diagnostics: [], state: 'active' });
+    } finally {
+      allowPrepare.resolve();
+      await session.close();
+    }
+  } finally {
+    await rm(copied.workspaceRoot, { force: true, recursive: true });
+  }
+});
+
+test('commits after the observation grace when an observed compile never completes mid-activation', { timeout: 90_000 * timeScale }, async () => {
+  const copied = await copyProviderExample();
+  try {
+    const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
+    const observer = interceptCompileObserver();
+    const prepareReached = deferred<void>();
+    const allowPrepare = deferred<void>();
+    let armPrepareBarrier = false;
+    const events: Array<{ readonly runtimeGenerationId?: string; readonly type: string }> = [];
+    const session = await RsbuildRuntimeSession.start({
+      ...startContext({
+        projectRoot: copied.projectRoot,
+        preparedRuntime: prepared.devRuntime!,
+        providerSessionId: 'provider-grace-dangling-observation',
+        signal: new AbortController().signal,
+        storageRoot: join(copied.projectRoot, '.agent-bundle', 'runtime-grace-dangling-observation'),
+      }),
+      emit: (event) => { events.push(event); },
+    }, {
+      activationPhaseBudgetMs: 4_000 * timeScale,
+      afterActivationPrepare: async (input) => {
+        if (!armPrepareBarrier || input.phase !== 'registry') return;
+        armPrepareBarrier = false;
+        prepareReached.resolve();
+        await allowPrepare.promise;
+      },
+      createRsbuild: observer.create,
+    });
+    try {
+      await waitFor(() => session.status().state === 'active');
+      const firstGeneration = session.status().activeVector!.runtimeGenerationId;
+      armPrepareBarrier = true;
+      const graceChildren = await stageSyntheticCohort(observer, join(copied.projectRoot, '.agent-bundle', 'runtime-grace-dangling-observation'), 'grace');
+      await observer.completeAttempt({ children: graceChildren });
+      await prepareReached.promise;
+      // The #75 hostage scenario: an observed compile whose completion never
+      // arrives (coalesced or superseded invalidation). The guard wait may
+      // only delay this activation by its bounded grace - it must then
+      // commit, not fail, and the dangling observation must not leave any
+      // failed generation or diagnostic behind.
+      observer.observeCompileStart();
+      allowPrepare.resolve();
+      await waitForWithin(() => session.status().activeVector?.runtimeGenerationId !== firstGeneration, 30_000);
+      expect(session.status()).toMatchObject({ diagnostics: [], state: 'active' });
+      expect(events.filter((event) => event.type === 'runtime.generation.failed')).toHaveLength(0);
+    } finally {
+      allowPrepare.resolve();
+      await session.close();
+    }
+  } finally {
+    await rm(copied.workspaceRoot, { force: true, recursive: true });
+  }
+});
+
 test('fails a wedged activation reconcile within the budget and releases its late reservation', { timeout: 120_000 * timeScale }, async () => {
   const copied = await copyProviderExample();
   try {

--- a/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
+++ b/examples/rsc-agent-runtime/tests/dev-provider.integration.test.ts
@@ -70,7 +70,7 @@ const compileObserver = (
     onAfterEnvironmentCompile: () => undefined,
     onBeforeDevCompile: (callback: unknown) => { before = callback as () => void; },
   });
-  const beginAttempt = (): void => {
+  const observeCompileStart = (): void => {
     if (before === undefined) throw new Error('RSC compiler observer before hook is unavailable.');
     before();
   };
@@ -93,24 +93,24 @@ const compileObserver = (
     });
   };
   return Object.freeze({
-    beginAttempt,
     async compile(input: Readonly<{
       readonly children?: readonly unknown[];
       readonly hasErrors?: boolean;
     }> = {}): Promise<void> {
-      beginAttempt();
+      observeCompileStart();
       await completeAttempt(input);
     },
     completeAttempt,
+    observeCompileStart,
   });
 };
 
 /**
  * Wraps the real Rsbuild factory to steal the compile-observer plugin's dev
  * hooks. Registering the plugin against a second minimal API shares its
- * closure state (attempt FIFO, captured cohort) with the real compiler, so a
- * test can drive additional attempt lifecycles deterministically while the
- * real watcher is idle.
+ * closure state (captured cohort) with the real compiler, so a test can
+ * drive additional compile lifecycles deterministically while the real
+ * watcher is idle.
  */
 const interceptCompileObserver = () => {
   let before: (() => void) | undefined;
@@ -132,10 +132,6 @@ const interceptCompileObserver = () => {
     return createRsbuild(input);
   }) as typeof createRsbuild;
   return Object.freeze({
-    beginAttempt: (): void => {
-      if (before === undefined) throw new Error('RSC compile observer hooks are unavailable.');
-      before();
-    },
     async completeAttempt(input: Readonly<{
       readonly children?: readonly Readonly<{ readonly hash: string; readonly name: string }>[];
       readonly hasErrors?: boolean;
@@ -149,6 +145,10 @@ const interceptCompileObserver = () => {
       });
     },
     create,
+    observeCompileStart: (): void => {
+      if (before === undefined) throw new Error('RSC compile observer hooks are unavailable.');
+      before();
+    },
     /**
      * Drives the plugin's per-environment staging hook against the session's
      * real compiler output roots, staging an immutable checkpoint under a
@@ -612,13 +612,14 @@ test('retries an identical compiler cohort after an asynchronous provider activa
   const captures: boolean[] = [];
   let enqueueCount = 0;
   const observer = compileObserver({
-    beforeAttempt: () => `attempt-${String(captures.length + 1)}`,
+    beginCompletedCohort: () => `attempt-${String(captures.length + 1)}`,
     capture: async (input) => {
       captures.push(input.cohortChanged);
       return input.cohortChanged ? snapshotFor(input.attemptId, input.sourceRevision) : undefined;
     },
     enqueue: () => outcomes[enqueueCount++]!.promise,
     failAttempt: () => undefined,
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile();
@@ -639,7 +640,7 @@ test('classifies a same-hash compiler cohort as unchanged while its activation i
   let attempts = 0;
   let enqueueCount = 0;
   const observer = compileObserver({
-    beforeAttempt: () => `attempt-${String(++attempts)}`,
+    beginCompletedCohort: () => `attempt-${String(++attempts)}`,
     capture: async (input) => {
       captures.push(input.cohortChanged);
       return input.cohortChanged ? snapshotFor(input.attemptId, input.sourceRevision) : undefined;
@@ -649,6 +650,7 @@ test('classifies a same-hash compiler cohort as unchanged while its activation i
       return activation.promise;
     },
     failAttempt: () => undefined,
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile();
@@ -664,7 +666,7 @@ test('classifies direct compiler errors as source build failures without capture
   const enqueued: string[] = [];
   const failures: unknown[][] = [];
   const observer = compileObserver({
-    beforeAttempt: () => 'attempt-source-build',
+    beginCompletedCohort: () => 'attempt-source-build',
     capture: async (input) => {
       captured.push(input.attemptId);
       return snapshotFor(input.attemptId, input.sourceRevision);
@@ -674,6 +676,7 @@ test('classifies direct compiler errors as source build failures without capture
       return 'activated';
     },
     failAttempt: (...input: unknown[]) => { failures.push(input); },
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile({ hasErrors: true });
@@ -688,13 +691,14 @@ test('classifies direct compiler errors as source build failures without capture
 test('recaptures an unchanged successful cohort after a source build failure', async () => {
   const captured: boolean[] = [];
   const observer = compileObserver({
-    beforeAttempt: () => `attempt-${String(captured.length + 1)}`,
+    beginCompletedCohort: () => `attempt-${String(captured.length + 1)}`,
     capture: async (input) => {
       captured.push(input.cohortChanged);
       return snapshotFor(input.attemptId, input.sourceRevision);
     },
     enqueue: () => 'activated',
     failAttempt: () => undefined,
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile();
@@ -707,10 +711,11 @@ test('recaptures an unchanged successful cohort after a source build failure', a
 test('keeps malformed compiler stats in the provider lifecycle failure lane', async () => {
   const failures: unknown[][] = [];
   const observer = compileObserver({
-    beforeAttempt: () => 'attempt-malformed-stats',
+    beginCompletedCohort: () => 'attempt-malformed-stats',
     capture: async (input) => snapshotFor(input.attemptId, input.sourceRevision),
     enqueue: () => 'activated',
     failAttempt: (...input: unknown[]) => { failures.push(input); },
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile({ children: [] });
@@ -720,42 +725,104 @@ test('keeps malformed compiler stats in the provider lifecycle failure lane', as
   expect(failures[0]?.[2]).toBe('provider-lifecycle');
 });
 
-test('retains FIFO pairing when MultiCompiler emits overlapping before hooks', async () => {
-  let attempts = 0;
+test('derives identity from completed cohorts when before callbacks are coalesced, missing, or duplicated', async () => {
+  let cohorts = 0;
+  let observedStarts = 0;
   const captures: string[] = [];
   const failures: unknown[][] = [];
   const observer = compileObserver({
-    beforeAttempt: () => `attempt-${String(++attempts)}`,
+    beginCompletedCohort: () => `cohort-${String(++cohorts)}`,
     capture: async (input) => {
       captures.push(input.attemptId);
       return undefined;
     },
     enqueue: () => undefined,
     failAttempt: (...input: unknown[]) => { failures.push(input); },
+    observeCompileStart: () => { observedStarts += 1; },
   });
 
-  observer.beginAttempt();
-  observer.beginAttempt();
+  // Coalesced invalidation: two pre-compile callbacks, one completion.
+  observer.observeCompileStart();
+  observer.observeCompileStart();
   await observer.completeAttempt();
-  await observer.completeAttempt();
+  // Missing pre-compile callback: a completion with no before callback at
+  // all still allocates the next identity and is processed normally.
+  await observer.completeAttempt({ children: [{ hash: 'rsc-2', name: 'rsc' }, { hash: 'widget-2', name: 'widget' }, { hash: 'app-2', name: 'app' }] });
+  // Duplicated pre-compile callback after everything settled: advisory only.
+  observer.observeCompileStart();
 
-  expect(captures).toEqual(['attempt-1', 'attempt-2']);
+  expect(observedStarts).toBe(3);
+  expect(captures).toEqual(['cohort-1', 'cohort-2']);
   expect(failures).toEqual([]);
 });
 
-test('fails duplicate pending attempt identities loudly instead of silently mispairing them', () => {
+test('assigns ascending completed-cohort identity to duplicated and reordered completion callbacks', async () => {
+  let cohorts = 0;
+  const captures: Array<Readonly<{ readonly attemptId: string; readonly cohortChanged: boolean; readonly sourceRevision: string }>> = [];
+  const enqueued: string[] = [];
   const failures: unknown[][] = [];
   const observer = compileObserver({
-    beforeAttempt: () => 'attempt-duplicate',
-    capture: async () => undefined,
-    enqueue: () => undefined,
+    beginCompletedCohort: () => `cohort-${String(++cohorts)}`,
+    capture: async (input) => {
+      captures.push(Object.freeze({ attemptId: input.attemptId, cohortChanged: input.cohortChanged, sourceRevision: input.sourceRevision }));
+      return input.cohortChanged ? snapshotFor(input.attemptId, input.sourceRevision) : undefined;
+    },
+    enqueue: (snapshot) => {
+      enqueued.push(snapshot.attemptId);
+      return 'activated';
+    },
     failAttempt: (...input: unknown[]) => { failures.push(input); },
+    observeCompileStart: () => undefined,
   });
 
-  observer.beginAttempt();
-  expect(() => observer.beginAttempt()).toThrow('duplicate pending attempt identity');
-  expect(failures.map(([attemptId]) => attemptId)).toEqual(['attempt-duplicate', 'attempt-duplicate']);
-  expect(failures.every((failure) => failure[2] === 'provider-lifecycle')).toBe(true);
+  const newer = [{ hash: 'rsc-newer', name: 'rsc' }, { hash: 'widget-newer', name: 'widget' }, { hash: 'app-newer', name: 'app' }];
+  const older = [{ hash: 'rsc-older', name: 'rsc' }, { hash: 'widget-older', name: 'widget' }, { hash: 'app-older', name: 'app' }];
+  // Reordered delivery: the completion for the newer compile arrives first.
+  // Identity binds to completion arrival, so the last-delivered cohort is
+  // the authoritative one - there is no queue to pair either callback with
+  // an older observation.
+  await observer.completeAttempt({ children: newer });
+  await observer.completeAttempt({ children: older });
+  // Duplicated completion: the same MultiStats delivered again is an
+  // unchanged cohort no-op under a fresh identity, never a mispair.
+  await observer.completeAttempt({ children: older });
+
+  expect(captures.map((capture) => capture.attemptId)).toEqual(['cohort-1', 'cohort-2', 'cohort-3']);
+  expect(captures.map((capture) => capture.cohortChanged)).toEqual([true, true, false]);
+  expect(captures[0]!.sourceRevision).not.toBe(captures[1]!.sourceRevision);
+  expect(captures[1]!.sourceRevision).toBe(captures[2]!.sourceRevision);
+  expect(enqueued).toEqual(['cohort-1', 'cohort-2']);
+  expect(failures).toEqual([]);
+});
+
+test('treats skewed child invalidations as distinct completed cohorts in completion order', async () => {
+  let cohorts = 0;
+  const captures: Array<Readonly<{ readonly attemptId: string; readonly cohortChanged: boolean }>> = [];
+  const failures: unknown[][] = [];
+  const observer = compileObserver({
+    beginCompletedCohort: () => `cohort-${String(++cohorts)}`,
+    capture: async (input) => {
+      captures.push(Object.freeze({ attemptId: input.attemptId, cohortChanged: input.cohortChanged }));
+      return input.cohortChanged ? snapshotFor(input.attemptId, input.sourceRevision) : undefined;
+    },
+    enqueue: () => 'activated',
+    failAttempt: (...input: unknown[]) => { failures.push(input); },
+    observeCompileStart: () => undefined,
+  });
+
+  // MultiCompiler children invalidating at different times surface as
+  // overlapping before callbacks and completions whose child hashes advance
+  // one child at a time. Every distinct completed pair is a fresh cohort.
+  observer.observeCompileStart();
+  await observer.completeAttempt({ children: [{ hash: 'rsc-1', name: 'rsc' }, { hash: 'widget-1', name: 'widget' }, { hash: 'app-1', name: 'app' }] });
+  observer.observeCompileStart();
+  observer.observeCompileStart();
+  await observer.completeAttempt({ children: [{ hash: 'rsc-2', name: 'rsc' }, { hash: 'widget-1', name: 'widget' }, { hash: 'app-1', name: 'app' }] });
+  await observer.completeAttempt({ children: [{ hash: 'rsc-2', name: 'rsc' }, { hash: 'widget-2', name: 'widget' }, { hash: 'app-2', name: 'app' }] });
+
+  expect(captures.map((capture) => capture.attemptId)).toEqual(['cohort-1', 'cohort-2', 'cohort-3']);
+  expect(captures.map((capture) => capture.cohortChanged)).toEqual([true, true, true]);
+  expect(failures).toEqual([]);
 });
 
 test('aggregates owned resource closer failures', async () => {
@@ -1442,7 +1509,7 @@ test('commits a compiled generation across an equivalent prepared-runtime revisi
   }
 });
 
-test('commits an activation while a later attempt is still live at the commit check', { timeout: 90_000 * timeScale }, async () => {
+test('commits an activation while a later compile is still in flight at the commit check', { timeout: 90_000 * timeScale }, async () => {
   const copied = await copyProviderExample();
   try {
     const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
@@ -1474,14 +1541,16 @@ test('commits an activation while a later attempt is still live at the commit ch
       const firstGeneration = session.status().activeVector!.runtimeGenerationId;
       armCommitBarrier = true;
       const raceChildren = await stageSyntheticCohort(observer, join(copied.projectRoot, '.agent-bundle', 'runtime-live-attempt-commit'), 'live-race');
-      observer.beginAttempt();
+      observer.observeCompileStart();
       await observer.completeAttempt({ children: raceChildren });
       await commitReached.promise;
-      // The #38 wedge: an undecided later attempt registers while the newest
-      // compile sits between its final guard wait and the commit check. It
-      // must not supersede the activation - it may still settle as a no-op or
-      // a failure, which would leave nothing to activate and no retrigger.
-      observer.beginAttempt();
+      // The #38 wedge: a later compile starts while the newest completed
+      // cohort sits between its final guard wait and the commit check.
+      // Pre-compile observation is advisory and owns no identity, so it must
+      // neither supersede nor delay the activation - it may still settle as
+      // a no-op or a failure, which would leave nothing to activate and no
+      // retrigger.
+      observer.observeCompileStart();
       allowCommit.resolve();
       await waitFor(() => session.status().activeVector?.runtimeGenerationId !== firstGeneration);
       const committed = session.status().activeVector?.runtimeGenerationId;
@@ -1530,14 +1599,15 @@ test('commits an activation after a later broken attempt fails inside the commit
       const firstGeneration = session.status().activeVector!.runtimeGenerationId;
       armCommitBarrier = true;
       const raceChildren = await stageSyntheticCohort(observer, join(copied.projectRoot, '.agent-bundle', 'runtime-failed-attempt-commit'), 'failed-race');
-      observer.beginAttempt();
+      observer.observeCompileStart();
       await observer.completeAttempt({ children: raceChildren });
       await commitReached.promise;
       // A later broken compile fails and settles entirely inside the commit
-      // window. A failed attempt produces no generation, so it must not
-      // supersede the newest successful compile (#38) - discarding it here
-      // left the runtime permanently on the stale first generation.
-      observer.beginAttempt();
+      // window. A failed completed cohort never bumps the cohort ordinal, so
+      // it must not supersede the newest successful compile (#38) -
+      // discarding it here left the runtime permanently on the stale first
+      // generation.
+      observer.observeCompileStart();
       await observer.completeAttempt({ hasErrors: true });
       allowCommit.resolve();
       await waitFor(() => session.status().activeVector?.runtimeGenerationId !== firstGeneration);
@@ -1545,6 +1615,58 @@ test('commits an activation after a later broken attempt fails inside the commit
       expect(committed).toEqual(expect.any(String));
       expect(session.status()).toMatchObject({ state: 'active' });
       expect(events.filter((event) => event.type === 'runtime.generation.activated' && event.runtimeGenerationId === committed)).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await rm(copied.workspaceRoot, { force: true, recursive: true });
+  }
+});
+
+test('activates from unpaired completion callbacks and never wedges behind a dangling pre-compile observation', { timeout: 90_000 * timeScale }, async () => {
+  const copied = await copyProviderExample();
+  try {
+    const prepared = await new ProjectService({ includeDevRuntime: true, mode: 'development', root: copied.projectRoot }).prepare('dev');
+    const observer = interceptCompileObserver();
+    const events: Array<{ readonly type: string }> = [];
+    const session = await RsbuildRuntimeSession.start({
+      ...startContext({
+        projectRoot: copied.projectRoot,
+        preparedRuntime: prepared.devRuntime!,
+        providerSessionId: 'provider-unpaired-completion',
+        signal: new AbortController().signal,
+        storageRoot: join(copied.projectRoot, '.agent-bundle', 'runtime-unpaired-completion'),
+      }),
+      emit: (event) => { events.push(event); },
+    }, { createRsbuild: observer.create });
+    try {
+      await waitFor(() => session.status().state === 'active');
+      const firstGeneration = session.status().activeVector!.runtimeGenerationId;
+      // A completion with no paired pre-compile callback (a coalesced or
+      // dropped onBeforeDevCompile) is a complete authoritative cohort.
+      const storageRoot = join(copied.projectRoot, '.agent-bundle', 'runtime-unpaired-completion');
+      const unpairedChildren = await stageSyntheticCohort(observer, storageRoot, 'unpaired');
+      await observer.completeAttempt({ children: unpairedChildren });
+      await waitFor(() => session.status().activeVector?.runtimeGenerationId !== firstGeneration);
+      const unpairedGeneration = session.status().activeVector!.runtimeGenerationId;
+      expect(session.status()).toMatchObject({ diagnostics: [], state: 'active' });
+
+      // A pre-compile observation whose completion never arrives owns no
+      // identity or barrier, so the next completed cohort activates without
+      // waiting on it.
+      observer.observeCompileStart();
+      const postDanglingChildren = await stageSyntheticCohort(observer, storageRoot, 'post-dangling');
+      await observer.completeAttempt({ children: postDanglingChildren });
+      await waitFor(() => session.status().activeVector?.runtimeGenerationId !== unpairedGeneration);
+      expect(session.status()).toMatchObject({ diagnostics: [], state: 'active' });
+
+      // Redelivering the same completed MultiStats is an unchanged-cohort
+      // no-op under a fresh identity, never a mispair or a failure.
+      const committed = session.status().activeVector!.runtimeGenerationId;
+      await observer.completeAttempt({ children: postDanglingChildren });
+      await new Promise<void>((resolve) => { setTimeout(resolve, 100); });
+      expect(session.status().activeVector?.runtimeGenerationId).toBe(committed);
+      expect(events.filter((event) => event.type === 'runtime.generation.failed')).toHaveLength(0);
     } finally {
       await session.close();
     }

--- a/examples/rsc-agent-runtime/tests/generation-materializer.test.ts
+++ b/examples/rsc-agent-runtime/tests/generation-materializer.test.ts
@@ -230,7 +230,7 @@ const compilerObserver = (input: Readonly<{
   readonly enqueued: string[];
   readonly failed: unknown[];
 }>) => activateCompilerObserver({
-      beforeAttempt: () => 'attempt-1',
+      beginCompletedCohort: () => 'attempt-1',
       capture: async (value) => {
         input.capture.push(value);
         return {
@@ -243,6 +243,7 @@ const compilerObserver = (input: Readonly<{
       },
       enqueue: (snapshot) => input.enqueued.push(snapshot.attemptId),
       failAttempt: (_attemptId, error) => input.failed.push(error),
+      observeCompileStart: () => undefined,
 });
 
 test('resolves the coherent development compiler configuration through Rsbuild', async () => {
@@ -743,10 +744,11 @@ test('passes exact per-environment hashes to capture alongside the rsc and widge
 test('stages a checkpoint for every successful environment compilation and skips unusable ones', async () => {
   const staged: Array<Readonly<Record<string, unknown>>> = [];
   const observer = activateCompilerObserver({
-    beforeAttempt: () => 'attempt-stage',
+    beginCompletedCohort: () => 'attempt-stage',
     capture: async () => undefined,
     enqueue: () => undefined,
     failAttempt: () => undefined,
+    observeCompileStart: () => undefined,
     stageEnvironmentCheckpoint: async (input) => { staged.push(input); },
   });
 
@@ -778,7 +780,7 @@ test('recaptures an identical cohort from its immutable checkpoints after an enq
   let index = 0;
   let enqueueCount = 0;
   const observer = activateCompilerObserver({
-    beforeAttempt: () => `attempt-${String(index)}`,
+    beginCompletedCohort: () => `attempt-${String(index)}`,
     capture: async (input) => {
       captures.push({ cohortChanged: input.cohortChanged });
       const snapshot = snapshots[index];
@@ -791,6 +793,7 @@ test('recaptures an identical cohort from its immutable checkpoints after an enq
       if (enqueueCount === 2) throw new Error('enqueue failed');
     },
     failAttempt: (_attemptId, error) => failed.push(error),
+    observeCompileStart: () => undefined,
   });
 
   await observer.compile(cohortChildren('a'));
@@ -898,7 +901,7 @@ test('recaptures a stale known compiler chunk cohort through the observer after 
   try {
     await writeCompilerCohort(compilerRoot);
     const observer = activateCompilerObserver({
-      beforeAttempt: () => `attempt-${String(candidateNumber)}`,
+      beginCompletedCohort: () => `attempt-${String(candidateNumber)}`,
       capture: async (input) => {
         candidateNumber += 1;
         const candidate = await store.begin({ id: `candidate-${String(candidateNumber)}`, sourceRevision: input.sourceRevision });
@@ -930,6 +933,7 @@ test('recaptures a stale known compiler chunk cohort through the observer after 
         if (enqueueNumber === 2) throw new Error('enqueue rejects B');
       },
       failAttempt: (_attemptId, error) => failed.push(error),
+      observeCompileStart: () => undefined,
       stageEnvironmentCheckpoint: (input) => checkpointStore.stage({
         environment: input.environmentName,
         hash: input.statsHash,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #75. Follow-up to the Rsbuild 2.2.1 conformance audit (#72); this is the identity rearchitecture that #76 deferred.

## Problem

The runtime compile observer allocated an attempt ID in the global `onBeforeDevCompile` hook and consumed IDs FIFO in `onAfterDevCompile`. Rsbuild documents lifecycle order but not a stable cycle ID, callback cardinality under coalesced invalidations, or one-to-one pairing when MultiCompiler children invalidate at different times. On top of that, the session's activation guard waited on every attempt barrier newer than the activating snapshot — so a `onBeforeDevCompile` whose completion never arrived (a coalesced or superseded invalidation) held an activation hostage until the bounded budget failed it loudly.

## What changed

- **`examples/rsc-agent-runtime/rsbuild.config.ts`** — the FIFO `pendingAttemptIds` queue, the duplicate-identity throw, and the "completed without a matching attempt" throw are gone. `onBeforeDevCompile` now only calls the advisory `observeCompileStart()`; it owns no identity, queue, or barrier. Every `onAfterDevCompile` callback allocates the next monotonic identity via `beginCompletedCohort()` at its start, in global completion order. Nothing pairs the two hooks, so there is no queue to mispair.
- **`examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts`** — `AttemptBarrier`, the `#attempts` map, `#latestAttemptSequence`, and `#sequenceFor` are removed. `#beginCompletedCohort()` allocates `cohort-N` ordinals at completion time. The activation guard's `wait()` no longer owns an attempt barrier: the completed-cohort ordinal (`#latestRscCohortRevision`) bumps synchronously with each completed changed cohort's callback, and supersession is fully decided by `check()` against completed ordinals and prepared-runtime authority. Pre-compile observation remains a bounded collapse hint: an in-flight activation waits for observed compiles only up to half the activation phase budget (then proceeds, never fails), so one settled edit keeps activating exactly one visible generation, while a completion that never arrives can only delay one activation once and self-heals at the next settled completion. In-flight compiles have no identity at all; failed and no-op completed cohorts still never bump the ordinal, so the #38 commit-window protections (a live/failed/no-op later compile must not discard the newest successful one) are intact and covered by the existing commit-window tests.
- The failed-attempt dedup, candidate cleanup (`#candidatesByAttempt`), compiler-asset checkpoint lifecycle, bounded activation phases from #76, and the `writeToDisk` copy path are all unchanged.

## How this differs from #76

#76 kept FIFO identity and made its violations loud: a non-singleton pending queue or duplicate identity failed all live attempts and threw rather than silently misassociating, and a wedged activation failed within a bounded budget. This PR removes the FIFO identity entirely, so those failure modes cannot arise: identity is allocated per completed MultiStats cohort in completion order, pre-compile observation is advisory, and no activation ever waits on a pre-compile observation. The bounded activation budgets from #76 remain as a backstop for genuinely wedged store/registry phases.

## New deterministic coverage

Plugin-level (driven directly against the observer hooks):
- coalesced / missing / duplicated `onBeforeDevCompile` callbacks — identity derives only from completions, no failures;
- duplicated and reordered completion callbacks — ascending fresh identity, unchanged-cohort no-op instead of a mispair;
- skewed child invalidations — each distinct completed `rsc`/`widget` hash pair is its own cohort in completion order.

Real-session (via the intercepted compile observer on a live `RsbuildRuntimeSession`):
- a completion with no paired pre-compile callback activates a generation;
- a dangling pre-compile observation (completion never arrives) does not block the next completed cohort from activating;
- an observed compile completing during an older activation's guard wait collapses that activation into the newer cohort (exactly one activated generation per settled edit);
- a dangling observation during an in-flight activation delays it by at most the bounded grace, then commits with zero failed events;
- redelivered identical MultiStats is a no-op with zero `runtime.generation.failed` events.

The two #76-era commit-window regression tests are retained (retitled/re-commented for the new model), as are all failed-attempt, no-op-attempt, and source-build-diagnostic tests.

## No changeset — why

Every change is inside `examples/rsc-agent-runtime` (the private, unpublished `@agent-bundle/rsc-agent-runtime-demo` example runtime). No published package (`agent-bundle`, `@agent-bundle/rsc-runtime`, `create-agent-bundle`) changes behavior, so per the changeset convention there is nothing to version. (#76 needed a changeset because it also changed the published dev-server relay in `agent-bundle`.)

## Out of scope (stayed in lane)

No changes to #73's reload channel, #74's per-environment output staging or `onAfterEnvironmentCompile` checkpoints, how live `writeToDisk` roots are copied, `packages/agent-bundle/src/build/rslib.ts`, `build.test.ts`, `hooks.test.ts`, or `RuntimeClientSurfaceProxy` frame parsing.

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @agent-bundle/rsc-agent-runtime-demo typecheck`
- [x] `rslint examples/rsc-agent-runtime` (0 errors)
- [x] `tests/dev-provider.integration.test.ts` — 39/39 passed (includes the 4 new tests)
- [x] `tests/generation-materializer.test.ts` — all passed
- [x] full `@agent-bundle/rsc-agent-runtime-demo` suite — 181 tests: 175 passed, 6 skipped (env-gated native/eval tests, pre-existing), 0 failed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f761ef9f-f3b2-4066-90ab-8478c80587e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f761ef9f-f3b2-4066-90ab-8478c80587e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


