### PR TITLE
perf(tests): move the 600s evidence-capture journey to a nightly pool (#128 rec 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
             pnpm exec playwright install --with-deps chrome
           fi
       - run: pnpm check:release
+      # Nightly evidence-capture pool: documentation-artifact browser
+      # journeys whose behavioral contracts are already proven per PR by the
+      # integration pool (see nightlyEvidenceTestFiles).
+      - run: pnpm test:evidence
 
   rsc-runtime-micro-eval:
     # Deterministic end-to-end spot-check of the built RSC runtime artifacts

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit": "rstest --config rstest.unit.config.ts",
     "test:integration": "pnpm build && pnpm test:integration:run",
     "test:integration:run": "AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 rstest --config rstest.integration.config.ts",
+    "test:evidence": "pnpm build && AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 rstest --config rstest.evidence.config.ts",
     "test:watch": "rstest --config rstest.config.ts --watch",
     "lint": "rslint .",
     "typecheck": "tsc --noEmit && tsc --project packages/workbench/tsconfig.json && tsc --project packages/create-agent-bundle/tsconfig.json",

--- a/rstest.evidence.config.ts
+++ b/rstest.evidence.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rstest/core';
+
+import { nightlyEvidenceTestFiles } from './rstest.integration-tests.ts';
+import { withAgentBundleRslibConfig } from './rstest.rslib.ts';
+
+/**
+ * The nightly evidence-capture pool (`pnpm test:evidence`): the single-file
+ * documentation-artifact journeys listed in nightlyEvidenceTestFiles. One
+ * worker — each journey drives its own Chrome + dev-server + rsbuild trio
+ * end to end, so there is nothing to parallelize — and the same shared
+ * example-payload globalSetup the integration pool uses, because the
+ * capture harness copies `examples/rsc-agent-runtime/dist` through
+ * runtime-playground-fixture.ts.
+ */
+export default defineConfig({
+  extends: withAgentBundleRslibConfig(),
+  include: [...nightlyEvidenceTestFiles],
+  globalSetup: ['./rstest.integration.setup.ts'],
+  pool: { maxWorkers: 1 },
+  setupFiles: ['./rstest.setup.ts'],
+  isolate: true,
+  testTimeout: 30_000,
+});

--- a/rstest.integration-tests.ts
+++ b/rstest.integration-tests.ts
@@ -59,10 +59,23 @@ export const integrationTestFiles: readonly string[] = [
   'packages/workbench/tests/rsbuild-workbench.test.ts',
   'packages/workbench/tests/runtime-inspector.test.ts',
   'packages/workbench/tests/runtime-consent-dialog.test.ts',
-  'packages/workbench/tests/runtime-playground-capture.test.ts',
   'packages/workbench/tests/runtime-playground.e2e.test.ts',
   'packages/workbench/tests/runtime-playground-hmr.e2e.test.ts',
   'packages/workbench/tests/workbench-dev-command.test.ts',
+];
+
+/**
+ * Evidence-capture harnesses: browser journeys whose product is a
+ * documentation artifact (screenshots + evidence.json), not a per-PR
+ * behavioral proof. The behavioral contracts they exercise (HMR activation,
+ * last-good retention, recovery) are already covered per PR by
+ * runtime-playground.e2e.test.ts and runtime-playground-hmr.e2e.test.ts in
+ * the integration pool, so these run through the root `test:evidence`
+ * script in CI's nightly schedule instead — evidence regenerates when the
+ * flow changes, not on every PR (#128).
+ */
+export const nightlyEvidenceTestFiles: readonly string[] = [
+  'packages/workbench/tests/runtime-playground-capture.test.ts',
 ];
 
 /**

--- a/rstest.unit.config.ts
+++ b/rstest.unit.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rstest/core';
 
-import { integrationTestFiles, packedTestFiles, templateTestFiles } from './rstest.integration-tests.ts';
+import { integrationTestFiles, nightlyEvidenceTestFiles, packedTestFiles, templateTestFiles } from './rstest.integration-tests.ts';
 import { withAgentBundleRslibConfig } from './rstest.rslib.ts';
 
 /** Build-free, process-free tests only; safe on parallel workers. `pnpm test` runs this before the integration config. */
@@ -9,7 +9,7 @@ export default defineConfig({
   include: [
     'packages/**/tests/**/*.test.ts',
   ],
-  exclude: [...integrationTestFiles, ...packedTestFiles, ...templateTestFiles],
+  exclude: [...integrationTestFiles, ...nightlyEvidenceTestFiles, ...packedTestFiles, ...templateTestFiles],
   setupFiles: ['./rstest.setup.ts'],
   // Unit files construct per-test services; logs-real.e2e is not in this pool.
   isolate: false,


### PR DESCRIPTION
## Summary

- Implements [#128](https://github.com/ScriptedAlchemy/agent-bundle/issues/128) recommendation 2 (the audit's "one genuine misplacement"): `runtime-playground-capture.test.ts` — the 600s-budget browser journey whose product is a documentation artifact (screenshots + `evidence.json`) — leaves the per-PR integration pool. The behavioral contracts it exercises (HMR activation, last-good retention, recovery) stay proven per PR by `runtime-playground.e2e.test.ts` and `runtime-playground-hmr.e2e.test.ts` in the same pool.
- New `nightlyEvidenceTestFiles` list in `rstest.integration-tests.ts`, excluded from the unit pool, with its own `rstest.evidence.config.ts` (one worker; same shared example-payload `globalSetup`, because the capture harness copies `examples/rsc-agent-runtime/dist` through the playground fixture).
- New root script `pnpm test:evidence` runs in CI's nightly `packed-matrix` job — evidence regenerates when the flow changes, not on every PR. Estimated 60–120s off every per-PR integration pool run per the audit.
- Sequencing note from the audit is satisfied: #118 (which owned the shared `runtime-playground-fixture.ts` helper) has landed; this change touches no #118-owned file contents, only pool membership and new wiring.

## Test plan

- [x] `pnpm test:evidence` green: all three tests in the moved file pass, including the full identity-backed HMR/last-good/recovery browser journey.
- [x] `pnpm typecheck` and `pnpm lint` green.
- [x] Unit pool confirmed to still exclude the moved file (no `runtime-playground-capture` execution in `pnpm test:unit` output; the two unrelated 5s-timeout flakes observed under external machine load pass in isolation).

Refs #128.