### PR TITLE
feat(state): #98 v1 kernel contract, memory driver, conformance suite (PR-1)

### DIFF
--- a/.changeset/state-kernel-contract.md
+++ b/.changeset/state-kernel-contract.md
@@ -1,0 +1,14 @@
+---
+"@agent-bundle/runtime": minor
+---
+
+Add the optional Agent state kernel contract (#98 v1) behind the new
+`./state` subpath: `defineState({ schema, initial, events, reduce })` with
+the explicit lifetime taxonomy (`request` | `process` | `workspace-durable`
+| `external`), typed `AgentStateError` codes, monotonic revisions,
+exact-revision reads, idempotency-key replay/conflict, compare-and-swap,
+explicit versioned migrations, and polling change cursors. Ships the
+volatile in-memory driver (request/process lifetimes; never durable), the
+request-bound handle that fills the reserved `state` slot on
+`AgentRequestContext`, and the driver conformance suite every driver —
+including external ones — must pass. Stateless projects import none of it.

--- a/docs/framework-mode.md
+++ b/docs/framework-mode.md
@@ -130,8 +130,10 @@ hydrate, or hold server component state. What the MCP projection uses is an **MC
 result DSL**: `render` returns ordinary React elements, and
 `lowerMcpResult` walks that tree synchronously — function components are
 simply called — to produce the `CallToolResult` the MCP SDK sends. The
-package owns no transport, persistence, or application state; those remain
-explicit dependencies of `execute` implementations.
+package owns no transport, and operations receive no implicit storage:
+persistent application state exists only through the opt-in state kernel
+subpath (`@agent-bundle/runtime/state`, issue #98), which stateless projects
+never import.
 
 Operation modules are `.tsx` for exactly one reason: the `render` callback
 returns JSX. Everything else in an operation — schemas, argv parsing, MCP

--- a/packages/rsc-runtime/README.md
+++ b/packages/rsc-runtime/README.md
@@ -140,5 +140,54 @@ and hands it to the server through `import apps from 'agent-bundle/mcp-apps'`.
 `createRscMcpServer` registers tools only, so serving that resource remains an
 explicit `registerResource` call on the server it returns.
 
-This layer intentionally does not own transport persistence or application
-state. Those remain explicit dependencies of operation implementations.
+This layer intentionally does not own transport persistence, and operations
+never receive implicit storage: application state is an opt-in kernel behind
+its own subpath, described next.
+
+## State (optional)
+
+`@agent-bundle/runtime/state` is the event-sourced Agent state kernel
+([#98](https://github.com/ScriptedAlchemy/agent-bundle/issues/98)). Stateless
+projects never import the subpath and ship none of it. Stateful applications
+declare typed events and a pure reducer once, and every mutation flows through
+`dispatch` with a caller-owned idempotency key:
+
+```ts
+import { defineState } from '@agent-bundle/runtime/state';
+import { z } from 'zod';
+
+export const editTimeline = defineState({
+  id: 'my-plugin/edit-timeline',
+  lifetime: 'workspace-durable',
+  schema: z.object({ edits: z.array(EditSchema) }).strict(),
+  initial: { edits: [] },
+  events: { editRecorded: EditSchema },
+  reduce: (state, event) => ({ edits: [...state.edits, event.payload] }),
+});
+```
+
+Every state declares one explicit lifetime — `request` (discarded with the
+invocation), `process` (a warm runtime's heap; lost on restart by definition),
+`workspace-durable` (survives restarts for one workspace), or `external` (an
+application-provided authority). Nothing infers durability from the presence
+of an MCP process: hosts restart, multiply, or omit it.
+
+The kernel owns monotonic revisions, exact-revision snapshot reads,
+idempotency-key replay (a committed key returns its committed result; the same
+key with a different payload is a typed `idempotency-conflict`),
+compare-and-swap via `expectedRevision`, deterministic resets, explicit
+versioned migrations, and polling change cursors — subscriptions across
+short-lived processes are polling, and the kernel promises nothing stronger.
+Corruption fails closed with typed errors, and error messages never embed
+state or payload contents.
+
+Host wiring opens a store from a driver and installs a request-bound handle on
+the reserved context slot, so routes read
+`const { state } = await agent()` and call
+`state.dispatch(event, payload, { idempotencyKey })`. The in-memory driver
+(`createMemoryStateDriver`) serves the two volatile lifetimes and doubles as
+the test stand-in; it is never durable. The workspace-durable driver ships on
+`node:sqlite` behind `@agent-bundle/runtime/state/sqlite`. Any driver —
+including external ones — must pass the exported conformance suite
+(`stateDriverConformanceCases`); a disconnected adapter is not a completed
+integration.

--- a/packages/rsc-runtime/package.json
+++ b/packages/rsc-runtime/package.json
@@ -36,6 +36,10 @@
     "./plugin": {
       "types": "./dist/plugin.d.ts",
       "import": "./dist/plugin.js"
+    },
+    "./state": {
+      "types": "./dist/state/index.d.ts",
+      "import": "./dist/state.js"
     }
   },
   "scripts": {

--- a/packages/rsc-runtime/rslib.config.ts
+++ b/packages/rsc-runtime/rslib.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
       plugin: './src/plugin.ts',
+      state: './src/state/index.ts',
     },
     tsconfigPath: './tsconfig.build.json',
   },

--- a/packages/rsc-runtime/src/agent-request.ts
+++ b/packages/rsc-runtime/src/agent-request.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { JsonValue } from './lower-mcp.js';
+import type { AgentStateHandle } from './state/contract.js';
 
 export const AGENT_REQUEST_STORE_VERSION = 1;
 
@@ -130,8 +131,11 @@ export interface AgentRequestContext {
   readonly signal: AbortSignal;
   readonly services: AgentServiceRegistry;
   readonly providers: AgentProviderValues;
-  /** Reserved for the durable state kernel (#98). Wave 1 leaves this undefined. */
-  readonly state: undefined;
+  /**
+   * State kernel handle (#98) installed by the host wiring via
+   * `runAgentRequest({ state })`; undefined for stateless projects.
+   */
+  readonly state: AgentStateHandle | undefined;
   /** Reserved for recipient-aware notices (#99). Wave 1 leaves this undefined. */
   readonly notices: undefined;
 }
@@ -146,6 +150,8 @@ export interface AgentRequestInit {
   readonly services?: AgentServiceRegistry;
   readonly session?: Observed<AgentSessionIdentity>;
   readonly signal?: AbortSignal;
+  /** Request-bound state handle from `createAgentStateHandle` (subpath `./state`). */
+  readonly state?: AgentStateHandle;
   readonly workspace?: Observed<AgentWorkspaceIdentity>;
 }
 
@@ -240,7 +246,7 @@ interface FrozenValues {
   readonly services: AgentServiceRegistry;
   readonly session: Observed<AgentSessionIdentity>;
   readonly signal: AbortSignal;
-  readonly state: undefined;
+  readonly state: AgentStateHandle | undefined;
   readonly workspace: Observed<AgentWorkspaceIdentity>;
 }
 
@@ -353,7 +359,7 @@ export const runAgentRequest = async <T>(
     services: Object.freeze({ ...(init.services ?? {}) }),
     session: snapshotObserved(init.session ?? unavailable<AgentSessionIdentity>()),
     signal: init.signal ?? new AbortController().signal,
-    state: undefined,
+    state: init.state,
     workspace: snapshotObserved(init.workspace ?? unavailable<AgentWorkspaceIdentity>()),
   });
   const lease: Lease = {

--- a/packages/rsc-runtime/src/index.ts
+++ b/packages/rsc-runtime/src/index.ts
@@ -45,5 +45,8 @@ export type { NativePostToolUseOutput } from './lower-hook.js';
 export { lowerMcpResult } from './lower-mcp.js';
 export type { JsonObject, JsonValue } from './lower-mcp.js';
 export { createRscRequestContext } from './request-context.js';
+// Type-only: the state kernel itself ships behind the './state' subpath so
+// stateless artifacts include none of it (#98).
+export type { AgentStateHandle, AgentStateLifetime } from './state/contract.js';
 export type { RscRequestContext } from './request-context.js';
 export * from './plugin.js';

--- a/packages/rsc-runtime/src/state/conformance.ts
+++ b/packages/rsc-runtime/src/state/conformance.ts
@@ -1,0 +1,504 @@
+import assert from 'node:assert/strict';
+
+import { z } from 'zod';
+
+import type {
+  AgentStateDefinition,
+  AgentStateErrorCode,
+  AgentStateEventSchemas,
+  AgentStateLifetime,
+  AgentStateStore,
+} from './contract.js';
+import {
+  AGENT_STATE_LIFETIMES,
+  AGENT_STATE_RESERVED_KEY_PREFIX,
+  AgentStateError,
+  defineState,
+} from './contract.js';
+
+/**
+ * Driver conformance suite (#98).
+ *
+ * One shared, test-runner-agnostic suite that every state driver must pass —
+ * the in-memory driver and the `node:sqlite` workspace-durable driver run it
+ * in this repository, and an external driver (Postgres, Redis, a daemon) is
+ * only a completed integration once it passes the same cases. Each case
+ * receives a fresh, isolated context from the harness and asserts with
+ * `node:assert`, so any test framework can host it.
+ */
+
+export interface StateConformanceContext {
+  /** Whether commits survive re-opening the storage from a fresh driver instance. */
+  readonly durable: boolean;
+  /** The lifetime the harness driver provides; cases declare definitions with it. */
+  readonly lifetime: AgentStateLifetime;
+  /** Opens a store over this context's isolated storage. */
+  open<TState, TEvents extends AgentStateEventSchemas>(
+    definition: AgentStateDefinition<TState, TEvents>,
+  ): Promise<AgentStateStore<TState, TEvents>>;
+  /**
+   * Opens an independent second view over the same storage: another
+   * connection for durable drivers, the shared in-process store for
+   * volatile ones.
+   */
+  reopen<TState, TEvents extends AgentStateEventSchemas>(
+    definition: AgentStateDefinition<TState, TEvents>,
+  ): Promise<AgentStateStore<TState, TEvents>>;
+}
+
+export interface StateConformanceCase {
+  /** Skip unless the harness declares durable storage. */
+  readonly durableOnly?: boolean;
+  readonly name: string;
+  readonly run: (context: StateConformanceContext) => Promise<void>;
+}
+
+const rejectsWith = (code: AgentStateErrorCode) => (error: unknown): boolean => {
+  assert.ok(error instanceof AgentStateError, `expected AgentStateError, received ${String(error)}`);
+  assert.equal(error.code, code);
+  return true;
+};
+
+interface TaskState {
+  readonly tasks: readonly { readonly id: string; readonly title: string }[];
+  readonly total: number;
+}
+
+const taskSchema = z
+  .object({
+    tasks: z.array(z.object({ id: z.string().min(1), title: z.string().min(1) }).strict()),
+    total: z.number().int().min(0),
+  })
+  .strict();
+
+const taskEvents = {
+  taskAdded: z.object({ id: z.string().min(1), title: z.string().min(1) }).strict(),
+  taskRemoved: z.object({ id: z.string().min(1) }).strict(),
+  totalForced: z.object({ total: z.number().int() }).strict(),
+} as const;
+
+/** Standard fixture: a task list whose reducer exercises success, throw, and invalid-output paths. */
+const taskDefinition = (
+  lifetime: AgentStateLifetime,
+  id = 'agent-state-conformance/tasks',
+): AgentStateDefinition<TaskState, typeof taskEvents> =>
+  defineState({
+    events: taskEvents,
+    id,
+    initial: { tasks: [], total: 0 },
+    lifetime,
+    reduce: (state, event): TaskState => {
+      switch (event.name) {
+        case 'taskAdded':
+          return {
+            tasks: [...state.tasks, { id: event.payload.id, title: event.payload.title }],
+            total: state.total + 1,
+          };
+        case 'taskRemoved': {
+          const remaining = state.tasks.filter((task) => task.id !== event.payload.id);
+          if (remaining.length === state.tasks.length) {
+            throw new Error(`no task ${event.payload.id}`);
+          }
+          return { tasks: remaining, total: state.total };
+        }
+        case 'totalForced':
+          // Deliberately unvalidated: negative payloads produce schema-invalid state.
+          return { tasks: state.tasks, total: event.payload.total };
+        default: {
+          const unreachable: never = event;
+          throw new Error(`unhandled event ${String(unreachable)}`);
+        }
+      }
+    },
+    schema: taskSchema,
+  });
+
+interface TaskStateV2 extends TaskState {
+  readonly labels: readonly string[];
+}
+
+const taskSchemaV2 = z
+  .object({
+    labels: z.array(z.string()),
+    tasks: z.array(z.object({ id: z.string().min(1), title: z.string().min(1) }).strict()),
+    total: z.number().int().min(0),
+  })
+  .strict();
+
+const taskDefinitionV2 = (
+  lifetime: AgentStateLifetime,
+  id = 'agent-state-conformance/tasks',
+): AgentStateDefinition<TaskStateV2, typeof taskEvents> =>
+  defineState({
+    events: taskEvents,
+    id,
+    initial: { labels: [], tasks: [], total: 0 },
+    lifetime,
+    migrations: {
+      2: (persisted) => ({ ...(persisted as TaskState), labels: [] }),
+    },
+    reduce: (state, event): TaskStateV2 => {
+      switch (event.name) {
+        case 'taskAdded':
+          return {
+            labels: state.labels,
+            tasks: [...state.tasks, { id: event.payload.id, title: event.payload.title }],
+            total: state.total + 1,
+          };
+        case 'taskRemoved':
+          return { labels: state.labels, tasks: state.tasks.filter((task) => task.id !== event.payload.id), total: state.total };
+        case 'totalForced':
+          return { labels: state.labels, tasks: state.tasks, total: event.payload.total };
+        default: {
+          const unreachable: never = event;
+          throw new Error(`unhandled event ${String(unreachable)}`);
+        }
+      }
+    },
+    schema: taskSchemaV2,
+    version: 2,
+  });
+
+const addTask = (
+  store: AgentStateStore<TaskState, typeof taskEvents>,
+  id: string,
+  key = `add:${id}`,
+): ReturnType<typeof store.dispatch> =>
+  store.dispatch('taskAdded', { id, title: `Task ${id}` }, { idempotencyKey: key });
+
+export const stateDriverConformanceCases: readonly StateConformanceCase[] = Object.freeze([
+  {
+    name: 'an unwritten store reads the initial state at revision 0',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      assert.deepEqual(await store.read(), { revision: 0, state: { tasks: [], total: 0 } });
+      assert.deepEqual(await store.changes({ afterRevision: 0 }), { changes: [], headRevision: 0 });
+    },
+  },
+  {
+    name: 'dispatch validates payloads, applies the reducer, and commits monotonic revisions',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      const first = await addTask(store, 'a');
+      assert.equal(first.revision, 1);
+      assert.equal(first.replayed, false);
+      assert.deepEqual(first.state, { tasks: [{ id: 'a', title: 'Task a' }], total: 1 });
+      const second = await addTask(store, 'b');
+      assert.equal(second.revision, 2);
+      assert.equal((await store.read()).revision, 2);
+      assert.deepEqual((await store.read()).state, {
+        tasks: [
+          { id: 'a', title: 'Task a' },
+          { id: 'b', title: 'Task b' },
+        ],
+        total: 2,
+      });
+    },
+  },
+  {
+    name: 'unknown events and invalid payloads fail typed without committing',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await assert.rejects(
+        store.dispatch('taskrenamed' as never, { id: 'a' } as never, { idempotencyKey: 'bad:event' }),
+        rejectsWith('invalid-event'),
+      );
+      await assert.rejects(
+        store.dispatch('taskAdded', { id: '', title: '' }, { idempotencyKey: 'bad:payload' }),
+        rejectsWith('invalid-event'),
+      );
+      assert.equal((await store.read()).revision, 0);
+    },
+  },
+  {
+    name: 'replaying an idempotency key returns the committed result',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      const original = await addTask(store, 'a');
+      await addTask(store, 'b');
+      const replayed = await addTask(store, 'a');
+      assert.equal(replayed.replayed, true);
+      assert.equal(replayed.revision, original.revision);
+      assert.deepEqual(replayed.state, original.state);
+      assert.equal((await store.read()).revision, 2);
+    },
+  },
+  {
+    name: 'reusing an idempotency key with a different payload is an idempotency-conflict',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a', 'shared:key');
+      await assert.rejects(
+        store.dispatch('taskAdded', { id: 'z', title: 'Task z' }, { idempotencyKey: 'shared:key' }),
+        rejectsWith('idempotency-conflict'),
+      );
+      await assert.rejects(
+        store.reset({ idempotencyKey: 'shared:key' }),
+        rejectsWith('idempotency-conflict'),
+      );
+      assert.equal((await store.read()).revision, 1);
+    },
+  },
+  {
+    name: 'expectedRevision mismatches are revision-conflicts and commit nothing',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a');
+      await assert.rejects(
+        store.dispatch('taskAdded', { id: 'b', title: 'Task b' }, { expectedRevision: 0, idempotencyKey: 'cas:miss' }),
+        rejectsWith('revision-conflict'),
+      );
+      assert.equal((await store.read()).revision, 1);
+      const committed = await store.dispatch(
+        'taskAdded',
+        { id: 'b', title: 'Task b' },
+        { expectedRevision: 1, idempotencyKey: 'cas:hit' },
+      );
+      assert.equal(committed.revision, 2);
+    },
+  },
+  {
+    name: 'a replayed key wins over a stale expectedRevision',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      const original = await addTask(store, 'a');
+      await addTask(store, 'b');
+      const replayed = await store.dispatch(
+        'taskAdded',
+        { id: 'a', title: 'Task a' },
+        { expectedRevision: 0, idempotencyKey: 'add:a' },
+      );
+      assert.equal(replayed.replayed, true);
+      assert.equal(replayed.revision, original.revision);
+    },
+  },
+  {
+    name: 'exact-revision reads reconstruct every retained revision',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a');
+      await addTask(store, 'b');
+      await store.dispatch('taskRemoved', { id: 'a' }, { idempotencyKey: 'remove:a' });
+      assert.deepEqual((await store.read({ revision: 0 })).state, { tasks: [], total: 0 });
+      assert.deepEqual((await store.read({ revision: 1 })).state, { tasks: [{ id: 'a', title: 'Task a' }], total: 1 });
+      assert.equal((await store.read({ revision: 2 })).state.tasks.length, 2);
+      assert.deepEqual((await store.read({ revision: 3 })).state, {
+        tasks: [{ id: 'b', title: 'Task b' }],
+        total: 2,
+      });
+      await assert.rejects(store.read({ revision: 4 }), rejectsWith('revision-unavailable'));
+      await assert.rejects(store.read({ revision: -1 }), rejectsWith('invalid-input'));
+      await assert.rejects(store.read({ revision: 1.5 }), rejectsWith('invalid-input'));
+    },
+  },
+  {
+    name: 'reset returns to the initial state while revisions stay monotonic',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a');
+      await addTask(store, 'b');
+      const reset = await store.reset({ idempotencyKey: 'reset:1' });
+      assert.equal(reset.revision, 3);
+      assert.deepEqual(reset.state, { tasks: [], total: 0 });
+      const replayedReset = await store.reset({ idempotencyKey: 'reset:1' });
+      assert.equal(replayedReset.replayed, true);
+      assert.equal(replayedReset.revision, 3);
+      assert.deepEqual((await store.read({ revision: 2 })).state.tasks.length, 2);
+      const after = await addTask(store, 'c');
+      assert.equal(after.revision, 4);
+      assert.deepEqual(after.state, { tasks: [{ id: 'c', title: 'Task c' }], total: 1 });
+    },
+  },
+  {
+    name: 'reset seeds are validated and preserved',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      const seeded = await store.reset({
+        idempotencyKey: 'reset:seeded',
+        seed: { tasks: [{ id: 'seed', title: 'Seeded' }], total: 9 },
+      });
+      assert.deepEqual(seeded.state, { tasks: [{ id: 'seed', title: 'Seeded' }], total: 9 });
+      await assert.rejects(
+        store.reset({ idempotencyKey: 'reset:bad', seed: { tasks: [], total: -1 } }),
+        rejectsWith('invalid-state'),
+      );
+      assert.equal((await store.read()).revision, 1);
+    },
+  },
+  {
+    name: 'reducer failures and invalid reducer output commit nothing',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a');
+      await assert.rejects(
+        store.dispatch('taskRemoved', { id: 'missing' }, { idempotencyKey: 'remove:missing' }),
+        rejectsWith('reducer-failure'),
+      );
+      await assert.rejects(
+        store.dispatch('totalForced', { total: -5 }, { idempotencyKey: 'force:negative' }),
+        rejectsWith('invalid-state'),
+      );
+      assert.equal((await store.read()).revision, 1);
+    },
+  },
+  {
+    name: 'the change cursor returns committed changes after a revision',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await addTask(store, 'a');
+      await addTask(store, 'b');
+      await store.reset({ idempotencyKey: 'reset:1' });
+      const all = await store.changes({ afterRevision: 0 });
+      assert.equal(all.headRevision, 3);
+      assert.deepEqual(
+        all.changes.map((change) => ({ kind: change.kind, revision: change.revision })),
+        [
+          { kind: 'event', revision: 1 },
+          { kind: 'event', revision: 2 },
+          { kind: 'reset', revision: 3 },
+        ],
+      );
+      const firstEvent = all.changes[0];
+      assert.ok(firstEvent !== undefined && firstEvent.kind === 'event');
+      assert.equal(firstEvent.name, 'taskAdded');
+      assert.deepEqual(firstEvent.payload, { id: 'a', title: 'Task a' });
+      assert.equal(typeof firstEvent.committedAt, 'string');
+      const tail = await store.changes({ afterRevision: 2 });
+      assert.deepEqual(
+        tail.changes.map((change) => change.revision),
+        [3],
+      );
+      const limited = await store.changes({ afterRevision: 0, limit: 1 });
+      assert.equal(limited.changes.length, 1);
+      assert.equal(limited.headRevision, 3);
+      assert.deepEqual((await store.changes({ afterRevision: 3 })).changes, []);
+      await assert.rejects(store.changes({ afterRevision: -1 }), rejectsWith('invalid-input'));
+      await assert.rejects(store.changes({ afterRevision: 0, limit: 0 }), rejectsWith('invalid-input'));
+    },
+  },
+  {
+    name: 'a second open over the same storage observes committed state',
+    run: async (context) => {
+      const writer = await context.open(taskDefinition(context.lifetime));
+      const reader = await context.reopen(taskDefinition(context.lifetime));
+      await addTask(writer, 'a');
+      const observed = await reader.read();
+      assert.equal(observed.revision, 1);
+      assert.deepEqual(observed.state, { tasks: [{ id: 'a', title: 'Task a' }], total: 1 });
+      const cursor = await reader.changes({ afterRevision: 0 });
+      assert.equal(cursor.headRevision, 1);
+      assert.equal(cursor.changes.length, 1);
+    },
+  },
+  {
+    name: 'independent definition ids stay isolated',
+    run: async (context) => {
+      const first = await context.open(taskDefinition(context.lifetime, 'agent-state-conformance/first'));
+      const second = await context.open(taskDefinition(context.lifetime, 'agent-state-conformance/second'));
+      await addTask(first, 'a');
+      assert.equal((await second.read()).revision, 0);
+      assert.deepEqual((await second.read()).state, { tasks: [], total: 0 });
+    },
+  },
+  {
+    name: 'explicit migrations run on open, rebase history, and fail closed when missing',
+    run: async (context) => {
+      const storeV1 = await context.open(taskDefinition(context.lifetime));
+      await addTask(storeV1, 'a');
+      await addTask(storeV1, 'b');
+      const storeV2 = await context.reopen(taskDefinitionV2(context.lifetime));
+      const migrated = await storeV2.read();
+      assert.equal(migrated.revision, 3);
+      assert.deepEqual(migrated.state, {
+        labels: [],
+        tasks: [
+          { id: 'a', title: 'Task a' },
+          { id: 'b', title: 'Task b' },
+        ],
+        total: 2,
+      });
+      const changes = await storeV2.changes({ afterRevision: 0 });
+      assert.deepEqual(
+        changes.changes.map((change) => change.kind),
+        ['event', 'event', 'migrate'],
+      );
+      await assert.rejects(storeV2.read({ revision: 2 }), rejectsWith('revision-unavailable'));
+      assert.equal((await storeV2.read({ revision: 3 })).revision, 3);
+      const after = await storeV2.dispatch(
+        'taskAdded',
+        { id: 'c', title: 'Task c' },
+        { idempotencyKey: 'add:c' },
+      );
+      assert.equal(after.revision, 4);
+      await assert.rejects(context.reopen(taskDefinition(context.lifetime)), rejectsWith('migration-missing'));
+    },
+  },
+  {
+    name: 'closed stores fail typed',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await store.close();
+      await assert.rejects(addTask(store, 'a'), rejectsWith('store-closed'));
+      await assert.rejects(store.read(), rejectsWith('store-closed'));
+      await assert.rejects(store.changes({ afterRevision: 0 }), rejectsWith('store-closed'));
+    },
+  },
+  {
+    name: 'aborted signals stop operations before they touch state',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      const controller = new AbortController();
+      controller.abort(new Error('caller cancelled'));
+      await assert.rejects(
+        store.dispatch('taskAdded', { id: 'a', title: 'Task a' }, { idempotencyKey: 'abort:1', signal: controller.signal }),
+        rejectsWith('aborted'),
+      );
+      await assert.rejects(store.read({ signal: controller.signal }), rejectsWith('aborted'));
+      assert.equal((await store.read()).revision, 0);
+    },
+  },
+  {
+    name: 'empty and reserved idempotency keys are invalid-input',
+    run: async (context) => {
+      const store = await context.open(taskDefinition(context.lifetime));
+      await assert.rejects(
+        store.dispatch('taskAdded', { id: 'a', title: 'Task a' }, { idempotencyKey: '  ' }),
+        rejectsWith('invalid-input'),
+      );
+      await assert.rejects(
+        store.dispatch(
+          'taskAdded',
+          { id: 'a', title: 'Task a' },
+          { idempotencyKey: `${AGENT_STATE_RESERVED_KEY_PREFIX}migrate:2` },
+        ),
+        rejectsWith('invalid-input'),
+      );
+      assert.equal((await store.read()).revision, 0);
+    },
+  },
+  {
+    name: 'lifetime mismatches fail closed',
+    run: async (context) => {
+      const other = AGENT_STATE_LIFETIMES.find((candidate) => candidate !== context.lifetime);
+      assert.ok(other !== undefined);
+      await assert.rejects(context.open(taskDefinition(other)), rejectsWith('lifetime-mismatch'));
+    },
+  },
+  {
+    durableOnly: true,
+    name: 'commits survive closing every store and reopening the storage',
+    run: async (context) => {
+      const writer = await context.open(taskDefinition(context.lifetime));
+      await addTask(writer, 'a');
+      await addTask(writer, 'b');
+      await writer.close();
+      const reopened = await context.reopen(taskDefinition(context.lifetime));
+      const snapshot = await reopened.read();
+      assert.equal(snapshot.revision, 2);
+      assert.deepEqual(snapshot.state.tasks.map((task) => task.id), ['a', 'b']);
+      const replayed = await addTask(reopened, 'a');
+      assert.equal(replayed.replayed, true);
+      assert.equal(replayed.revision, 1);
+    },
+  },
+]);

--- a/packages/rsc-runtime/src/state/contract.ts
+++ b/packages/rsc-runtime/src/state/contract.ts
@@ -1,0 +1,362 @@
+import type { ZodError, ZodType, z } from 'zod';
+
+import { canonicalJson, deepFreezeJson, isJsonSafe } from './json.js';
+
+/**
+ * Driver-neutral contract for the optional Agent state kernel (#98).
+ *
+ * Stateful applications declare typed events and a pure reducer with
+ * {@link defineState}; drivers supply storage for one explicit lifetime and
+ * must preserve the kernel's revision, idempotency, transaction, and error
+ * semantics (enforced by the shared conformance suite in `conformance.ts`).
+ * Stateless projects never import this module: it ships behind the
+ * `@agent-bundle/runtime/state` subpath, outside the package root export.
+ */
+
+/**
+ * Where a state instance lives and when it is honestly lost.
+ *
+ * - `request`: one invocation; discarded when the request settles.
+ * - `process`: one warm runtime process; lost on restart by definition.
+ * - `workspace-durable`: survives process restarts for one workspace via a
+ *   durable local driver.
+ * - `external`: an application-provided authority (database, daemon, remote
+ *   service); durability is whatever that driver honestly declares.
+ *
+ * v1 ships `request`, `process`, and `workspace-durable` drivers; `external`
+ * drivers are admitted through the conformance suite.
+ */
+export type AgentStateLifetime = 'request' | 'process' | 'workspace-durable' | 'external';
+
+export const AGENT_STATE_LIFETIMES: readonly AgentStateLifetime[] = Object.freeze([
+  'request',
+  'process',
+  'workspace-durable',
+  'external',
+]);
+
+export type AgentStateErrorCode =
+  | 'aborted'
+  | 'corrupt'
+  | 'idempotency-conflict'
+  | 'invalid-definition'
+  | 'invalid-event'
+  | 'invalid-input'
+  | 'invalid-state'
+  | 'lifetime-mismatch'
+  | 'migration-failure'
+  | 'migration-missing'
+  | 'reducer-failure'
+  | 'revision-conflict'
+  | 'revision-unavailable'
+  | 'store-closed'
+  | 'unavailable';
+
+/**
+ * Typed state kernel failure. Messages identify definitions, events, keys,
+ * and revisions but never embed state or payload contents: state stays out
+ * of logs and error channels by default.
+ */
+export class AgentStateError extends Error {
+  readonly code: AgentStateErrorCode;
+
+  constructor(code: AgentStateErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = 'AgentStateError';
+  }
+}
+
+/** True when the lifetime is lost with its owning request or process rather than stored durably. */
+export const agentStateLifetimeIsVolatile = (lifetime: AgentStateLifetime): boolean => {
+  switch (lifetime) {
+    case 'request':
+    case 'process':
+      return true;
+    case 'workspace-durable':
+    case 'external':
+      return false;
+    default: {
+      const unreachable: never = lifetime;
+      throw new AgentStateError('invalid-definition', `Unknown state lifetime ${String(unreachable)}`);
+    }
+  }
+};
+
+export type AgentStateEventSchemas = Readonly<Record<string, ZodType>>;
+
+export type AgentStateEventName<TEvents extends AgentStateEventSchemas> = Extract<keyof TEvents, string>;
+
+export type AgentStateEventPayload<
+  TEvents extends AgentStateEventSchemas,
+  TName extends AgentStateEventName<TEvents>,
+> = z.output<TEvents[TName]>;
+
+/** Discriminated event union passed to the reducer; `switch (event.name)` narrows `payload`. */
+export type AgentStateEvent<TEvents extends AgentStateEventSchemas> = {
+  [TName in AgentStateEventName<TEvents>]: {
+    readonly name: TName;
+    readonly payload: z.output<TEvents[TName]>;
+  };
+}[AgentStateEventName<TEvents>];
+
+/**
+ * Explicit, versioned migration steps. `migrations[n]` migrates a state
+ * persisted at definition version `n - 1` to version `n`; a definition of
+ * version `v > 1` must supply every step from `2` through `v`. Steps receive
+ * the raw persisted value and their final output must satisfy the current
+ * schema. Migrating rebases history: exact-revision reads below the recorded
+ * migration become `revision-unavailable`.
+ */
+export type AgentStateMigrations = Readonly<Record<number, (persisted: unknown) => unknown>>;
+
+export interface AgentStateDefinitionInput<TState, TEvents extends AgentStateEventSchemas> {
+  /** Event name to payload schema; dispatch validates payloads before the reducer runs. */
+  readonly events: TEvents;
+  /** Stable identity for storage naming and cross-process addressing. */
+  readonly id: string;
+  /** Initial state; must satisfy `schema` and be JSON-safe. */
+  readonly initial: TState;
+  readonly lifetime: AgentStateLifetime;
+  readonly migrations?: AgentStateMigrations;
+  /** Pure, deterministic, synchronous transition; must not mutate its input (it is frozen). */
+  readonly reduce: (state: TState, event: AgentStateEvent<TEvents>) => TState;
+  readonly schema: ZodType<TState>;
+  /** Schema version for explicit migrations; defaults to 1. */
+  readonly version?: number;
+}
+
+export interface AgentStateDefinition<
+  TState = unknown,
+  TEvents extends AgentStateEventSchemas = AgentStateEventSchemas,
+> {
+  readonly events: TEvents;
+  readonly id: string;
+  readonly initial: TState;
+  readonly lifetime: AgentStateLifetime;
+  readonly migrations: AgentStateMigrations;
+  readonly reduce: (state: TState, event: AgentStateEvent<TEvents>) => TState;
+  readonly schema: ZodType<TState>;
+  readonly version: number;
+}
+
+/** Compact zod issue summary that names paths and codes without embedding rejected values. */
+export const describeSchemaIssues = (error: ZodError): string =>
+  error.issues
+    .map((issue) => `${issue.path.length === 0 ? '(root)' : issue.path.join('.')}: ${issue.code}`)
+    .join('; ');
+
+const expectNonEmptyText = (value: unknown, label: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AgentStateError('invalid-definition', `${label} must be a non-empty string`);
+  }
+  return value;
+};
+
+export const defineState = <TState, TEvents extends AgentStateEventSchemas>(
+  input: AgentStateDefinitionInput<TState, TEvents>,
+): AgentStateDefinition<TState, TEvents> => {
+  const id = expectNonEmptyText(input.id, 'State definition id');
+  if (!AGENT_STATE_LIFETIMES.includes(input.lifetime)) {
+    throw new AgentStateError('invalid-definition', `State '${id}' declares an unknown lifetime`);
+  }
+  if (typeof input.reduce !== 'function') {
+    throw new AgentStateError('invalid-definition', `State '${id}' requires a reduce function`);
+  }
+  const eventNames = Object.keys(input.events);
+  if (eventNames.length === 0) {
+    throw new AgentStateError('invalid-definition', `State '${id}' must declare at least one event`);
+  }
+  for (const name of eventNames) {
+    expectNonEmptyText(name, `State '${id}' event name`);
+    if (typeof input.events[name]?.safeParse !== 'function') {
+      throw new AgentStateError('invalid-definition', `State '${id}' event '${name}' requires a zod schema`);
+    }
+  }
+  const version = input.version ?? 1;
+  if (!Number.isInteger(version) || version < 1) {
+    throw new AgentStateError('invalid-definition', `State '${id}' version must be an integer >= 1`);
+  }
+  const migrations = input.migrations ?? {};
+  const migrationVersions = Object.keys(migrations).map((key) => Number(key));
+  for (const target of migrationVersions) {
+    if (!Number.isInteger(target) || target < 2 || target > version) {
+      throw new AgentStateError(
+        'invalid-definition',
+        `State '${id}' migration targets must be integers from 2 through ${String(version)}`,
+      );
+    }
+    if (typeof migrations[target] !== 'function') {
+      throw new AgentStateError('invalid-definition', `State '${id}' migration to version ${String(target)} must be a function`);
+    }
+  }
+  for (let target = 2; target <= version; target += 1) {
+    if (migrations[target] === undefined) {
+      throw new AgentStateError('invalid-definition', `State '${id}' is missing the migration to version ${String(target)}`);
+    }
+  }
+  const parsedInitial = input.schema.safeParse(input.initial);
+  if (!parsedInitial.success) {
+    throw new AgentStateError(
+      'invalid-definition',
+      `State '${id}' initial state failed its schema: ${describeSchemaIssues(parsedInitial.error)}`,
+    );
+  }
+  if (!isJsonSafe(parsedInitial.data)) {
+    throw new AgentStateError('invalid-definition', `State '${id}' initial state must be JSON-safe`);
+  }
+  return Object.freeze({
+    events: Object.freeze({ ...input.events }) as TEvents,
+    id,
+    initial: deepFreezeJson(parsedInitial.data),
+    lifetime: input.lifetime,
+    migrations: Object.freeze({ ...migrations }),
+    reduce: input.reduce,
+    schema: input.schema,
+    version,
+  });
+};
+
+export interface AgentStateSnapshot<TState = unknown> {
+  readonly revision: number;
+  readonly state: TState;
+}
+
+export interface AgentStateCommitResult<TState = unknown> extends AgentStateSnapshot<TState> {
+  /** True when the idempotency key had already committed and the stored result was returned. */
+  readonly replayed: boolean;
+}
+
+/**
+ * One committed journal entry, exposed through the polling change cursor.
+ * `reset` and `migrate` entries mark history discontinuities: consumers
+ * re-read instead of folding payloads.
+ */
+export type AgentStateChange =
+  | {
+      readonly committedAt: string;
+      readonly kind: 'event';
+      readonly name: string;
+      readonly payload: unknown;
+      readonly revision: number;
+    }
+  | { readonly committedAt: string; readonly kind: 'migrate'; readonly revision: number }
+  | { readonly committedAt: string; readonly kind: 'reset'; readonly revision: number };
+
+export interface AgentStateChangeBatch {
+  readonly changes: readonly AgentStateChange[];
+  readonly headRevision: number;
+}
+
+export interface AgentStateDispatchOptions {
+  /** Compare-and-swap: fail with `revision-conflict` unless the head revision matches. */
+  readonly expectedRevision?: number;
+  /**
+   * Required caller-owned dedupe identity. Replaying a committed key with an
+   * identical payload returns the committed result; reusing it with a
+   * different payload is an `idempotency-conflict`.
+   */
+  readonly idempotencyKey: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentStateReadOptions {
+  /** Exact-revision snapshot read; defaults to the head revision. */
+  readonly revision?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentStateChangesOptions {
+  /** Change cursor position: return changes with revisions greater than this. */
+  readonly afterRevision: number;
+  readonly limit?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentStateResetOptions<TState = unknown> {
+  readonly expectedRevision?: number;
+  readonly idempotencyKey: string;
+  /** Replacement state; defaults to the definition's initial state. Must satisfy the schema. */
+  readonly seed?: TState;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * An open state instance. Revisions are monotonic across events, resets, and
+ * migrations; revision 0 is the initial state.
+ */
+export interface AgentStateStore<
+  TState = unknown,
+  TEvents extends AgentStateEventSchemas = AgentStateEventSchemas,
+> {
+  readonly definition: AgentStateDefinition<TState, TEvents>;
+  /** Storage identity for diagnostics (path or memory label); never state contents. */
+  readonly location: string;
+  changes(options: AgentStateChangesOptions): Promise<AgentStateChangeBatch>;
+  close(): Promise<void>;
+  dispatch<TName extends AgentStateEventName<TEvents>>(
+    name: TName,
+    payload: AgentStateEventPayload<TEvents, TName>,
+    options: AgentStateDispatchOptions,
+  ): Promise<AgentStateCommitResult<TState>>;
+  read(options?: AgentStateReadOptions): Promise<AgentStateSnapshot<TState>>;
+  reset(options: AgentStateResetOptions<TState>): Promise<AgentStateCommitResult<TState>>;
+}
+
+/**
+ * Storage backend for exactly one lifetime. Opening a definition whose
+ * lifetime differs from the driver's is a `lifetime-mismatch`; a driver must
+ * never claim a stronger lifetime than its storage honestly provides, and
+ * in-memory storage is never durable.
+ */
+export interface AgentStateDriver {
+  /** Whether commits survive a process restart. Volatile drivers must say false. */
+  readonly durable: boolean;
+  readonly kind: string;
+  readonly lifetime: AgentStateLifetime;
+  close(): Promise<void>;
+  open<TState, TEvents extends AgentStateEventSchemas>(
+    definition: AgentStateDefinition<TState, TEvents>,
+  ): Promise<AgentStateStore<TState, TEvents>>;
+}
+
+/**
+ * Request-bound view of one open store, installed on the reserved `state`
+ * slot of the Agent request context: `(await agent()).state`.
+ */
+export interface AgentStateHandle<
+  TState = unknown,
+  TEvents extends AgentStateEventSchemas = AgentStateEventSchemas,
+> {
+  readonly lifetime: AgentStateLifetime;
+  changes(options: AgentStateChangesOptions): Promise<AgentStateChangeBatch>;
+  dispatch<TName extends AgentStateEventName<TEvents>>(
+    name: TName,
+    payload: AgentStateEventPayload<TEvents, TName>,
+    options: AgentStateDispatchOptions,
+  ): Promise<AgentStateCommitResult<TState>>;
+  read(options?: AgentStateReadOptions): Promise<AgentStateSnapshot<TState>>;
+}
+
+/** Reserved namespace for kernel-generated idempotency keys (migrations). */
+export const AGENT_STATE_RESERVED_KEY_PREFIX = 'agent-state:';
+
+export const expectIdempotencyKey = (key: string): string => {
+  if (typeof key !== 'string' || key.trim() === '') {
+    throw new AgentStateError('invalid-input', 'State mutations require a non-empty idempotency key');
+  }
+  if (key.startsWith(AGENT_STATE_RESERVED_KEY_PREFIX)) {
+    throw new AgentStateError(
+      'invalid-input',
+      `Idempotency keys must not use the reserved '${AGENT_STATE_RESERVED_KEY_PREFIX}' prefix`,
+    );
+  }
+  return key;
+};
+
+export const expectCanonicalPayload = (value: unknown, label: string): string => {
+  if (!isJsonSafe(value)) {
+    throw new AgentStateError('invalid-event', `${label} must be JSON-safe`);
+  }
+  return canonicalJson(value);
+};

--- a/packages/rsc-runtime/src/state/handle.ts
+++ b/packages/rsc-runtime/src/state/handle.ts
@@ -1,0 +1,37 @@
+import type {
+  AgentStateEventSchemas,
+  AgentStateHandle,
+  AgentStateStore,
+} from './contract.js';
+
+export interface AgentStateHandleOptions {
+  /**
+   * Request signal folded into every operation that does not carry its own,
+   * so an aborted invocation stops touching state.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Binds one open store to a request as the reserved `state` slot of the
+ * Agent request context (#98 over #95): host wiring passes the result to
+ * `runAgentRequest({ state, ... })` and routes reach it via
+ * `(await agent()).state.dispatch(event, payload, { idempotencyKey })`.
+ *
+ * The handle deliberately narrows the store: no `reset` and no `close`.
+ * Deterministic resets and store lifecycle belong to the host wiring and
+ * test harnesses, not to request-scoped application code.
+ */
+export const createAgentStateHandle = <TState, TEvents extends AgentStateEventSchemas>(
+  store: AgentStateStore<TState, TEvents>,
+  options: AgentStateHandleOptions = {},
+): AgentStateHandle<TState, TEvents> => {
+  const handle: AgentStateHandle<TState, TEvents> = {
+    lifetime: store.definition.lifetime,
+    changes: (changesOptions) => store.changes({ signal: options.signal, ...changesOptions }),
+    dispatch: (name, payload, dispatchOptions) =>
+      store.dispatch(name, payload, { signal: options.signal, ...dispatchOptions }),
+    read: (readOptions = {}) => store.read({ signal: options.signal, ...readOptions }),
+  };
+  return Object.freeze(handle);
+};

--- a/packages/rsc-runtime/src/state/index.ts
+++ b/packages/rsc-runtime/src/state/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Optional Agent state kernel (#98): `@agent-bundle/runtime/state`.
+ *
+ * This subpath is the only way state code enters an artifact — the package
+ * root export never imports it, so stateless projects ship none of the
+ * kernel. The workspace-durable driver lives one subpath deeper
+ * (`@agent-bundle/runtime/state/sqlite`) so volatile-state users never load
+ * `node:sqlite`.
+ */
+export {
+  AGENT_STATE_LIFETIMES,
+  AGENT_STATE_RESERVED_KEY_PREFIX,
+  AgentStateError,
+  agentStateLifetimeIsVolatile,
+  defineState,
+} from './contract.js';
+export type {
+  AgentStateChange,
+  AgentStateChangeBatch,
+  AgentStateChangesOptions,
+  AgentStateCommitResult,
+  AgentStateDefinition,
+  AgentStateDefinitionInput,
+  AgentStateDispatchOptions,
+  AgentStateDriver,
+  AgentStateErrorCode,
+  AgentStateEvent,
+  AgentStateEventName,
+  AgentStateEventPayload,
+  AgentStateEventSchemas,
+  AgentStateHandle,
+  AgentStateLifetime,
+  AgentStateMigrations,
+  AgentStateReadOptions,
+  AgentStateResetOptions,
+  AgentStateSnapshot,
+  AgentStateStore,
+} from './contract.js';
+export { createAgentStateHandle } from './handle.js';
+export type { AgentStateHandleOptions } from './handle.js';
+export { createMemoryStateDriver } from './memory-driver.js';
+export type { MemoryStateDriverOptions } from './memory-driver.js';
+export { stateDriverConformanceCases } from './conformance.js';
+export type { StateConformanceCase, StateConformanceContext } from './conformance.js';

--- a/packages/rsc-runtime/src/state/journal.ts
+++ b/packages/rsc-runtime/src/state/journal.ts
@@ -1,0 +1,288 @@
+import type {
+  AgentStateChange,
+  AgentStateDefinition,
+  AgentStateEvent,
+  AgentStateEventSchemas,
+} from './contract.js';
+import { AGENT_STATE_RESERVED_KEY_PREFIX, AgentStateError, describeSchemaIssues } from './contract.js';
+import { canonicalJson, deepFreezeJson, isJsonSafe } from './json.js';
+
+/**
+ * Shared journal semantics for state drivers (#98).
+ *
+ * Every driver persists the same logical journal: monotonic revisions
+ * starting at 1, `event` records carrying validated payloads, and `reset` /
+ * `migrate` baseline records carrying the full replacement state. Exact
+ * revision reads replay events from the nearest baseline at or below the
+ * target through the definition's pure reducer. Drivers store these records
+ * however their storage works, but the semantics here are the contract the
+ * conformance suite enforces.
+ */
+
+export type AgentStateJournalRecord =
+  | {
+      readonly committedAt: string;
+      readonly idempotencyKey: string;
+      readonly kind: 'event';
+      readonly name: string;
+      readonly payload: unknown;
+      readonly revision: number;
+    }
+  | {
+      readonly committedAt: string;
+      readonly idempotencyKey: string;
+      readonly kind: 'migrate';
+      readonly revision: number;
+      /** Migrated state validated against the current schema. */
+      readonly state: unknown;
+      readonly toVersion: number;
+    }
+  | {
+      readonly committedAt: string;
+      readonly idempotencyKey: string;
+      readonly kind: 'reset';
+      readonly revision: number;
+      /** Resolved post-reset state (the validated seed or the initial state). */
+      readonly state: unknown;
+    };
+
+/** Canonical dedupe identity for idempotency-key comparison. */
+export const canonicalCommitInput = (record: AgentStateJournalRecord): string => {
+  switch (record.kind) {
+    case 'event':
+      return canonicalJson({ kind: 'event', name: record.name, payload: record.payload });
+    case 'reset':
+      return canonicalJson({ kind: 'reset', state: record.state });
+    case 'migrate':
+      return canonicalJson({ kind: 'migrate', toVersion: record.toVersion });
+    default: {
+      const unreachable: never = record;
+      throw new AgentStateError('corrupt', `Unknown journal record kind ${String(unreachable)}`);
+    }
+  }
+};
+
+export const migrationIdempotencyKey = (toVersion: number): string =>
+  `${AGENT_STATE_RESERVED_KEY_PREFIX}migrate:${String(toVersion)}`;
+
+/**
+ * Validates one event payload, runs the reducer, and validates its output.
+ * Throws typed `invalid-event`, `reducer-failure`, or `invalid-state`
+ * errors; never exposes payload or state contents in messages.
+ */
+export const applyStateEvent = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  state: TState,
+  name: string,
+  payload: unknown,
+): { readonly payload: unknown; readonly state: TState } => {
+  const schema = definition.events[name];
+  if (schema === undefined) {
+    throw new AgentStateError('invalid-event', `State '${definition.id}' has no event '${name}'`);
+  }
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new AgentStateError(
+      'invalid-event',
+      `State '${definition.id}' event '${name}' payload failed its schema: ${describeSchemaIssues(parsed.error)}`,
+    );
+  }
+  if (!isJsonSafe(parsed.data)) {
+    throw new AgentStateError('invalid-event', `State '${definition.id}' event '${name}' payload must be JSON-safe`);
+  }
+  let next: TState;
+  try {
+    next = definition.reduce(state, { name, payload: parsed.data } as AgentStateEvent<TEvents>);
+  } catch (error) {
+    throw new AgentStateError(
+      'reducer-failure',
+      `State '${definition.id}' reducer threw for event '${name}'`,
+      { cause: error },
+    );
+  }
+  const validated = definition.schema.safeParse(next);
+  if (!validated.success) {
+    throw new AgentStateError(
+      'invalid-state',
+      `State '${definition.id}' reducer output for event '${name}' failed the schema: ${describeSchemaIssues(validated.error)}`,
+    );
+  }
+  if (!isJsonSafe(validated.data)) {
+    throw new AgentStateError('invalid-state', `State '${definition.id}' reducer output for event '${name}' must be JSON-safe`);
+  }
+  return { payload: deepFreezeJson(parsed.data), state: deepFreezeJson(validated.data) };
+};
+
+/** Validates a reset seed (or resolves the initial state) against the schema. */
+export const resolveResetState = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  seed: TState | undefined,
+): TState => {
+  if (seed === undefined) return definition.initial;
+  const parsed = definition.schema.safeParse(seed);
+  if (!parsed.success) {
+    throw new AgentStateError(
+      'invalid-state',
+      `State '${definition.id}' reset seed failed the schema: ${describeSchemaIssues(parsed.error)}`,
+    );
+  }
+  if (!isJsonSafe(parsed.data)) {
+    throw new AgentStateError('invalid-state', `State '${definition.id}' reset seed must be JSON-safe`);
+  }
+  return deepFreezeJson(parsed.data);
+};
+
+const parseBaselineState = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  record: Extract<AgentStateJournalRecord, { kind: 'migrate' | 'reset' }>,
+): TState => {
+  const parsed = definition.schema.safeParse(record.state);
+  if (!parsed.success) {
+    throw new AgentStateError(
+      'corrupt',
+      `State '${definition.id}' ${record.kind} record at revision ${String(record.revision)} no longer satisfies the schema: ${describeSchemaIssues(parsed.error)}`,
+    );
+  }
+  return deepFreezeJson(parsed.data);
+};
+
+/**
+ * Reconstructs the exact state at `targetRevision` from ordered journal
+ * records. Revisions below the latest migration are `revision-unavailable`:
+ * migration rebases history because older records were written under an
+ * earlier definition version. Replay failures are `corrupt` (fail closed).
+ */
+export const replayJournal = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  records: readonly AgentStateJournalRecord[],
+  targetRevision: number,
+): TState => {
+  const latestMigration = [...records].reverse().find((record) => record.kind === 'migrate');
+  if (latestMigration !== undefined && targetRevision < latestMigration.revision) {
+    throw new AgentStateError(
+      'revision-unavailable',
+      `State '${definition.id}' revision ${String(targetRevision)} predates the migration at revision ${String(latestMigration.revision)}`,
+    );
+  }
+  let state = definition.initial;
+  let baselineRevision = 0;
+  for (const record of records) {
+    if (record.revision > targetRevision) break;
+    if (record.kind === 'reset' || record.kind === 'migrate') {
+      state = parseBaselineState(definition, record);
+      baselineRevision = record.revision;
+    }
+  }
+  for (const record of records) {
+    if (record.revision <= baselineRevision || record.revision > targetRevision) continue;
+    if (record.kind !== 'event') {
+      throw new AgentStateError(
+        'corrupt',
+        `State '${definition.id}' journal has an out-of-order baseline at revision ${String(record.revision)}`,
+      );
+    }
+    try {
+      state = applyStateEvent(definition, state, record.name, record.payload).state;
+    } catch (error) {
+      throw new AgentStateError(
+        'corrupt',
+        `State '${definition.id}' could not replay revision ${String(record.revision)}`,
+        { cause: error },
+      );
+    }
+  }
+  return state;
+};
+
+/** Asserts revisions run 1..n without gaps and idempotency keys never repeat. */
+export const expectConsistentJournal = (
+  definitionId: string,
+  records: readonly AgentStateJournalRecord[],
+): void => {
+  const keys = new Set<string>();
+  for (const [index, record] of records.entries()) {
+    if (record.revision !== index + 1) {
+      throw new AgentStateError(
+        'corrupt',
+        `State '${definitionId}' journal expected revision ${String(index + 1)} but found ${String(record.revision)}`,
+      );
+    }
+    if (keys.has(record.idempotencyKey)) {
+      throw new AgentStateError('corrupt', `State '${definitionId}' journal repeats an idempotency key`);
+    }
+    keys.add(record.idempotencyKey);
+  }
+};
+
+/**
+ * Runs the explicit migration chain from `persistedVersion` to the
+ * definition's version and validates the final result against the current
+ * schema. A persisted version newer than the definition fails closed with
+ * `migration-missing`.
+ */
+export const runStateMigrations = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  persistedVersion: number,
+  persistedState: unknown,
+): TState => {
+  if (!Number.isInteger(persistedVersion) || persistedVersion < 1) {
+    throw new AgentStateError('corrupt', `State '${definition.id}' persisted an invalid schema version`);
+  }
+  if (persistedVersion > definition.version) {
+    throw new AgentStateError(
+      'migration-missing',
+      `State '${definition.id}' was persisted at version ${String(persistedVersion)} but this definition is version ${String(definition.version)}`,
+    );
+  }
+  let migrated = persistedState;
+  for (let target = persistedVersion + 1; target <= definition.version; target += 1) {
+    const step = definition.migrations[target];
+    if (step === undefined) {
+      throw new AgentStateError(
+        'migration-missing',
+        `State '${definition.id}' is missing the migration to version ${String(target)}`,
+      );
+    }
+    try {
+      migrated = step(migrated);
+    } catch (error) {
+      throw new AgentStateError(
+        'migration-failure',
+        `State '${definition.id}' migration to version ${String(target)} threw`,
+        { cause: error },
+      );
+    }
+  }
+  const parsed = definition.schema.safeParse(migrated);
+  if (!parsed.success) {
+    throw new AgentStateError(
+      'migration-failure',
+      `State '${definition.id}' migrated state failed the version ${String(definition.version)} schema: ${describeSchemaIssues(parsed.error)}`,
+    );
+  }
+  if (!isJsonSafe(parsed.data)) {
+    throw new AgentStateError('migration-failure', `State '${definition.id}' migrated state must be JSON-safe`);
+  }
+  return deepFreezeJson(parsed.data);
+};
+
+export const changeFromJournalRecord = (record: AgentStateJournalRecord): AgentStateChange => {
+  switch (record.kind) {
+    case 'event':
+      return {
+        committedAt: record.committedAt,
+        kind: 'event',
+        name: record.name,
+        payload: record.payload,
+        revision: record.revision,
+      };
+    case 'reset':
+      return { committedAt: record.committedAt, kind: 'reset', revision: record.revision };
+    case 'migrate':
+      return { committedAt: record.committedAt, kind: 'migrate', revision: record.revision };
+    default: {
+      const unreachable: never = record;
+      throw new AgentStateError('corrupt', `Unknown journal record kind ${String(unreachable)}`);
+    }
+  }
+};

--- a/packages/rsc-runtime/src/state/json.ts
+++ b/packages/rsc-runtime/src/state/json.ts
@@ -1,0 +1,47 @@
+/**
+ * JSON-safety and canonicalization helpers for the state kernel (#98).
+ *
+ * Persisted state, event payloads, and reset seeds must round-trip through
+ * JSON deterministically: drivers store canonical text, and idempotency-key
+ * replay compares canonical forms. Keys are sorted so two structurally equal
+ * values always canonicalize to the same bytes.
+ */
+
+const isPlainObject = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+
+export const isJsonSafe = (value: unknown): boolean => {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isJsonSafe);
+  return isPlainObject(value) && Object.values(value).every(isJsonSafe);
+};
+
+/** Deterministic JSON text with sorted object keys; callers must check {@link isJsonSafe} first. */
+export const canonicalJson = (value: unknown): string => {
+  if (value === null || typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  const record = value as Readonly<Record<string, unknown>>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`;
+};
+
+/** Recursively freezes JSON-safe data in place and returns it. */
+export const deepFreezeJson = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    for (const item of value) deepFreezeJson(item);
+    return Object.freeze(value);
+  }
+  if (isPlainObject(value)) {
+    for (const nested of Object.values(value)) deepFreezeJson(nested);
+    return Object.freeze(value) as T;
+  }
+  return value;
+};

--- a/packages/rsc-runtime/src/state/memory-driver.ts
+++ b/packages/rsc-runtime/src/state/memory-driver.ts
@@ -1,0 +1,328 @@
+import type {
+  AgentStateChangeBatch,
+  AgentStateChangesOptions,
+  AgentStateCommitResult,
+  AgentStateDefinition,
+  AgentStateDispatchOptions,
+  AgentStateDriver,
+  AgentStateEventSchemas,
+  AgentStateLifetime,
+  AgentStateReadOptions,
+  AgentStateResetOptions,
+  AgentStateSnapshot,
+  AgentStateStore,
+} from './contract.js';
+import { AgentStateError, expectIdempotencyKey } from './contract.js';
+import type { AgentStateJournalRecord } from './journal.js';
+import {
+  applyStateEvent,
+  canonicalCommitInput,
+  changeFromJournalRecord,
+  migrationIdempotencyKey,
+  replayJournal,
+  resolveResetState,
+  runStateMigrations,
+} from './journal.js';
+
+/**
+ * In-memory state driver (#98).
+ *
+ * TEST-ONLY as a durability stand-in: storage lives in this process's heap,
+ * is never written anywhere, and must never be labeled durable. Its two
+ * honest production uses are exactly the volatile lifetimes it can provide:
+ * `request` (a fresh store per open, discarded with the request) and
+ * `process` (one store per definition id for the life of this driver inside
+ * a warm runtime process — lost on restart by definition). The conformance
+ * suite runs against this driver to pin the shared kernel semantics.
+ */
+
+export interface MemoryStateDriverOptions {
+  /** Volatile lifetime this driver provides; defaults to `process`. */
+  readonly lifetime?: 'process' | 'request';
+  /** Clock injection for deterministic tests. */
+  readonly now?: () => Date;
+}
+
+type MemoryLifetime = 'process' | 'request';
+
+const expectVolatileLifetime = (lifetime: AgentStateLifetime): MemoryLifetime => {
+  switch (lifetime) {
+    case 'request':
+    case 'process':
+      return lifetime;
+    case 'workspace-durable':
+    case 'external':
+      throw new AgentStateError(
+        'lifetime-mismatch',
+        `In-memory state storage is never '${lifetime}': it provides only volatile lifetimes and must never be labeled durable`,
+      );
+    default: {
+      const unreachable: never = lifetime;
+      throw new AgentStateError('invalid-definition', `Unknown state lifetime ${String(unreachable)}`);
+    }
+  }
+};
+
+interface MemoryStoreInternals<TState, TEvents extends AgentStateEventSchemas> {
+  closed: boolean;
+  definition: AgentStateDefinition<TState, TEvents>;
+  head: AgentStateSnapshot<TState>;
+  readonly journal: AgentStateJournalRecord[];
+  readonly keys: Map<string, AgentStateJournalRecord>;
+}
+
+interface MemoryStoreEntry<TState, TEvents extends AgentStateEventSchemas> {
+  readonly internals: MemoryStoreInternals<TState, TEvents>;
+  readonly store: AgentStateStore<TState, TEvents>;
+}
+
+const expectRevisionShape = (revision: number | undefined, label: string): void => {
+  if (revision !== undefined && (!Number.isInteger(revision) || revision < 0)) {
+    throw new AgentStateError('invalid-input', `${label} must be an integer >= 0`);
+  }
+};
+
+const expectOperable = (closed: boolean, definitionId: string, signal: AbortSignal | undefined): void => {
+  if (closed) {
+    throw new AgentStateError('store-closed', `State '${definitionId}' store is closed`);
+  }
+  if (signal?.aborted === true) {
+    throw new AgentStateError('aborted', `State '${definitionId}' operation was aborted`, { cause: signal.reason });
+  }
+};
+
+const createMemoryStore = <TState, TEvents extends AgentStateEventSchemas>(
+  definition: AgentStateDefinition<TState, TEvents>,
+  lifetime: MemoryLifetime,
+  now: () => Date,
+  onClose: () => void,
+): MemoryStoreEntry<TState, TEvents> => {
+  const internals: MemoryStoreInternals<TState, TEvents> = {
+    closed: false,
+    definition,
+    head: Object.freeze({ revision: 0, state: definition.initial }),
+    journal: [],
+    keys: new Map(),
+  };
+
+  /**
+   * Commits share one shape: validate inputs, then honor a committed
+   * idempotency key (replay/conflict), then compare-and-swap, then append.
+   * The interior is fully synchronous, so a commit is atomic per store
+   * within this process.
+   */
+  const commit = (
+    record: Readonly<{ canonicalInput: string; key: string }> &
+      (
+        | { readonly kind: 'event'; readonly name: string; readonly payload: unknown; readonly state: TState }
+        | { readonly kind: 'reset'; readonly state: TState }
+      ),
+    expectedRevision: number | undefined,
+  ): AgentStateCommitResult<TState> => {
+    const committed = internals.keys.get(record.key);
+    if (committed !== undefined) {
+      if (canonicalCommitInput(committed) !== record.canonicalInput) {
+        throw new AgentStateError(
+          'idempotency-conflict',
+          `State '${internals.definition.id}' idempotency key was reused with a conflicting input`,
+        );
+      }
+      return Object.freeze({
+        replayed: true,
+        revision: committed.revision,
+        state: replayJournal(internals.definition, internals.journal, committed.revision),
+      });
+    }
+    if (expectedRevision !== undefined && expectedRevision !== internals.head.revision) {
+      throw new AgentStateError(
+        'revision-conflict',
+        `State '${internals.definition.id}' expected revision ${String(expectedRevision)} but the head is ${String(internals.head.revision)}`,
+      );
+    }
+    const journalRecord: AgentStateJournalRecord =
+      record.kind === 'event'
+        ? {
+            committedAt: now().toISOString(),
+            idempotencyKey: record.key,
+            kind: 'event',
+            name: record.name,
+            payload: record.payload,
+            revision: internals.head.revision + 1,
+          }
+        : {
+            committedAt: now().toISOString(),
+            idempotencyKey: record.key,
+            kind: 'reset',
+            revision: internals.head.revision + 1,
+            state: record.state,
+          };
+    internals.journal.push(journalRecord);
+    internals.keys.set(journalRecord.idempotencyKey, journalRecord);
+    internals.head = Object.freeze({ revision: journalRecord.revision, state: record.state });
+    return Object.freeze({ replayed: false, revision: journalRecord.revision, state: record.state });
+  };
+
+  const store: AgentStateStore<TState, TEvents> = {
+    get definition() {
+      return internals.definition;
+    },
+    location: `memory:${lifetime}:${definition.id}`,
+
+    async changes(options: AgentStateChangesOptions): Promise<AgentStateChangeBatch> {
+      expectOperable(internals.closed, internals.definition.id, options.signal);
+      if (options.afterRevision === undefined) {
+        throw new AgentStateError('invalid-input', `State '${internals.definition.id}' changes require afterRevision`);
+      }
+      expectRevisionShape(options.afterRevision, `State '${internals.definition.id}' afterRevision`);
+      if (options.limit !== undefined && (!Number.isInteger(options.limit) || options.limit < 1)) {
+        throw new AgentStateError(
+          'invalid-input',
+          `State '${internals.definition.id}' changes limit must be an integer >= 1`,
+        );
+      }
+      const selected = internals.journal
+        .filter((record) => record.revision > options.afterRevision)
+        .slice(0, options.limit)
+        .map((record) => changeFromJournalRecord(record));
+      return Object.freeze({ changes: Object.freeze(selected), headRevision: internals.head.revision });
+    },
+
+    async close(): Promise<void> {
+      if (!internals.closed) {
+        internals.closed = true;
+        onClose();
+      }
+    },
+
+    async dispatch(name, payload, options: AgentStateDispatchOptions): Promise<AgentStateCommitResult<TState>> {
+      expectOperable(internals.closed, internals.definition.id, options.signal);
+      const key = expectIdempotencyKey(options.idempotencyKey);
+      expectRevisionShape(options.expectedRevision, `State '${internals.definition.id}' expectedRevision`);
+      const applied = applyStateEvent(internals.definition, internals.head.state, name, payload);
+      const canonicalInput = canonicalCommitInput({
+        committedAt: '',
+        idempotencyKey: key,
+        kind: 'event',
+        name,
+        payload: applied.payload,
+        revision: 0,
+      });
+      return commit(
+        { canonicalInput, key, kind: 'event', name, payload: applied.payload, state: applied.state },
+        options.expectedRevision,
+      );
+    },
+
+    async read(options: AgentStateReadOptions = {}): Promise<AgentStateSnapshot<TState>> {
+      expectOperable(internals.closed, internals.definition.id, options.signal);
+      expectRevisionShape(options.revision, `State '${internals.definition.id}' revision`);
+      if (options.revision === undefined || options.revision === internals.head.revision) {
+        return internals.head;
+      }
+      if (options.revision > internals.head.revision) {
+        throw new AgentStateError(
+          'revision-unavailable',
+          `State '${internals.definition.id}' revision ${String(options.revision)} is beyond the head ${String(internals.head.revision)}`,
+        );
+      }
+      return Object.freeze({
+        revision: options.revision,
+        state: replayJournal(internals.definition, internals.journal, options.revision),
+      });
+    },
+
+    async reset(options: AgentStateResetOptions<TState>): Promise<AgentStateCommitResult<TState>> {
+      expectOperable(internals.closed, internals.definition.id, options.signal);
+      const key = expectIdempotencyKey(options.idempotencyKey);
+      expectRevisionShape(options.expectedRevision, `State '${internals.definition.id}' expectedRevision`);
+      const state = resolveResetState(internals.definition, options.seed);
+      const canonicalInput = canonicalCommitInput({
+        committedAt: '',
+        idempotencyKey: key,
+        kind: 'reset',
+        revision: 0,
+        state,
+      });
+      return commit({ canonicalInput, key, kind: 'reset', state }, options.expectedRevision);
+    },
+  };
+
+  return { internals, store: Object.freeze(store) };
+};
+
+const migrateOpenStore = <TState, TEvents extends AgentStateEventSchemas>(
+  internals: MemoryStoreInternals<TState, TEvents>,
+  definition: AgentStateDefinition<TState, TEvents>,
+  now: () => Date,
+): void => {
+  const migrated = runStateMigrations(definition, internals.definition.version, internals.head.state);
+  const record: AgentStateJournalRecord = {
+    committedAt: now().toISOString(),
+    idempotencyKey: migrationIdempotencyKey(definition.version),
+    kind: 'migrate',
+    revision: internals.head.revision + 1,
+    state: migrated,
+    toVersion: definition.version,
+  };
+  internals.journal.push(record);
+  internals.keys.set(record.idempotencyKey, record);
+  internals.head = Object.freeze({ revision: record.revision, state: migrated });
+  internals.definition = definition;
+};
+
+export const createMemoryStateDriver = (options: MemoryStateDriverOptions = {}): AgentStateDriver => {
+  const lifetime = expectVolatileLifetime(options.lifetime ?? 'process');
+  const now = options.now ?? ((): Date => new Date());
+  // Heterogeneously typed per definition; entries are cast back at the one
+  // retrieval site below, keyed by the definition id they were created for.
+  const registry = new Map<string, MemoryStoreEntry<unknown, AgentStateEventSchemas>>();
+  let closed = false;
+
+  return Object.freeze({
+    durable: false,
+    kind: 'memory',
+    lifetime,
+
+    async close(): Promise<void> {
+      closed = true;
+      for (const entry of [...registry.values()]) {
+        await entry.store.close();
+      }
+      registry.clear();
+    },
+
+    async open<TState, TEvents extends AgentStateEventSchemas>(
+      definition: AgentStateDefinition<TState, TEvents>,
+    ): Promise<AgentStateStore<TState, TEvents>> {
+      if (closed) {
+        throw new AgentStateError('store-closed', `State '${definition.id}' cannot open on a closed driver`);
+      }
+      if (definition.lifetime !== lifetime) {
+        throw new AgentStateError(
+          'lifetime-mismatch',
+          `State '${definition.id}' declares lifetime '${definition.lifetime}' but this driver provides '${lifetime}'`,
+        );
+      }
+      switch (lifetime) {
+        case 'request':
+          return createMemoryStore(definition, lifetime, now, () => undefined).store;
+        case 'process': {
+          const existing = registry.get(definition.id) as unknown as MemoryStoreEntry<TState, TEvents> | undefined;
+          if (existing === undefined) {
+            const created = createMemoryStore(definition, lifetime, now, () => registry.delete(definition.id));
+            registry.set(definition.id, created as unknown as MemoryStoreEntry<unknown, AgentStateEventSchemas>);
+            return created.store;
+          }
+          if (definition.version !== existing.internals.definition.version) {
+            migrateOpenStore(existing.internals, definition, now);
+          }
+          return existing.store;
+        }
+        default: {
+          const unreachable: never = lifetime;
+          throw new AgentStateError('invalid-definition', `Unknown volatile lifetime ${String(unreachable)}`);
+        }
+      }
+    },
+  });
+};

--- a/packages/rsc-runtime/tests/state-conformance.test.ts
+++ b/packages/rsc-runtime/tests/state-conformance.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from '@rstest/core';
+
+import {
+  createMemoryStateDriver,
+  stateDriverConformanceCases,
+  type StateConformanceContext,
+} from '../src/state/index.js';
+
+/**
+ * Runs the shared driver conformance suite against the in-memory driver
+ * (test-only, never durable). The workspace-durable `node:sqlite` driver
+ * runs the same cases in state-sqlite tests; any external driver must pass
+ * this exact suite to count as a completed integration (#98).
+ */
+const memoryContext = (): StateConformanceContext => {
+  // One driver per case: `open` and `reopen` both resolve the shared
+  // process-lifetime store, which is exactly what "another instance" means
+  // for volatile in-process storage.
+  const driver = createMemoryStateDriver({ lifetime: 'process' });
+  return {
+    durable: false,
+    lifetime: 'process',
+    open: (definition) => driver.open(definition),
+    reopen: (definition) => driver.open(definition),
+  };
+};
+
+describe('memory driver conformance', () => {
+  for (const conformanceCase of stateDriverConformanceCases) {
+    if (conformanceCase.durableOnly === true) {
+      it.skip(`${conformanceCase.name} (durable-only)`, () => undefined);
+      continue;
+    }
+    it(conformanceCase.name, () => conformanceCase.run(memoryContext()));
+  }
+});

--- a/packages/rsc-runtime/tests/state-kernel.test.ts
+++ b/packages/rsc-runtime/tests/state-kernel.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from '@rstest/core';
+import { z } from 'zod';
+
+import { agent, runAgentRequest } from '../src/index.js';
+import {
+  AGENT_STATE_LIFETIMES,
+  AgentStateError,
+  agentStateLifetimeIsVolatile,
+  createAgentStateHandle,
+  createMemoryStateDriver,
+  defineState,
+  type AgentStateDefinition,
+  type AgentStateHandle,
+  type AgentStateLifetime,
+} from '../src/state/index.js';
+
+const counterEvents = {
+  incremented: z.object({ by: z.number().int().min(1) }).strict(),
+} as const;
+
+interface CounterState {
+  readonly count: number;
+}
+
+const counterDefinition = (
+  lifetime: AgentStateLifetime = 'process',
+  id = 'state-kernel-test/counter',
+): AgentStateDefinition<CounterState, typeof counterEvents> =>
+  defineState({
+    events: counterEvents,
+    id,
+    initial: { count: 0 },
+    lifetime,
+    reduce: (state, event) => ({ count: state.count + event.payload.by }),
+    schema: z.object({ count: z.number().int() }).strict(),
+  });
+
+describe('defineState', () => {
+  it('rejects invalid definitions with typed invalid-definition errors', () => {
+    const base = {
+      events: counterEvents,
+      id: 'state-kernel-test/invalid',
+      initial: { count: 0 },
+      lifetime: 'process' as const,
+      reduce: (state: CounterState) => state,
+      schema: z.object({ count: z.number().int() }).strict(),
+    };
+    const failures: readonly (() => unknown)[] = [
+      () => defineState({ ...base, id: '  ' }),
+      () => defineState({ ...base, lifetime: 'session' as never }),
+      () => defineState({ ...base, events: {} as never }),
+      () => defineState({ ...base, events: { incremented: 42 } as never }),
+      () => defineState({ ...base, version: 0 }),
+      () => defineState({ ...base, version: 1.5 }),
+      // Version 2 without the migration step to 2.
+      () => defineState({ ...base, version: 2 }),
+      // Migration step outside 2..version.
+      () => defineState({ ...base, migrations: { 3: (value: unknown) => value }, version: 2 }),
+      // Migrations without a version bump.
+      () => defineState({ ...base, migrations: { 2: (value: unknown) => value } }),
+      // Initial state fails the schema.
+      () => defineState({ ...base, initial: { count: 0.5 } }),
+      // Initial state is not JSON-safe.
+      () =>
+        defineState({
+          ...base,
+          initial: { count: Number.POSITIVE_INFINITY },
+          schema: z.object({ count: z.number() }).strict(),
+        }),
+      () => defineState({ ...base, reduce: undefined as never }),
+    ];
+    for (const failure of failures) {
+      expect(failure).toThrow(AgentStateError);
+      try {
+        failure();
+      } catch (error) {
+        expect((error as AgentStateError).code).toBe('invalid-definition');
+      }
+    }
+  });
+
+  it('freezes the definition and its parsed initial state', () => {
+    const definition = counterDefinition();
+    expect(Object.isFrozen(definition)).toBe(true);
+    expect(Object.isFrozen(definition.initial)).toBe(true);
+    expect(definition.version).toBe(1);
+    expect(definition.migrations).toEqual({});
+  });
+
+  it('schema issues in errors name paths and codes, never rejected values', () => {
+    const definition = defineState({
+      events: { noted: z.object({ secret: z.string().max(3) }).strict() },
+      id: 'state-kernel-test/error-hygiene',
+      initial: { notes: [] as readonly string[] },
+      lifetime: 'process',
+      reduce: (state, event) => ({ notes: [...state.notes, event.payload.secret] }),
+      schema: z.object({ notes: z.array(z.string()) }).strict(),
+    });
+    const driver = createMemoryStateDriver();
+    const confidential = 'hunter2-super-secret';
+    return driver
+      .open(definition)
+      .then((store) => store.dispatch('noted', { secret: confidential }, { idempotencyKey: 'n1' }))
+      .then(
+        () => {
+          throw new Error('expected dispatch to reject');
+        },
+        (error: unknown) => {
+          expect(error).toBeInstanceOf(AgentStateError);
+          expect((error as AgentStateError).code).toBe('invalid-event');
+          expect((error as AgentStateError).message).not.toContain(confidential);
+          expect((error as AgentStateError).message).toContain('secret');
+        },
+      );
+  });
+});
+
+describe('agentStateLifetimeIsVolatile', () => {
+  it('classifies every lifetime in the taxonomy', () => {
+    expect(AGENT_STATE_LIFETIMES).toEqual(['request', 'process', 'workspace-durable', 'external']);
+    expect(agentStateLifetimeIsVolatile('request')).toBe(true);
+    expect(agentStateLifetimeIsVolatile('process')).toBe(true);
+    expect(agentStateLifetimeIsVolatile('workspace-durable')).toBe(false);
+    expect(agentStateLifetimeIsVolatile('external')).toBe(false);
+    expect(() => agentStateLifetimeIsVolatile('daemon' as never)).toThrow(AgentStateError);
+  });
+});
+
+describe('createMemoryStateDriver', () => {
+  it('is labeled test-only volatile storage and never durable', () => {
+    const driver = createMemoryStateDriver();
+    expect(driver.durable).toBe(false);
+    expect(driver.kind).toBe('memory');
+    expect(driver.lifetime).toBe('process');
+    expect(() => createMemoryStateDriver({ lifetime: 'workspace-durable' as never })).toThrow(
+      AgentStateError,
+    );
+  });
+
+  it('shares one process store per definition id and isolates request stores', async () => {
+    const processDriver = createMemoryStateDriver({ lifetime: 'process' });
+    const processDefinition = counterDefinition('process');
+    const first = await processDriver.open(processDefinition);
+    const second = await processDriver.open(processDefinition);
+    await first.dispatch('incremented', { by: 2 }, { idempotencyKey: 'i1' });
+    expect((await second.read()).state).toEqual({ count: 2 });
+
+    const requestDriver = createMemoryStateDriver({ lifetime: 'request' });
+    const requestDefinition = counterDefinition('request');
+    const a = await requestDriver.open(requestDefinition);
+    const b = await requestDriver.open(requestDefinition);
+    await a.dispatch('incremented', { by: 5 }, { idempotencyKey: 'i1' });
+    expect((await b.read()).revision).toBe(0);
+  });
+
+  it('reducers receive frozen state, so accidental mutation fails the dispatch', async () => {
+    const definition = defineState({
+      events: { pushed: z.object({ value: z.string() }).strict() },
+      id: 'state-kernel-test/mutating-reducer',
+      initial: { values: [] as string[] },
+      lifetime: 'process',
+      reduce: (state, event) => {
+        state.values.push(event.payload.value); // mutation of frozen state throws
+        return state;
+      },
+      schema: z.object({ values: z.array(z.string()) }).strict(),
+    });
+    const store = await createMemoryStateDriver().open(definition);
+    await expect(store.dispatch('pushed', { value: 'x' }, { idempotencyKey: 'p1' })).rejects.toMatchObject({
+      code: 'reducer-failure',
+      name: 'AgentStateError',
+    });
+    expect((await store.read()).revision).toBe(0);
+  });
+
+  it('driver close closes every registered store', async () => {
+    const driver = createMemoryStateDriver();
+    const store = await driver.open(counterDefinition());
+    await driver.close();
+    await expect(store.read()).rejects.toMatchObject({ code: 'store-closed' });
+    await expect(driver.open(counterDefinition())).rejects.toMatchObject({ code: 'store-closed' });
+  });
+});
+
+describe('request context state slot', () => {
+  it('installs a request-bound handle on (await agent()).state', async () => {
+    const definition = counterDefinition();
+    const store = await createMemoryStateDriver().open(definition);
+    const handle = createAgentStateHandle(store);
+    await runAgentRequest({ invocation: { kind: 'tool' }, state: handle }, async () => {
+      const context = await agent();
+      expect(context.state).toBe(handle);
+      const committed = await context.state!.dispatch(
+        'incremented',
+        { by: 3 },
+        { idempotencyKey: 'evt-1' },
+      );
+      expect(committed).toMatchObject({ replayed: false, revision: 1, state: { count: 3 } });
+      expect(await context.state!.read()).toEqual({ revision: 1, state: { count: 3 } });
+      const batch = await context.state!.changes({ afterRevision: 0 });
+      expect(batch.headRevision).toBe(1);
+      expect(batch.changes).toHaveLength(1);
+    });
+    // The slot stays undefined for stateless requests.
+    await runAgentRequest({ invocation: { kind: 'tool' } }, async () => {
+      expect((await agent()).state).toBeUndefined();
+    });
+  });
+
+  it('exposes the declared lifetime and folds the request signal into operations', async () => {
+    const store = await createMemoryStateDriver().open(counterDefinition());
+    const controller = new AbortController();
+    const handle = createAgentStateHandle(store, { signal: controller.signal });
+    expect(handle.lifetime).toBe('process');
+    await handle.dispatch('incremented', { by: 1 }, { idempotencyKey: 'live' });
+    controller.abort(new Error('request settled'));
+    await expect(handle.read()).rejects.toMatchObject({ code: 'aborted' });
+    await expect(
+      handle.dispatch('incremented', { by: 1 }, { idempotencyKey: 'dead' }),
+    ).rejects.toMatchObject({ code: 'aborted' });
+    // A per-call signal still wins over the request signal.
+    await expect(
+      handle.read({ signal: new AbortController().signal }),
+    ).resolves.toEqual({ revision: 1, state: { count: 1 } });
+  });
+
+  it('a typed handle satisfies the loosely typed context slot', async () => {
+    const store = await createMemoryStateDriver().open(counterDefinition());
+    const typed: AgentStateHandle<CounterState, typeof counterEvents> = createAgentStateHandle(store);
+    const slot: AgentStateHandle = typed;
+    expect(slot.lifetime).toBe('process');
+  });
+});
+
+describe('explicit migrations', () => {
+  const v1 = (): AgentStateDefinition<CounterState, typeof counterEvents> =>
+    counterDefinition('process', 'state-kernel-test/migrating');
+
+  const v2Schema = z.object({ count: z.number().int(), unit: z.string() }).strict();
+
+  const v2 = (
+    migrate: (persisted: unknown) => unknown = (persisted) => ({
+      ...(persisted as CounterState),
+      unit: 'edits',
+    }),
+  ) =>
+    defineState({
+      events: counterEvents,
+      id: 'state-kernel-test/migrating',
+      initial: { count: 0, unit: 'edits' },
+      lifetime: 'process',
+      migrations: { 2: migrate },
+      reduce: (state, event) => ({ count: state.count + event.payload.by, unit: state.unit }),
+      schema: v2Schema,
+      version: 2,
+    });
+
+  it('runs the chain on open, records a migrate change, and rebases exact reads', async () => {
+    const driver = createMemoryStateDriver();
+    const storeV1 = await driver.open(v1());
+    await storeV1.dispatch('incremented', { by: 4 }, { idempotencyKey: 'i1' });
+    const storeV2 = await driver.open(v2());
+    expect(await storeV2.read()).toEqual({ revision: 2, state: { count: 4, unit: 'edits' } });
+    const changes = await storeV2.changes({ afterRevision: 0 });
+    expect(changes.changes.map((change) => change.kind)).toEqual(['event', 'migrate']);
+    await expect(storeV2.read({ revision: 1 })).rejects.toMatchObject({ code: 'revision-unavailable' });
+    // Reopening at the same version does not migrate again.
+    const again = await driver.open(v2());
+    expect((await again.read()).revision).toBe(2);
+  });
+
+  it('fails closed when a migration step throws or produces invalid state', async () => {
+    const throwingDriver = createMemoryStateDriver();
+    await throwingDriver.open(v1());
+    await expect(
+      throwingDriver.open(
+        v2(() => {
+          throw new Error('cannot migrate');
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'migration-failure' });
+
+    const invalidDriver = createMemoryStateDriver();
+    await invalidDriver.open(v1());
+    await expect(invalidDriver.open(v2(() => ({ wrong: true })))).rejects.toMatchObject({
+      code: 'migration-failure',
+    });
+  });
+
+  it('rejects opening a persisted-newer store with an older definition', async () => {
+    const driver = createMemoryStateDriver();
+    await driver.open(v2());
+    await expect(driver.open(v1())).rejects.toMatchObject({ code: 'migration-missing' });
+  });
+});


### PR DESCRIPTION
## Summary

Wave 2 Lane B, PR 1 of 2 for the #98 v1 state kernel (plan #107 §6, G3 recorded).

- **Driver-neutral contract** behind the new `@agent-bundle/runtime/state` subpath: `defineState({ schema, initial, events, reduce })` (zod schemas, typed event union, pure deterministic reducer), typed `AgentStateError` codes, monotonic revisions, exact-revision snapshot reads, idempotency-key replay (duplicate key returns the committed result; conflicting payload under the same key is a typed `idempotency-conflict`), compare-and-swap via `expectedRevision`, explicit versioned migrations that rebase history, deterministic resets, and polling change cursors — nothing stronger promised.
- **Explicit lifetime taxonomy** `AgentStateLifetime = 'request' | 'process' | 'workspace-durable' | 'external'` with exhaustive never-default switches; volatile vs durable is a typed property, never inferred from an MCP process.
- **In-memory driver** for the `request` and `process` lifetimes — labeled test-only as a durability stand-in, `durable: false` structurally, refuses durable lifetimes.
- **Request-bound handle** `createAgentStateHandle(store, { signal })` fills the reserved `state` slot #113 shipped on `AgentRequestContext`: `(await agent()).state.dispatch(event, payload, { idempotencyKey })`. Slot type goes `undefined` → `AgentStateHandle | undefined`; wiring stays additive.
- **Conformance suite** (`stateDriverConformanceCases`, `node:assert`-based, runner-agnostic): 18 shared cases every driver must pass; runs here against the memory driver. PR-2 runs the same suite against the `node:sqlite` workspace-durable driver.
- **Packaging**: `./state` is its own rslib entry + subpath export; `dist/index.js` / `dist/plugin.js` contain none of the kernel (verified against the built tree; PR-2 adds the packaged-tree test alongside the sqlite entry). README + `docs/framework-mode.md` persistence statements flipped in-PR.

PR-2 (same branch family) ships the `node:sqlite` workspace-durable driver (G3), cross-process proofs, and the `examples/rsc-agent-runtime` migration that retires the 781-line JSONL kernel.

## Test plan

- `pnpm --filter @agent-bundle/runtime test` — 73 passed (17 conformance cases on memory, kernel/migration/handle units; 1 durable-only case skipped by design)
- `pnpm --filter @agent-bundle/runtime typecheck` + root `pnpm typecheck` — clean
- `pnpm lint` — clean
- Built-tree check: `dist/state.js` smoke-tested; root entries free of state/kernel identifiers

Refs #98, #107.