### PR TITLE
ci: cache Playwright and cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,13 @@ on:
 permissions:
   contents: read
 
+# PR pushes cancel the superseded run of the same PR (only the latest commit
+# matters). Pushes to main, the nightly schedule, and manual dispatches get
+# SHA-keyed groups with no cancellation, so a new main push can never kill an
+# in-flight main or nightly run. Same pattern as package-preview.yml.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Builds and checks every public example through its own toolchain.
@@ -51,7 +55,20 @@ jobs:
           install: false
           runtime: node@${{ matrix.node-version }}
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chrome
+      # Tests launch branded Chrome (`channel: 'chrome'`), which Playwright
+      # installs system-wide via apt — never into ~/.cache/ms-playwright, so
+      # a browser cache cannot help. In CI, `playwright install chrome`
+      # unconditionally removes and re-downloads ~120 MB of Chrome per job,
+      # while ubuntu-latest images already ship Google Chrome stable with its
+      # OS deps. Reuse it; fall back to the full install (browser + deps) if
+      # the runner image ever drops it.
+      - name: Ensure branded Chrome for Playwright
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "Using preinstalled $(google-chrome --version)"
+          else
+            pnpm exec playwright install --with-deps chrome
+          fi
       # Build first: checked-in suites and API tests import the package's built type
       # declarations, so typecheck requires dist (same order as `pnpm check`).
       - run: pnpm build
@@ -74,7 +91,14 @@ jobs:
           install: false
           runtime: node@22.19.0
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chrome
+      # Reuse the runner image's Chrome; see the Verify job for the rationale.
+      - name: Ensure branded Chrome for Playwright
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "Using preinstalled $(google-chrome --version)"
+          else
+            pnpm exec playwright install --with-deps chrome
+          fi
       # Per-PR packed pool: single pack+install proofs plus the
       # minimal-template scaffolder smoke. The full template matrix runs in
       # the nightly packed-matrix job and in pre-publish `pnpm check:release`.
@@ -95,7 +119,14 @@ jobs:
           install: false
           runtime: node@22.19.0
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chrome
+      # Reuse the runner image's Chrome; see the Verify job for the rationale.
+      - name: Ensure branded Chrome for Playwright
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "Using preinstalled $(google-chrome --version)"
+          else
+            pnpm exec playwright install --with-deps chrome
+          fi
       - run: pnpm check:release
 
   rsc-runtime-micro-eval:

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -100,14 +100,15 @@ never lets it drop below what its own pool shape requires.
   publish-side effects, not checks; nothing about them gates a merge.
 - **native-host-smoke** needs signed-in Claude/Codex CLIs and is opt-in even
   on hosted CI.
-- **Environment skew**: hosted runners are `ubuntu-latest` with the exact
-  glibc/OS package set `--with-deps` installs, and hosted Verify installs
-  branded Chrome fresh. A green local run on a different distro, glibc, or
-  Chrome build is strong but not identical evidence — this is the main
-  reason hosted CI remains the post-merge safety net. The local `browsers`
-  step only validates/installs the browser itself (`playwright install
-  chrome`); the OS dependencies (`--with-deps`) are one-time machine setup
-  and may need root.
+- **Environment skew**: hosted runners are `ubuntu-latest`, and hosted jobs
+  use the Google Chrome stable that ships preinstalled (with its OS
+  dependencies) on the runner image, falling back to
+  `playwright install --with-deps chrome` only if the image ever drops it. A
+  green local run on a different distro, glibc, or Chrome build is strong but
+  not identical evidence — this is the main reason hosted CI remains the
+  post-merge safety net. The local `browsers` step only validates/installs
+  the browser itself (`playwright install chrome`); the OS dependencies
+  (`--with-deps`) are one-time machine setup and may need root.
 - **Job isolation**: hosted gives every job a fresh VM; local legs reuse
   worktrees for speed. `--fresh` restores cold-start fidelity when staleness
   is suspected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Concurrency: cancel superseded PR runs, never main or nightly

`ci.yml` grouped concurrency by `github.ref`, so a push to `main` cancelled the previous in-flight `main` CI run. It now uses the same pattern as `package-preview.yml`:

```yaml
concurrency:
  group: ci-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **Pull requests** group by PR number with `cancel-in-progress: true`, so pushing a new commit cancels the superseded run of that PR only.
- **Main pushes, the nightly schedule, and manual dispatches** group by SHA with no cancellation, so a new main push can never kill another main or nightly run.

`package-preview.yml` already cancels superseded PR previews and SHA-keys main, `release.yml`'s `package-release` group without cancel is correct for a publish, and `native-host-smoke.yml` is manual-dispatch on self-hosted — all three are unchanged.

## Browser install: reuse preinstalled Chrome instead of re-downloading

Every test that drives a browser launches **branded Chrome** (`channel: 'chrome'`). Playwright installs branded channels system-wide via apt — never into `~/.cache/ms-playwright` — so an `actions/cache` entry for the Playwright browsers directory would sit empty here. The actual waste: in CI (`CI=true`), `playwright install chrome` skips its "already installed" short-circuit and runs `reinstall_chrome_stable_linux.sh`, which removes the runner's Chrome, runs `apt-get update`, and re-downloads ~120 MB from `dl.google.com` — in each of the three `verify` legs, `release-gates`, and nightly `packed-matrix`.

`ubuntu-latest` images ship Google Chrome stable (with its OS dependencies) preinstalled, which is exactly what `channel: 'chrome'` launches. Those jobs now use it when present and fall back to the full `pnpm exec playwright install --with-deps chrome` (browser + OS deps) only if the runner image ever drops Chrome.

pnpm store caching via `pnpm/setup@v2` `cache: true` was already in place on every job and is kept as-is. The repo has no turbo or other build cache to wire up, and `node_modules` is intentionally not cached so it doesn't fight pnpm's store cache.

## Unchanged on purpose

- Node 22.19 / 24 / 26 verify matrix, `examples-check`, `release-gates`, `rsc-runtime-micro-eval`, `dependency-review`, and the nightly `packed-matrix` all run exactly as before; `fail-fast: false` and all timeouts stay.
- `docs/local-ci.md`'s environment-skew note is updated to describe the new hosted Chrome behavior.
- No changeset: workflow/docs-only change, no published package changes.

All four workflows pass `actionlint` v1.7.12.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fc8e34f-c695-47f8-afbc-5b0773e1bf29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fc8e34f-c695-47f8-afbc-5b0773e1bf29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

