### PR TITLE
test: retry known flaky cases per #122

### DIFF
--- a/packages/agent-bundle/tests/dev-watcher.test.ts
+++ b/packages/agent-bundle/tests/dev-watcher.test.ts
@@ -85,7 +85,8 @@ it('debounces only relevant source paths into one ordered invalidation and close
   expect(invalidations).toHaveLength(1);
 });
 
-it('waits for the real watcher root before reporting create, change, and delete source inputs', async () => {
+// Flaky under full-pool load (chokidar create-event coalescing, #122); retry while the root cause stays open.
+it('waits for the real watcher root before reporting create, change, and delete source inputs', { retry: 2 }, async () => {
   const root = await mkdtemp(join(tmpdir(), 'agent-bundle-real-watcher-'));
   await mkdir(join(root, 'src'), { recursive: true });
   await writeFile(join(root, 'src', 'existing.ts'), 'export const value = 1;\n');

--- a/packages/workbench/tests/mcp-app-real.e2e.test.ts
+++ b/packages/workbench/tests/mcp-app-real.e2e.test.ts
@@ -455,7 +455,8 @@ e2e('runs a generated SDK-v2 App through the real foreground session and separat
   if (cleanupFailure !== undefined) throw cleanupFailure;
 });
 
-e2e('opens the real RSC runtime timeline App from provider-owned run evidence', { timeout: 120_000 }, async ({ page }) => {
+// Flaky under gate load (expect.poll budget, #122); retry while the root cause stays open.
+e2e('opens the real RSC runtime timeline App from provider-owned run evidence', { retry: 2, timeout: 120_000 }, async ({ page }) => {
   const fixture = await startRuntimePlaygroundFixture({
     prepare: async ({ root }) => {
       const definitionSource = join(root, 'src', 'definition.ts');


### PR DESCRIPTION
## Summary

Adds per-test rstest retries (`{ retry: 2 }`) to the two load-sensitive flakes tracked in #122, each annotated with a one-line comment. Root causes stay open; this only mitigates the gate noise.

- `packages/agent-bundle/tests/dev-watcher.test.ts` :: `waits for the real watcher root before reporting create, change, and delete source inputs` (chokidar create-event coalescing under full-pool load)
- `packages/workbench/tests/mcp-app-real.e2e.test.ts` :: `opens the real RSC runtime timeline App from provider-owned run evidence` (`expect.poll` budget under gate load; `retry: 2` merged into the existing `{ timeout: 120_000 }` options)

No changeset (test-only). Refs #122 — do not close.

## Test plan

- [x] `pnpm exec rstest --config rstest.config.ts packages/agent-bundle/tests/dev-watcher.test.ts packages/workbench/tests/mcp-app-real.e2e.test.ts` — 2 files, 6 tests, all passed