### PR TITLE
perf(examples): parallelize examples:check with scaled budgets (#128 rec 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "example:audiobook": "pnpm build && pnpm --filter @agent-bundle-example/audiobook-curator dev",
     "example:mcp-app": "pnpm build && pnpm --filter @agent-bundle-example/mcp-app dev",
     "example:skills": "pnpm build && pnpm --filter @agent-bundle-example/skills-starter dev",
-    "examples:check": "pnpm build && pnpm --filter './examples/*' --workspace-concurrency=1 check"
+    "examples:check": "pnpm build && AGENT_BUNDLE_TEST_TIME_SCALE=${AGENT_BUNDLE_TEST_TIME_SCALE:-2} pnpm --filter './examples/*' --workspace-concurrency=3 check"
   },
   "devDependencies": {
     "@changesets/cli": "3.0.1",


### PR DESCRIPTION
## Summary

- Implements [#128](https://github.com/ScriptedAlchemy/agent-bundle/issues/128) recommendation 1: `examples:check` runs the five example `check` scripts at `--workspace-concurrency=3` instead of one at a time. The examples are disjoint directories, and the audit measured the serial shape as the gate's critical path (5m14s of a 9m52s green gate wall).
- Parallel example checks share cores exactly like the multi-worker integration pool, so the script also floors `AGENT_BUNDLE_TEST_TIME_SCALE` at 2 (`${AGENT_BUNDLE_TEST_TIME_SCALE:-2}`), mirroring the integration config's multi-worker `poolTimeScale`. An externally provided larger value is never lowered — local-ci passes 4 into its gates leg, and the hosted examples-check job pins 4 through the `CI` env inside each example's own time-scale helper.

## Why the scale floor is needed

A first verification run at concurrency 3 with the default scale of 1 failed exactly one test: `examples/rsc-agent-runtime tests/dev-invocation.integration.test.ts :: contains invocation stdout, stderr, and timeout failures…` timed out at its `45_000 * timeScale` budget while the other examples' rsbuild builds competed for cores — the precise contention class the repo's time-scale mechanism exists for (see `rstest.integration.config.ts`).

## Test plan

- [x] `pnpm examples:check` green end to end at concurrency 3 with the scale floor, on a loaded 96-core machine (load ~30): all five example checks pass, 3m47s wall including the root build (vs 5m14s measured serial in the audit).

Refs #128.