### PR TITLE
feat!: rename the renderer package to @agent-bundle/runtime

### DIFF
--- a/.changeset/clarify-rsc-runtime-not-rsc.md
+++ b/.changeset/clarify-rsc-runtime-not-rsc.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": patch
+"@agent-bundle/runtime": patch
 ---
 
 Docs-only clarification of the operation/JSX model (#88). The published

--- a/.changeset/deslop-wave1-delta.md
+++ b/.changeset/deslop-wave1-delta.md
@@ -1,6 +1,6 @@
 ---
 'agent-bundle': patch
-'@agent-bundle/rsc-runtime': patch
+'@agent-bundle/runtime': patch
 ---
 
 Deslop pass over the Wave 1 delta: `config/normalize.ts` reuses the shared `core/freeze.ts` `deepFreeze` instead of a local copy, the internal `configClaimedSources` helper is no longer exported, the dev-lock URL publication settles through one named cleanup, and the rsc-runtime CLI binding drops a redundant `Object.freeze` (the request store snapshots and freezes capabilities itself). No behavior changes.

--- a/.changeset/framework-mode-rsc-runtime.md
+++ b/.changeset/framework-mode-rsc-runtime.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": minor
+"@agent-bundle/runtime": minor
 ---
 
 Framework mode (RFC #63), runtime side — **breaking removals**. The

--- a/.changeset/fresh-runtimes-curate.md
+++ b/.changeset/fresh-runtimes-curate.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": minor
+"@agent-bundle/runtime": minor
 "agent-bundle": patch
 ---
 

--- a/.changeset/lower-mcp-undefined-wire-semantics.md
+++ b/.changeset/lower-mcp-undefined-wire-semantics.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": patch
+"@agent-bundle/runtime": patch
 ---
 
 `lowerMcpResult` now follows MCP SDK wire semantics for `undefined` inside

--- a/.changeset/rename-rsc-runtime-package.md
+++ b/.changeset/rename-rsc-runtime-package.md
@@ -1,0 +1,7 @@
+---
+"@agent-bundle/runtime": minor
+---
+
+Rename the preview runtime package from `@agent-bundle/rsc-runtime` to
+`@agent-bundle/runtime`. Update workspace consumers, documentation, paired
+pkg.pr.new URL derivation, and preview publishing guidance for the new name.

--- a/.changeset/request-store-agent.md
+++ b/.changeset/request-store-agent.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": minor
+"@agent-bundle/runtime": minor
 ---
 
 Add the versioned realm-singleton request store, `await agent()`, and

--- a/.changeset/rsc-mcp-app-element.md
+++ b/.changeset/rsc-mcp-app-element.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": minor
+"@agent-bundle/runtime": minor
 ---
 
 `defineRscAgentBundle` element trees can declare MCP Apps first-class:

--- a/.changeset/rsc-mcp-listing-title-meta.md
+++ b/.changeset/rsc-mcp-listing-title-meta.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": minor
+"@agent-bundle/runtime": minor
 ---
 
 `RscMcpDefinition` gains optional listing-level `title` and `_meta` slots;

--- a/.changeset/rsc-runtime-drop-rsc-keyword.md
+++ b/.changeset/rsc-runtime-drop-rsc-keyword.md
@@ -1,5 +1,5 @@
 ---
-"@agent-bundle/rsc-runtime": patch
+"@agent-bundle/runtime": patch
 ---
 
 Published-metadata fix: the `react-server-components` keyword is removed from

--- a/docs/entry-conventions.md
+++ b/docs/entry-conventions.md
@@ -103,7 +103,7 @@ the framework lifecycle:
 
 ```ts
 // src/mcp/curator.ts — the whole stdio entry a consumer writes
-import { createRscMcpServer } from '@agent-bundle/rsc-runtime/plugin';
+import { createRscMcpServer } from '@agent-bundle/runtime/plugin';
 import { application } from '../application.js';
 
 export default () => createRscMcpServer(application, 'curator');

--- a/docs/framework-mode.md
+++ b/docs/framework-mode.md
@@ -68,8 +68,8 @@ like this in full, including the JSX:
 
 ```tsx
 // src/operations/status.tsx
-import { defineOperation } from '@agent-bundle/rsc-runtime/plugin';
-import { Mcp } from '@agent-bundle/rsc-runtime';
+import { defineOperation } from '@agent-bundle/runtime/plugin';
+import { Mcp } from '@agent-bundle/runtime';
 import { z } from 'zod';
 
 export const status = defineOperation({
@@ -122,12 +122,11 @@ validation cannot drift between surfaces. Only the last step differs:
   lowering is strict — `Mcp.Text` takes exactly one string child, hence the
   template literal above.
 
-## Why `.tsx`, and what "RSC runtime" is not
+## Why `.tsx`, and current renderer status
 
-Despite the package name, `@agent-bundle/rsc-runtime` is **not a React
-Server Components renderer or runtime, and no Flight transport is
-involved**. Nothing streams a component tree to a client, hydrates, or
-holds server component state. What the MCP projection uses is an **MCP
+`@agent-bundle/runtime` does **not yet execute React Server Components or
+Flight**. Its current compatibility lowerers do not stream a component tree,
+hydrate, or hold server component state. What the MCP projection uses is an **MCP
 result DSL**: `render` returns ordinary React elements, and
 `lowerMcpResult` walks that tree synchronously — function components are
 simply called — to produce the `CallToolResult` the MCP SDK sends. The

--- a/docs/preview-packages.md
+++ b/docs/preview-packages.md
@@ -5,7 +5,7 @@ placeholders, and npm publishing is deferred until the final name is chosen
 (it will then use [npm package provenance](https://docs.npmjs.com/generating-provenance-statements);
 the manifests and release workflow are already wired for it). Until then
 pkg.pr.new is the release channel. Every CI package-preview run publishes real,
-installable tarballs of both workspace packages to [pkg.pr.new](https://pkg.pr.new)
+installable tarballs of all three publishable workspace packages to [pkg.pr.new](https://pkg.pr.new)
 — a free continuous-release registry keyed by commit SHA and pull request.
 These are the packages to install until a first npm release is cut.
 
@@ -15,7 +15,7 @@ Reference a pull request number to track its most recent build:
 
 ```sh
 npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@1
-npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/rsc-runtime@1
+npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/runtime@1
 ```
 
 The `create-agent-bundle` scaffolder is published to the same channel and is
@@ -39,13 +39,13 @@ work), which is the right form for lockfiles and reproducible setups:
 
 ```sh
 npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@5685521
-npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/rsc-runtime@5685521
+npm i https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/runtime@5685521
 ```
 
 pnpm and yarn accept the same URLs (`pnpm add <url>`, `yarn add agent-bundle@<url>`).
 
 Previews carry the version string `0.0.0-preview-<sha>`, and the publish
-rewrites the `agent-bundle` peer range inside the `@agent-bundle/rsc-runtime`
+rewrites the `agent-bundle` peer range inside the `@agent-bundle/runtime`
 preview tarball to that exact preview version (`--peerDeps`). Installing both
 packages from the same sha therefore works with stock npm — no
 `--legacy-peer-deps` needed. Mixing two different shas fails with `ERESOLVE`
@@ -58,7 +58,8 @@ still requires `--legacy-peer-deps`.
 
 `.github/workflows/package-preview.yml` runs
 `pnpm preview:publish` (`pkg-pr-new publish --previewVersion --peerDeps
---no-compact --no-template './packages/agent-bundle' './packages/rsc-runtime'`)
+--no-compact --no-template './packages/agent-bundle' './packages/rsc-runtime'
+'./packages/create-agent-bundle'`)
 after a full build, on every pull request and on every push to `main`. Runs for
 `main` pushes use a per-commit concurrency group, so overlapping pushes
 cannot cancel one another and every `main` commit has an installable

--- a/examples/audiobook-curator/README.md
+++ b/examples/audiobook-curator/README.md
@@ -45,7 +45,7 @@ outputs beneath `artifact/` (each host's plugin metadata, Skill, bundled CLI
 script, and lifecycle-wrapped MCP server) plus the npm package build beneath
 `dist/` (`dist/bin/audiobook-curator.js` for `package.json` `bin`,
 `dist/index.js` and declarations for `exports`). The example uses only public
-`agent-bundle` and `@agent-bundle/rsc-runtime` exports with `workspace:*`
+`agent-bundle` and `@agent-bundle/runtime` exports with `workspace:*`
 dependencies.
 
 ## Operation model

--- a/examples/audiobook-curator/package.json
+++ b/examples/audiobook-curator/package.json
@@ -29,7 +29,7 @@
     "validate": "agent-bundle validate"
   },
   "dependencies": {
-    "@agent-bundle/rsc-runtime": "workspace:*",
+    "@agent-bundle/runtime": "workspace:*",
     "@modelcontextprotocol/server": "2.0.0",
     "react": "19.2.8",
     "zod": "4.4.3"

--- a/examples/audiobook-curator/src/application.ts
+++ b/examples/audiobook-curator/src/application.ts
@@ -7,7 +7,7 @@
  * runtime JSX is each operation's `render`, which delegates to
  * `<CuratorResult>` in `./result.tsx` for the MCP projection.
  */
-import { defineRscApplication } from '@agent-bundle/rsc-runtime/plugin';
+import { defineRscApplication } from '@agent-bundle/runtime/plugin';
 
 import {
   audibleOperations,

--- a/examples/audiobook-curator/src/cli.ts
+++ b/examples/audiobook-curator/src/cli.ts
@@ -1,4 +1,4 @@
-import { runRscCli } from '@agent-bundle/rsc-runtime/plugin';
+import { runRscCli } from '@agent-bundle/runtime/plugin';
 
 import {
   createAudiobookCuratorApplication,

--- a/examples/audiobook-curator/src/mcp/curator.ts
+++ b/examples/audiobook-curator/src/mcp/curator.ts
@@ -1,4 +1,4 @@
-import { createRscMcpServer } from '@agent-bundle/rsc-runtime/plugin';
+import { createRscMcpServer } from '@agent-bundle/runtime/plugin';
 
 import { audiobookCuratorApplication } from '../application.js';
 

--- a/examples/audiobook-curator/src/operations/audible.tsx
+++ b/examples/audiobook-curator/src/operations/audible.tsx
@@ -3,7 +3,7 @@
  * and `audible-cache`, backed by `../audible.ts`. Ranking is evidence only;
  * `audible-select` records the required human edition choice.
  */
-import { defineOperation, type RscOperationContext } from '@agent-bundle/rsc-runtime/plugin';
+import { defineOperation, type RscOperationContext } from '@agent-bundle/runtime/plugin';
 import React from 'react';
 import { z } from 'zod';
 

--- a/examples/audiobook-curator/src/operations/discovery.tsx
+++ b/examples/audiobook-curator/src/operations/discovery.tsx
@@ -3,7 +3,7 @@
  * `library-audit`, and `select`, backed by `../curator-core.ts` and
  * `../library.ts`. All four retain evidence and never mutate media.
  */
-import { defineOperation, type RscOperationContext } from '@agent-bundle/rsc-runtime/plugin';
+import { defineOperation, type RscOperationContext } from '@agent-bundle/runtime/plugin';
 import React from 'react';
 import { z } from 'zod';
 

--- a/examples/audiobook-curator/src/operations/evidence.tsx
+++ b/examples/audiobook-curator/src/operations/evidence.tsx
@@ -2,7 +2,7 @@
  * Acoustic and transcript identity-evidence operations: `acoustic-verify`,
  * `acoustic-identify`, and `whisper-verify`, backed by `../evidence.ts`.
  */
-import { defineOperation, type RscOperationContext } from '@agent-bundle/rsc-runtime/plugin';
+import { defineOperation, type RscOperationContext } from '@agent-bundle/runtime/plugin';
 import React from 'react';
 import { z } from 'zod';
 

--- a/examples/audiobook-curator/src/operations/media-mutation.tsx
+++ b/examples/audiobook-curator/src/operations/media-mutation.tsx
@@ -2,7 +2,7 @@
  * Plan-first derived-media repair operations: `apply-metadata` and
  * `apply-chapters`, backed by `../media-mutation.ts`.
  */
-import { defineOperation, type RscOperationContext } from '@agent-bundle/rsc-runtime/plugin';
+import { defineOperation, type RscOperationContext } from '@agent-bundle/runtime/plugin';
 import React from 'react';
 import { z } from 'zod';
 

--- a/examples/audiobook-curator/src/operations/output.tsx
+++ b/examples/audiobook-curator/src/operations/output.tsx
@@ -4,7 +4,7 @@
  * `../integrity-audit.ts`. Conversion and preparation plan by default and
  * mutate only a derived destination; the audit never mutates.
  */
-import { defineOperation, type RscOperationContext } from '@agent-bundle/rsc-runtime/plugin';
+import { defineOperation, type RscOperationContext } from '@agent-bundle/runtime/plugin';
 import React from 'react';
 import { z } from 'zod';
 

--- a/examples/audiobook-curator/src/result.tsx
+++ b/examples/audiobook-curator/src/result.tsx
@@ -6,7 +6,7 @@
  * transport is involved, and the CLI projection never calls it (it prints
  * the validated receipt as JSON instead).
  */
-import { Mcp } from '@agent-bundle/rsc-runtime';
+import { Mcp } from '@agent-bundle/runtime';
 import React from 'react';
 
 import type { AudibleCacheReceipt, AudibleSearchReceipt, AudibleSelectionReceipt } from './audible.ts';

--- a/examples/audiobook-curator/tests/application.test.ts
+++ b/examples/audiobook-curator/tests/application.test.ts
@@ -1,4 +1,4 @@
-import { lowerMcpResult } from '@agent-bundle/rsc-runtime';
+import { lowerMcpResult } from '@agent-bundle/runtime';
 import { describe, expect, it } from '@rstest/core';
 
 import maybeFactoryConfig from '../agent-bundle.config.ts';

--- a/examples/rsc-agent-runtime/README.md
+++ b/examples/rsc-agent-runtime/README.md
@@ -15,7 +15,7 @@ Native hooks are fresh requests: a process normalizes one host event, invokes th
 
 ```tsx
 // A Hook JSX route reads request-scoped context.
-import { Hook, agent } from '@agent-bundle/rsc-runtime';
+import { Hook, agent } from '@agent-bundle/runtime';
 import type { CanonicalPostToolUse, RuntimeSnapshot } from '../runtime/contracts.js';
 
 export async function AfterFileEdit() {
@@ -34,7 +34,7 @@ export async function AfterFileEdit() {
 
 ```tsx
 // An MCP JSX route describes protocol blocks, not browser HTML.
-import { Mcp } from '@agent-bundle/rsc-runtime';
+import { Mcp } from '@agent-bundle/runtime';
 
 export function RenderTimeline({ snapshot }: { snapshot: { edits: unknown[]; stateVersion: number } }) {
   return (

--- a/examples/rsc-agent-runtime/package.json
+++ b/examples/rsc-agent-runtime/package.json
@@ -12,7 +12,7 @@
     "capture:widget": "node scripts/capture-widget.mjs"
   },
   "dependencies": {
-    "@agent-bundle/rsc-runtime": "workspace:*",
+    "@agent-bundle/runtime": "workspace:*",
     "@modelcontextprotocol/ext-apps": "1.7.5",
     "@modelcontextprotocol/sdk": "1.30.0",
     "express": "5.2.1",

--- a/examples/rsc-agent-runtime/src/dev/invocation-worker.ts
+++ b/examples/rsc-agent-runtime/src/dev/invocation-worker.ts
@@ -1,6 +1,6 @@
 import { requestFlightRenderWithFlight } from '../flight/request-render.js';
 import { writeSync } from 'node:fs';
-import { lowerHookResult, lowerMcpResult } from '@agent-bundle/rsc-runtime';
+import { lowerHookResult, lowerMcpResult } from '@agent-bundle/runtime';
 import type {
   DevRuntimeInspectionRequest,
   DevRuntimeInspectionResponse,

--- a/examples/rsc-agent-runtime/src/hook/cli.ts
+++ b/examples/rsc-agent-runtime/src/hook/cli.ts
@@ -2,7 +2,7 @@ import { appendFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { requestFlightRender } from '../flight/request-render.js';
-import { lowerHookResult } from '@agent-bundle/rsc-runtime';
+import { lowerHookResult } from '@agent-bundle/runtime';
 import { resolveImplicitRuntimeStateFile } from '../runtime/state-file.js';
 import { normalizeClaudeHook, normalizeCodexHook } from './normalize.js';
 

--- a/examples/rsc-agent-runtime/src/mcp/handlers.ts
+++ b/examples/rsc-agent-runtime/src/mcp/handlers.ts
@@ -1,5 +1,5 @@
 import { createFileRuntimeKernel } from '../runtime/state-file.js';
-import { lowerMcpResult } from '@agent-bundle/rsc-runtime';
+import { lowerMcpResult } from '@agent-bundle/runtime';
 import { requestFlightRender } from '../flight/request-render.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 

--- a/examples/rsc-agent-runtime/src/rsc/components.tsx
+++ b/examples/rsc-agent-runtime/src/rsc/components.tsx
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 
-import { Hook, Mcp, agent } from '@agent-bundle/rsc-runtime';
+import { Hook, Mcp, agent } from '@agent-bundle/runtime';
 import type { CanonicalPostToolUse, RuntimeSnapshot } from '../runtime/contracts.js';
 
 const hookServices = async (): Promise<{ edit: CanonicalPostToolUse; snapshot: RuntimeSnapshot }> => {

--- a/examples/rsc-agent-runtime/src/rsc/worker.tsx
+++ b/examples/rsc-agent-runtime/src/rsc/worker.tsx
@@ -3,7 +3,7 @@ import { finished } from 'node:stream/promises';
 import { resolve } from 'node:path';
 import { writeSync } from 'node:fs';
 
-import { available, runAgentRequest } from '@agent-bundle/rsc-runtime';
+import { available, runAgentRequest } from '@agent-bundle/runtime';
 import { renderToReadableStream } from 'react-server-dom-rspack/server.node';
 
 import type { CanonicalPostToolUse, RenderRequest, RuntimeSnapshot } from '../runtime/contracts.js';

--- a/examples/rsc-agent-runtime/tests/mcp-lowering.test.tsx
+++ b/examples/rsc-agent-runtime/tests/mcp-lowering.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from '@rstest/core';
 import React from 'react';
 
-import { Mcp, lowerMcpResult } from '@agent-bundle/rsc-runtime';
+import { Mcp, lowerMcpResult } from '@agent-bundle/runtime';
 
 test('lowers every supported MCP result block in authored order', () => {
   const result = lowerMcpResult(

--- a/examples/rsc-agent-runtime/tests/support/copy-example.ts
+++ b/examples/rsc-agent-runtime/tests/support/copy-example.ts
@@ -9,7 +9,7 @@ export interface CopiedExample {
 
 /**
  * Copies the example into a temporary workspace shaped like the repository.
- * The example's direct dependencies (zod, @agent-bundle/rsc-runtime) live in
+ * The example's direct dependencies (zod, @agent-bundle/runtime) live in
  * its own node_modules, not the workspace root's hoisted set, so the copy
  * links both.
  */

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "packageManager": "pnpm@11.23.0",
   "scripts": {
-    "build": "pnpm --filter agent-bundle build && pnpm --filter @agent-bundle/rsc-runtime build && pnpm --filter create-agent-bundle build",
-    "lint:package": "publint packages/agent-bundle && publint packages/create-agent-bundle",
+    "build": "pnpm --filter agent-bundle build && pnpm --filter @agent-bundle/runtime build && pnpm --filter create-agent-bundle build",
+    "lint:package": "publint packages/agent-bundle && publint packages/rsc-runtime && publint packages/create-agent-bundle",
     "test": "pnpm test:unit && pnpm test:integration",
     "test:unit": "rstest --config rstest.unit.config.ts",
     "test:integration": "pnpm build && pnpm test:integration:run",

--- a/packages/create-agent-bundle/src/framework.ts
+++ b/packages/create-agent-bundle/src/framework.ts
@@ -2,8 +2,12 @@ import { UsageError } from './options.ts';
 
 const previewPattern = /-preview-([0-9a-f]{7,40})$/u;
 
-export const previewFrameworkSpec = (sha: string): string =>
-  `https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@${sha}`;
+export type PreviewPackageName = 'agent-bundle' | '@agent-bundle/runtime' | 'create-agent-bundle';
+
+export const previewPackageSpec = (packageName: PreviewPackageName, sha: string): string =>
+  `https://pkg.pr.new/ScriptedAlchemy/agent-bundle/${packageName}@${sha}`;
+
+export const previewFrameworkSpec = (sha: string): string => previewPackageSpec('agent-bundle', sha);
 
 /**
  * Resolve the dependency spec the scaffolded project pins `agent-bundle` to.

--- a/packages/create-agent-bundle/tests/framework.test.ts
+++ b/packages/create-agent-bundle/tests/framework.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from '@rstest/core';
 
-import { resolveFrameworkSpec } from '../src/framework.ts';
+import { previewPackageSpec, resolveFrameworkSpec } from '../src/framework.ts';
 import { UsageError } from '../src/options.ts';
+
+describe('previewPackageSpec', () => {
+  it('derives the renamed runtime pkg.pr.new URL', () => {
+    expect(previewPackageSpec('@agent-bundle/runtime', 'da5df1d'))
+      .toBe('https://pkg.pr.new/ScriptedAlchemy/agent-bundle/@agent-bundle/runtime@da5df1d');
+  });
+});
 
 describe('resolveFrameworkSpec', () => {
   it('derives the paired pkg.pr.new preview from the scaffolder preview version', () => {

--- a/packages/rsc-runtime/README.md
+++ b/packages/rsc-runtime/README.md
@@ -1,12 +1,12 @@
-# `@agent-bundle/rsc-runtime`
+# `@agent-bundle/runtime`
 
 Small React primitives for producing Agent Bundle hook and MCP protocol results with JSX.
 No npm release is cut yet; install the pkg.pr.new preview of any `main` commit or pull
 request — see [Preview packages](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/docs/preview-packages.md).
 
-Despite the name, this package is **not a React Server Components renderer
-or runtime, and no Flight transport is involved**. It is a synchronous
-React-element protocol DSL — an *MCP result DSL*: `lowerMcpResult` walks an
+The runtime package does **not yet execute React Server Components or
+Flight**. Its current lowerers form a synchronous React-element protocol DSL —
+an *MCP result DSL*: `lowerMcpResult` walks an
 element tree, calling your function components as it goes, and lowers it
 into a plain MCP `CallToolResult`. `lowerHookResult` lowers a `Hook.Result`
 tree into a native `PostToolUse` output the same way, except that it
@@ -15,7 +15,7 @@ your own component is rejected. Nothing streams components, hydrates, or
 holds server component state.
 
 ```tsx
-import { Mcp, lowerMcpResult } from '@agent-bundle/rsc-runtime';
+import { Mcp, lowerMcpResult } from '@agent-bundle/runtime';
 
 const result = lowerMcpResult(
   <Mcp.Result structuredContent={{ status: 'ready' }}>
@@ -52,13 +52,13 @@ Structure — targets, skills, scripts, MCP servers, MCP apps — lives in
 `agent-bundle.config.ts` and file conventions; JSX renders. That split is the
 whole authoring model, described on one screen in
 [Framework mode](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/docs/framework-mode.md).
-The `@agent-bundle/rsc-runtime/plugin` entry defines the application's runtime
+The `@agent-bundle/runtime/plugin` entry defines the application's runtime
 identity and typed operation catalog once and derives its CLI commands and
 MCP tool registrations from that one registry:
 
 ```tsx
-import { defineOperation, defineRscApplication } from '@agent-bundle/rsc-runtime/plugin';
-import { Mcp } from '@agent-bundle/rsc-runtime';
+import { defineOperation, defineRscApplication } from '@agent-bundle/runtime/plugin';
+import { Mcp } from '@agent-bundle/runtime';
 import { z } from 'zod';
 
 const inputSchema = z.object({}).strict();

--- a/packages/rsc-runtime/package.json
+++ b/packages/rsc-runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-bundle/rsc-runtime",
+  "name": "@agent-bundle/runtime",
   "version": "0.0.0",
   "description": "React-element result primitives (an MCP result DSL) for Agent Bundle hook and MCP protocol results.",
   "license": "MIT",

--- a/packages/rsc-runtime/src/agent-request.ts
+++ b/packages/rsc-runtime/src/agent-request.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 export const AGENT_REQUEST_STORE_VERSION = 1;
 
-const STORE_SYMBOL = Symbol.for('@agent-bundle/rsc-runtime/request-store');
+const STORE_SYMBOL = Symbol.for('@agent-bundle/runtime/request-store');
 
 export type AgentInvocationKind = 'tool' | 'event' | 'cli' | 'script' | 'workbench';
 
@@ -231,7 +231,7 @@ const getStore = (): RealmStore => {
     if (existing.version !== AGENT_REQUEST_STORE_VERSION) {
       throw new AgentRequestError(
         'store-version-conflict',
-        `Incompatible @agent-bundle/rsc-runtime request store version: found ${String(existing.version)}, expected ${String(AGENT_REQUEST_STORE_VERSION)}`,
+        `Incompatible @agent-bundle/runtime request store version: found ${String(existing.version)}, expected ${String(AGENT_REQUEST_STORE_VERSION)}`,
       );
     }
     return existing;

--- a/packages/rsc-runtime/tests/agent-request.test.ts
+++ b/packages/rsc-runtime/tests/agent-request.test.ts
@@ -22,7 +22,7 @@ import {
   runAgentRequest as pluginRunAgentRequest,
 } from '../src/plugin.js';
 
-const STORE_SYMBOL = Symbol.for('@agent-bundle/rsc-runtime/request-store');
+const STORE_SYMBOL = Symbol.for('@agent-bundle/runtime/request-store');
 
 const init = (kind: 'tool' | 'event' | 'cli' | 'script' | 'workbench', id?: string) => ({
   invocation: { ...(id === undefined ? {} : { id }), kind },

--- a/packages/rsc-runtime/tests/runtime.test.ts
+++ b/packages/rsc-runtime/tests/runtime.test.ts
@@ -9,7 +9,7 @@ import {
   lowerMcpResult,
 } from '../src/index.js';
 
-describe('@agent-bundle/rsc-runtime', () => {
+describe('@agent-bundle/runtime', () => {
   it('lowers one Hook result', () => {
     expect(lowerHookResult(
       createElement(Hook.Result, null, createElement(Hook.AdditionalContext, null, 'ready')),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
 
   examples/audiobook-curator:
     dependencies:
-      '@agent-bundle/rsc-runtime':
+      '@agent-bundle/runtime':
         specifier: workspace:*
         version: link:../../packages/rsc-runtime
       '@modelcontextprotocol/server':
@@ -117,7 +117,7 @@ importers:
 
   examples/rsc-agent-runtime:
     dependencies:
-      '@agent-bundle/rsc-runtime':
+      '@agent-bundle/runtime':
         specifier: workspace:*
         version: link:../../packages/rsc-runtime
       '@modelcontextprotocol/ext-apps':


### PR DESCRIPTION
## Summary
- rename the preview package and all active workspace consumers to `@agent-bundle/runtime`
- update pending changesets, docs, and the realm request-store identity for the clean G2 break
- teach create-agent-bundle's paired preview URL helper the renamed runtime package and include runtime in package linting

## Test plan
- [x] `pnpm exec rstest --config rstest.unit.config.ts packages/create-agent-bundle/tests/framework.test.ts packages/rsc-runtime/tests` (38 passed)
- [x] `pnpm --filter @agent-bundle/runtime typecheck`
- [x] `pnpm --filter create-agent-bundle typecheck`
- [x] `pnpm --filter @agent-bundle-example/audiobook-curator typecheck`
- [x] `pnpm --filter @agent-bundle/rsc-agent-runtime-demo typecheck`
- [x] focused rslint and `publint packages/rsc-runtime`

Closes the G2 rename slice of #107. Part of #96.