### PR TITLE
chore(rsc-runtime): drop the react-server-components keyword

### DIFF
--- a/.changeset/rsc-runtime-drop-rsc-keyword.md
+++ b/.changeset/rsc-runtime-drop-rsc-keyword.md
@@ -1,0 +1,12 @@
+---
+"@agent-bundle/rsc-runtime": patch
+---
+
+Published-metadata fix: the `react-server-components` keyword is removed from
+`packages/rsc-runtime/package.json`. #89 rewrote the `description` in that same
+file to state that the package is a React-element result DSL rather than a
+React Server Components renderer, but left the keyword asserting the opposite,
+so the npm manifest contradicted itself and the registry surfaced the package
+against RSC-renderer searches it cannot serve. The remaining keywords —
+`agent-bundle` and `mcp` — describe what the package actually is. No runtime
+code, export surface, or package name changes; the name is tracked separately.

--- a/packages/rsc-runtime/package.json
+++ b/packages/rsc-runtime/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "keywords": [
     "agent-bundle",
-    "mcp",
-    "react-server-components"
+    "mcp"
   ],
   "homepage": "https://github.com/ScriptedAlchemy/agent-bundle#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

`packages/rsc-runtime/package.json` contradicted itself. #89 rewrote the `description` in that file to state that the package is a React-element result DSL (an "MCP result DSL") and explicitly **not** a React Server Components renderer or Flight transport, but left `react-server-components` sitting in the `keywords` array of the same manifest. This drops that keyword so the published metadata agrees with itself and the registry stops surfacing the package against RSC-renderer searches it cannot serve.

Keywords kept: `agent-bundle`, `mcp` — both accurate. No other keyword in the array overclaims (there is no `rsc`, `flight`, or `server-components` entry).

Scope is deliberately narrow: **no rename**. The package name `@agent-bundle/rsc-runtime` is untouched and remains tracked in #78. Likewise, #96 proposes building a real RSC/Flight renderer later; this change describes the package as it exists today and does not prejudge that work.

## Pins

No test pins the rsc-runtime keywords array. The only keywords assertion in the suite is in `packages/agent-bundle/tests/release-audit.test.ts`, and it covers the `agent-bundle` product manifest, not this package. Nothing needed updating.

## Test plan

Metadata-only change, gated with the `--current-node-only` local-ci leg plus the packed release-audit metadata tests:

- [x] `pnpm check:local-ci --current-node-only` — **GREEN** (build, `lint:package`, `typecheck`, `lint`, `test:unit` 1781/1785 passed 4 skipped, `test:integration` 556/558 passed 2 skipped)
- [x] `node scripts/run-packed-tests.mjs --release packages/agent-bundle/tests/release-audit.test.ts` — 4/4 passed, including "ships repository and support metadata that matches the verified origin"
- [x] `publint packages/rsc-runtime` — All good

Patch changeset included for `@agent-bundle/rsc-runtime` (published metadata change).