### PR TITLE
perf(test): serve packed-pool installs from the npm cache with --prefer-offline

### DIFF
--- a/packages/agent-bundle/tests/cli.test.ts
+++ b/packages/agent-bundle/tests/cli.test.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { runCli as runSourceCli } from '../src/cli.ts';
+import { npmInstallArguments } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -128,7 +129,7 @@ const createPackedConsumer = async (): Promise<{ readonly cli: string; readonly 
   const [packed] = JSON.parse(stdout) as Array<{ readonly filename: string }>;
   await writeFile(join(root, 'package.json'), '{"type":"module"}\n');
   await execFile(
-    'npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', join(root, packed.filename)],
+    'npm', ['install', ...npmInstallArguments, join(root, packed.filename)],
     { cwd: root },
   );
   return { cli: join(root, 'node_modules', '.bin', 'agent-bundle'), root };

--- a/packages/agent-bundle/tests/cli.test.ts
+++ b/packages/agent-bundle/tests/cli.test.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { runCli as runSourceCli } from '../src/cli.ts';
-import { npmInstallArguments } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -129,7 +129,7 @@ const createPackedConsumer = async (): Promise<{ readonly cli: string; readonly 
   const [packed] = JSON.parse(stdout) as Array<{ readonly filename: string }>;
   await writeFile(join(root, 'package.json'), '{"type":"module"}\n');
   await execFile(
-    'npm', ['install', ...npmInstallArguments, join(root, packed.filename)],
+    'npm', ['install', ...cachedNpmInstallArguments, join(root, packed.filename)],
     { cwd: root },
   );
   return { cli: join(root, 'node_modules', '.bin', 'agent-bundle'), root };

--- a/packages/agent-bundle/tests/dev-workbench-packaging.test.ts
+++ b/packages/agent-bundle/tests/dev-workbench-packaging.test.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 
 import { describe, expect, it } from '@rstest/core';
 
-import { installedEnvironment, npmInstallArguments, sharedPackedTarball } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments, installedEnvironment, sharedPackedTarball } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -83,7 +83,7 @@ it('serves prebuilt workbench assets from an installed tarball without the repos
     expect(listing.stdout).not.toMatch(/package\/dist\/workbench\/.*-[a-f0-9]{8,}/iu);
 
     await writeFile(join(consumer, 'package.json'), '{"type":"module"}\n');
-    await execFile('npm', ['install', ...npmInstallArguments, tarball], { cwd: consumer });
+    await execFile('npm', ['install', ...cachedNpmInstallArguments, tarball], { cwd: consumer });
     await mkdir(join(project, 'skills', 'review'), { recursive: true });
     await Promise.all([
       writeFile(join(project, 'package.json'), '{"type":"module"}\n'),
@@ -115,7 +115,7 @@ it('runs the Agent API from an omit-dev installed tarball with its runtime MCP d
   const project = join(consumer, 'project');
   try {
     await writeFile(join(consumer, 'package.json'), '{"type":"module"}\n');
-    await execFile('npm', ['install', '--omit=dev', ...npmInstallArguments, tarball], { cwd: consumer });
+    await execFile('npm', ['install', '--omit=dev', ...cachedNpmInstallArguments, tarball], { cwd: consumer });
     await mkdir(join(project, 'skills', 'review'), { recursive: true });
     await Promise.all([
       writeFile(join(project, 'package.json'), '{"type":"module"}\n'),

--- a/packages/agent-bundle/tests/packed-consumer.test.ts
+++ b/packages/agent-bundle/tests/packed-consumer.test.ts
@@ -20,7 +20,7 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { sha256Hex } from '../src/core/digest.ts';
-import { installedEnvironment, npmInstallArguments } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments, installedEnvironment } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -110,7 +110,7 @@ it('uses only an installed tarball after source deletion', async () => {
     // The two consumers are disjoint directories; npm's cache handles the
     // concurrent installs (the scaffolder e2e relies on the same property).
     await Promise.all([projectRoot, scriptProjectRoot].map(async (consumer) =>
-      execFile('npm', ['install', ...npmInstallArguments, tarball], {
+      execFile('npm', ['install', ...cachedNpmInstallArguments, tarball], {
         cwd: consumer,
         env: installedEnvironment(),
       })));
@@ -331,7 +331,7 @@ it('uses only an installed tarball after source deletion', async () => {
         '',
       ].join('\n')),
     ]);
-    await execFile('npm', ['install', ...npmInstallArguments, tarball], {
+    await execFile('npm', ['install', ...cachedNpmInstallArguments, tarball], {
       cwd: frameworkRoot,
       env: installedEnvironment(),
     });

--- a/packages/agent-bundle/tests/public-api-packed.test.ts
+++ b/packages/agent-bundle/tests/public-api-packed.test.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { writeFixtureManifest } from './support/manifest.ts';
-import { npmInstallArguments, sharedPackedTarball } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments, sharedPackedTarball } from './support/shared-pack.ts';
 
 interface PackageManifest {
   bin: {
@@ -58,7 +58,7 @@ it('writes the package version as the producer of a packed CLI manifest', async 
   try {
     await writeFile(join(consumerRoot, 'package.json'), '{"type":"module"}\n');
     await execFile(
-      'npm', ['install', ...npmInstallArguments, tarball],
+      'npm', ['install', ...cachedNpmInstallArguments, tarball],
       { cwd: consumerRoot },
     );
 
@@ -90,7 +90,7 @@ it('imports the externalized config entry from a packed npm consumer', async () 
     await writeFile(join(consumerRoot, 'package.json'), '{"type":"module"}\n');
     await execFile(
       'npm',
-      ['install', ...npmInstallArguments, tarball],
+      ['install', ...cachedNpmInstallArguments, tarball],
       { cwd: consumerRoot },
     );
 
@@ -198,7 +198,7 @@ it('invokes a prebuilt MCP server from a clean packed consumer', async () => {
     await writeFile(join(consumerRoot, 'package.json'), '{"type":"module"}\n');
     await execFile(
       'npm',
-      ['install', ...npmInstallArguments, tarball],
+      ['install', ...cachedNpmInstallArguments, tarball],
       { cwd: consumerRoot },
     );
     const { stdout } = await execFile(process.execPath, [

--- a/packages/agent-bundle/tests/rsc-runtime-optional-packaging.test.ts
+++ b/packages/agent-bundle/tests/rsc-runtime-optional-packaging.test.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { describe, expect, it } from '@rstest/core';
 
-import { npmInstallArguments, sharedPackedTarball } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments, sharedPackedTarball } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -45,7 +45,7 @@ describe.sequential('optional RSC runtime package boundary', () => {
       const tarListing = (await execFile('tar', ['-tf', tarball])).stdout;
       expect(tarListing).not.toMatch(/examples\/rsc-agent-runtime|react-server-dom-rspack|rsbuild-plugin-rsc/u);
 
-      await execFile('npm', ['install', ...npmInstallArguments, tarball], { cwd: consumer });
+      await execFile('npm', ['install', ...cachedNpmInstallArguments, tarball], { cwd: consumer });
       const dependencyTree = JSON.parse((await execFile('npm', ['ls', '--all', '--json'], { cwd: consumer })).stdout) as InstalledDependencyTree;
       const installedNames = installedDependencyNames(dependencyTree);
       for (const name of ['react', 'react-dom', 'react-server-dom-rspack', 'rsbuild-plugin-rsc']) {

--- a/packages/agent-bundle/tests/support/packed-native-smoke.ts
+++ b/packages/agent-bundle/tests/support/packed-native-smoke.ts
@@ -15,6 +15,8 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
+// The native smoke installs the production closure a real consumer would get,
+// so it stays on npm's default metadata staleness checks.
 import { npmInstallArguments } from './shared-pack.ts';
 
 const execFile = promisify(executeFile);

--- a/packages/agent-bundle/tests/support/packed-native-smoke.ts
+++ b/packages/agent-bundle/tests/support/packed-native-smoke.ts
@@ -15,6 +15,8 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
+import { npmInstallArguments } from './shared-pack.ts';
+
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
 const packageRoot = join(workspaceRoot, 'packages', 'agent-bundle');
@@ -236,9 +238,7 @@ export const runPackedNativeSmoke = async (options: {
     const installed = await runNodeEntrypoint(npmEntrypoint, [
       'install',
       '--omit=dev',
-      '--ignore-scripts',
-      '--no-audit',
-      '--no-fund',
+      ...npmInstallArguments,
       join(tarballs, listing[0].filename),
     ], { cwd: consumer, environment });
     if (installed.exitCode !== 0) throw new Error('Packed native smoke could not install the release tarball.');

--- a/packages/agent-bundle/tests/support/shared-pack.ts
+++ b/packages/agent-bundle/tests/support/shared-pack.ts
@@ -28,14 +28,25 @@ export const installedEnvironment = (): NodeJS.ProcessEnv => {
 
 /**
  * Canonical flags for installing a packed tarball into a consumer fixture.
- * `--prefer-offline` serves cached registry metadata without revalidating it:
- * the tarball under test is always read from disk, and uncached dependencies
- * are still fetched, so only the staleness round-trips are skipped. The
- * release audit (scripts/audit-packed-release.mjs) deliberately does not use
- * these flags — its install feeds `npm audit`/`npm audit signatures`, which
- * must resolve against live registry metadata.
+ * They keep npm's default metadata staleness checks, so the install resolves
+ * the tree a consumer would get today. That is the point of the proofs that
+ * stand in for a real consumer — release-audit's production entrypoint walk,
+ * the scaffolder template matrix, the native host smoke — and exact direct
+ * pins do not make it free: transitive ranges still move underneath them, and
+ * scripts/audit-packed-release.mjs audits the installed tree without ever
+ * exercising it.
  */
-export const npmInstallArguments = ['--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'] as const;
+export const npmInstallArguments = ['--ignore-scripts', '--no-audit', '--no-fund'] as const;
+
+/**
+ * The same flags for suites that only prove the packed tarball resolves,
+ * imports, and runs, where the dependency tree is a means rather than the
+ * subject. `--prefer-offline` serves cached registry metadata without
+ * revalidating it: the tarball under test is always read from disk and
+ * uncached dependencies are still fetched, so only the staleness round-trips
+ * are skipped.
+ */
+export const cachedNpmInstallArguments = [...npmInstallArguments, '--prefer-offline'] as const;
 
 const packs = new Map<SharedPackPackage, Promise<SharedPack>>();
 let fallbackBuild: Promise<void> | undefined;

--- a/packages/agent-bundle/tests/support/shared-pack.ts
+++ b/packages/agent-bundle/tests/support/shared-pack.ts
@@ -26,8 +26,16 @@ export const installedEnvironment = (): NodeJS.ProcessEnv => {
   return environment;
 };
 
-/** Canonical flags for installing a packed tarball into a consumer fixture. */
-export const npmInstallArguments = ['--ignore-scripts', '--no-audit', '--no-fund'] as const;
+/**
+ * Canonical flags for installing a packed tarball into a consumer fixture.
+ * `--prefer-offline` serves cached registry metadata without revalidating it:
+ * the tarball under test is always read from disk, and uncached dependencies
+ * are still fetched, so only the staleness round-trips are skipped. The
+ * release audit (scripts/audit-packed-release.mjs) deliberately does not use
+ * these flags — its install feeds `npm audit`/`npm audit signatures`, which
+ * must resolve against live registry metadata.
+ */
+export const npmInstallArguments = ['--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'] as const;
 
 const packs = new Map<SharedPackPackage, Promise<SharedPack>>();
 let fallbackBuild: Promise<void> | undefined;

--- a/packages/create-agent-bundle/tests/support/scaffold-fixture.ts
+++ b/packages/create-agent-bundle/tests/support/scaffold-fixture.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { expect } from '@rstest/core';
 
-import { installedEnvironment, npmInstallArguments, sharedPackedTarball } from '../../../agent-bundle/tests/support/shared-pack.ts';
+import { cachedNpmInstallArguments, installedEnvironment, sharedPackedTarball } from '../../../agent-bundle/tests/support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 
@@ -36,7 +36,7 @@ const packFixture = async (): Promise<PackedFixture> => {
   const runnerRoot = join(root, 'runner');
   await mkdir(runnerRoot, { recursive: true });
   await writeFile(join(runnerRoot, 'package.json'), '{"name":"scaffold-runner","type":"module","private":true}\n');
-  await execFile('npm', ['install', ...npmInstallArguments, scaffolderTarball], {
+  await execFile('npm', ['install', ...cachedNpmInstallArguments, scaffolderTarball], {
     cwd: runnerRoot,
     env: installedEnvironment(),
   });

--- a/packages/workbench/tests/packed-release.e2e.test.ts
+++ b/packages/workbench/tests/packed-release.e2e.test.ts
@@ -14,7 +14,7 @@ import {
   validateOutageLedger,
   type ConsoleErrorRecord,
 } from './support/packed-outage-ledger.ts';
-import { npmInstallArguments, sharedPackedTarball } from '../../agent-bundle/tests/support/shared-pack.ts';
+import { cachedNpmInstallArguments, sharedPackedTarball } from '../../agent-bundle/tests/support/shared-pack.ts';
 import { timeScale } from '../../agent-bundle/tests/support/time-scale.ts';
 import {
   availablePort,
@@ -83,7 +83,7 @@ e2e('runs every Agent API tool from the installed tarball', { timeout: 360_000 *
   let primaryFailure: Error | undefined;
   try {
     await writeFile(join(consumer, 'package.json'), '{"type":"module"}\n');
-    await execFile('npm', ['install', '--omit=dev', ...npmInstallArguments, tarball], {
+    await execFile('npm', ['install', '--omit=dev', ...cachedNpmInstallArguments, tarball], {
       cwd: consumer,
       env: installedEnvironment(),
     });

--- a/scripts/audit-packed-release.mjs
+++ b/scripts/audit-packed-release.mjs
@@ -157,6 +157,10 @@ const auditPackedRelease = async () => {
       '--pack-destination', tarballs,
     ], { cwd: packageRoot, env: productionEnvironment })).stdout);
     const tarball = join(tarballs, asString(filename, 'npm pack did not produce a tarball filename'));
+    // No `--prefer-offline` here (unlike the packed test pool's shared install
+    // flags): the tree this install produces is what `npm audit`, `npm audit
+    // signatures`, and `npm sbom` below report on, so it has to resolve against
+    // live registry metadata rather than whatever the cache last saw.
     await execNpm([
       'install',
       '--omit=dev',

--- a/scripts/audit-packed-release.mjs
+++ b/scripts/audit-packed-release.mjs
@@ -157,10 +157,11 @@ const auditPackedRelease = async () => {
       '--pack-destination', tarballs,
     ], { cwd: packageRoot, env: productionEnvironment })).stdout);
     const tarball = join(tarballs, asString(filename, 'npm pack did not produce a tarball filename'));
-    // No `--prefer-offline` here (unlike the packed test pool's shared install
-    // flags): the tree this install produces is what `npm audit`, `npm audit
-    // signatures`, and `npm sbom` below report on, so it has to resolve against
-    // live registry metadata rather than whatever the cache last saw.
+    // No `--prefer-offline` here (unlike the packed pool's
+    // cachedNpmInstallArguments): the tree this install produces is what
+    // `npm audit`, `npm audit signatures`, and `npm sbom` below report on, so
+    // it has to resolve against live registry metadata rather than whatever
+    // the cache last saw.
     await execNpm([
       'install',
       '--omit=dev',


### PR DESCRIPTION
Follow-up to the npm-work inventory in #82: every pack-and-install fixture in the packed pool revalidated registry metadata on each `npm install`, even though the artifact under test is a local tarball.

## The split

`tests/support/shared-pack.ts` now exports two flag lists instead of one, so the choice is a documented decision at each site rather than a blanket policy:

- **`npmInstallArguments`** — unchanged flags, keeping npm's default metadata staleness checks. This stays the default a new test inherits.
- **`cachedNpmInstallArguments`** — the same flags plus `--prefer-offline`, for suites where the dependency tree is a means rather than the subject.

### Cache-first (`cachedNpmInstallArguments`)

| Site | Installs | Intent |
|---|---|---|
| `packed-consumer.test.ts` | 2 (concurrent) | Tarball hermeticity after the pack source is deleted |
| `public-api-packed.test.ts` | 3 | Packed producer manifest, externalized config entry, prebuilt MCP server |
| `dev-workbench-packaging.test.ts` | 2 | Prebuilt Workbench assets; omit-dev Agent API |
| `rsc-runtime-optional-packaging.test.ts` | 1 | RSC runtime absent from an ordinary install |
| `packed-release.e2e.test.ts` | 1 | Agent API tools from the installed tarball |
| `create-agent-bundle/tests/support/scaffold-fixture.ts` | 1 | Installed scaffolder bin (`create-agent-bundle` has no dependencies) |
| `cli.test.ts` | 1 | Packed CLI consumer (integration pool) |

### Kept on current metadata (`npmInstallArguments`)

- `release-audit.test.ts` — the functional counterpart of the audit: it installs the production closure, imports every public entrypoint, typechecks, and runs the CLI. It is the proof that stands in for a consumer installing today.
- `scaffold-packed-matrix.e2e.test.ts` — release-boundary only (`test:packed:release` and the nightly schedule); installs whole scaffolded projects.
- `tests/support/packed-native-smoke.ts` — installs the production closure and drives real Eval hosts.

Per Codex review: exact direct pins do not fix the installed tree, because transitive dependencies still carry ranges. Serving cached metadata everywhere would have let a newly published transitive version stay absent from every functional release proof, and `scripts/audit-packed-release.mjs` audits the installed tree without exercising it.

The two previously scattered copies of the flag literal now consume the helper instead of repeating it: `cli.test.ts`'s packed consumer and `packed-native-smoke.ts` (which spelled the same three flags one per line).

## Sites deliberately excluded

- **`scripts/audit-packed-release.mjs`** keeps its own flags. Its install produces the tree `npm audit`, `npm audit signatures`, `npm ls`, and `npm sbom` then report on, and the script serves `audit:release` at the publish boundary as well as the per-PR release-gates leg — a cache-served resolution would mean auditing and signature-verifying something other than what a consumer gets at publish time. A comment now records that so a future pass does not "fix" it.
- **The scaffolder's own install** (`create-agent-bundle/src/index.ts`, `spawn(packageManager, ['install'])`) is product behavior, not a test install: it runs in an end user's new project and the package manager may be pnpm, yarn, or bun. `scaffold-packed.e2e.test.ts`'s point is that this product path works, so it is untouched.
- **`scripts/local-ci.mjs`**'s `pnpm install --frozen-lockfile` mirrors the hosted matrix commands verbatim; deviating would defeat that job's purpose.

## Census proof

Per-PR packed pool, name-level diff of `pnpm test:packed --reporter=verbose` against main (39590cb5): 8 files, 21 tests (20 passed / 1 skipped), 28 reporter entries — **no additions, no removals, no status changes**, verified both before and after the split. The release pool via `check:release` is likewise unchanged at 22/23 passed, 1 skipped, 9 files.

## Measured delta — honest answer: below the noise floor with a warm cache

Pool-level timing cannot resolve an effect this size on this machine: back-to-back `pnpm test:packed` runs of *identical* main code came in at 250s and 170s, an 80s same-arm swing. So the lever was measured directly instead.

**Controlled same-worktree A/B** (build and pack done once and shared, only the flag toggled, arms alternating, most install-dense packed file at 3 installs), 6 pairs:

| Arm | Mean | Samples (s) |
|---|---|---|
| without `--prefer-offline` | 17.96s | 18.25, 18.17, 18.08, 17.62, 17.86, 17.79 |
| with `--prefer-offline` | 18.00s | 18.04, 18.21, 17.77, 17.94, 17.88, 18.16 |

A 0.04s difference inside a 0.6s spread: **no measurable win, and no regression.**

**Isolated install A/B** (`npm install <tarball>`, 5 iterations per arm, rotating order) explains why, and where the win actually lives:

| Arm | Median | Registry GETs |
|---|---|---|
| `--prefer-online` (revalidate everything — a stale or restored cache) | 5956ms | 222 |
| default | 4611ms | 0 when packuments are inside their max-age |
| `--prefer-offline` | 4499ms | 0 |

With a cache warmed minutes earlier, npm already skips revalidation, so `--prefer-offline` saves ~112ms per install (~2%). The real ceiling is the stale-cache case — a fresh runner, or any cache older than the registry max-age — where revalidation costs **222 registry requests and ~1.46s per install**, roughly 11s across the ten cache-first installs. That is the CI shape this targets, and it costs nothing in the warm case.

## Gate

Full `pnpm check:local-ci` (not `--current-node-only`, since this touches the release-gates leg): **GREEN** — Verify on Node 22/24/26 plus `examples:check`, `check:release`, and `eval:spot`.

Earlier attempts tripped three pre-existing load-sensitive flakes, none of which run an `npm install`: `overview.e2e.test.ts :: offers the host-owned MCP playground handoff...` (an extra `runtime-app-reload` generation frame — **reproduced 1-in-5 on unmodified main** under Node 26 in the same leg worktree), `mcp-app-real.e2e.test.ts` (browser sandbox URL), and `dev-watcher.test.ts` (chokidar coalescing a create event).

No changeset: test, support, and script layers only — nothing published changes.