### PR TITLE
refactor(dev): coalescing rebuild scheduler on Effect fiber + Semaphore + Deferred (wave 3.5 stage 3, PR 3)

### DIFF
--- a/.changeset/effect-rebuild-scheduler.md
+++ b/.changeset/effect-rebuild-scheduler.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Rewrite the dev coordinator's coalescing rebuild scheduler on Effect: build passes run as fibers holding a `Semaphore(1)` permit, and coalesced follow-up rebuilds share one `Deferred` result. No public API or behavior change.

--- a/packages/agent-bundle/src/dev/coordinator.ts
+++ b/packages/agent-bundle/src/dev/coordinator.ts
@@ -1,6 +1,9 @@
+import { Deferred, Effect, Semaphore } from 'effect';
 import { resolve } from 'node:path';
 
 import { freezeDiagnostics, hasErrors } from '../core/diagnostics.ts';
+import { runPromise, runSync } from '../effect/boundary.ts';
+import { liftPromise } from '../effect/lift.ts';
 import type { Diagnostic } from '../core/diagnostics.ts';
 import { ArtifactService, type ArtifactEpochResult, type FailedArtifactEpochResult } from './artifacts/artifact-service.ts';
 import { DiagnosticService, type DiagnosticReport } from './diagnostic-service.ts';
@@ -91,9 +94,14 @@ export interface DevCoordinatorOptions {
   readonly root: string;
 }
 
+/**
+ * The coalesced follow-up rebuild: every invalidation that arrives while a
+ * build runs merges into this single slot, and every requester shares one
+ * `Deferred` completed with the follow-up's result.
+ */
 interface QueuedBuild {
+  readonly deferred: Deferred.Deferred<ArtifactEpochResult>;
   readonly invalidation: Invalidation;
-  readonly resolvers: readonly ((result: ArtifactEpochResult) => void)[];
 }
 
 const emptySource = (): SourceStatus => Object.freeze({
@@ -209,6 +217,8 @@ export class DevCoordinator {
   readonly #prepareCommand: 'build' | 'dev';
   readonly #projectService: ProjectPreparer;
   readonly #root: string;
+  /** Serializes build passes; admission below guarantees one holder, the permit makes the invariant structural. */
+  readonly #buildPermit: Semaphore.Semaphore = runSync(Semaphore.make(1));
   readonly #startRebuildToken = Symbol('DevCoordinator initial rebuild');
   readonly #startupCancellation: Promise<void>;
   #activeEpoch: ArtifactEpoch | undefined;
@@ -281,14 +291,13 @@ export class DevCoordinator {
     if (this.#lock === undefined) return failure('DevCoordinator must be started before rebuilding.');
     const normalized = nowInvalidation(this.#now, invalidation.reason, invalidation.paths);
     if (this.#currentBuild === undefined) return this.#startBuild(normalized);
-    return new Promise<ArtifactEpochResult>((resolvePromise) => {
-      this.#queued = this.#queued === undefined
-        ? { invalidation: normalized, resolvers: [resolvePromise] }
-        : {
-          invalidation: mergeInvalidations(this.#queued.invalidation, normalized),
-          resolvers: [...this.#queued.resolvers, resolvePromise],
-        };
-    });
+    // Admission is synchronous on purpose: rebuilds issued in the same turn
+    // must observe the running build and merge into exactly one follow-up.
+    const queued = this.#queued;
+    this.#queued = queued === undefined
+      ? { deferred: runSync(Deferred.make<ArtifactEpochResult>()), invalidation: normalized }
+      : { deferred: queued.deferred, invalidation: mergeInvalidations(queued.invalidation, normalized) };
+    return runPromise(Deferred.await(this.#queued.deferred));
   }
 
   status(): ProjectStatus {
@@ -300,7 +309,9 @@ export class DevCoordinator {
     this.#closing = true;
     const queued = this.#queued;
     this.#queued = undefined;
-    queued?.resolvers.forEach((resolveResult) => resolveResult(failure('DevCoordinator is closing.')));
+    if (queued !== undefined) {
+      runSync(Deferred.succeed(queued.deferred, failure('DevCoordinator is closing.')));
+    }
     this.#closePromise = this.#close();
     return this.#closePromise;
   }
@@ -385,23 +396,34 @@ export class DevCoordinator {
     return this.#watcherClosePromise;
   }
 
+  /**
+   * Runs one build pass as an Effect fiber holding the build permit; the
+   * exit hook drains the coalesced follow-up slot before the caller's
+   * promise settles, exactly where the pre-Effect `finally` chain sat.
+   */
   #startBuild(invalidation: Invalidation): Promise<ArtifactEpochResult> {
-    const current = this.#performBuild(invalidation).finally(() => {
-      this.#currentBuild = undefined;
-      const queued = this.#queued;
-      this.#queued = undefined;
-      if (queued === undefined) return;
-      if (this.#closing) {
-        queued.resolvers.forEach((resolveResult) => resolveResult(failure('DevCoordinator is closing.')));
-        return;
-      }
-      this.#startBuild(queued.invalidation).then(
-        (result) => queued.resolvers.forEach((resolveResult) => resolveResult(result)),
-        () => queued.resolvers.forEach((resolveResult) => resolveResult(failure('DevCoordinator rebuild failed.'))),
-      );
-    });
+    const current = runPromise(this.#buildPermit.withPermit(
+      liftPromise(() => this.#performBuild(invalidation)).pipe(
+        Effect.onExit(() => Effect.sync(() => this.#drainQueuedBuild())),
+      ),
+    ));
     this.#currentBuild = current;
     return current;
+  }
+
+  #drainQueuedBuild(): void {
+    this.#currentBuild = undefined;
+    const queued = this.#queued;
+    this.#queued = undefined;
+    if (queued === undefined) return;
+    if (this.#closing) {
+      runSync(Deferred.succeed(queued.deferred, failure('DevCoordinator is closing.')));
+      return;
+    }
+    this.#startBuild(queued.invalidation).then(
+      (result) => runSync(Deferred.succeed(queued.deferred, result)),
+      () => runSync(Deferred.succeed(queued.deferred, failure('DevCoordinator rebuild failed.'))),
+    );
   }
 
   #beginBuild(invalidation: Invalidation, source: SourceStatus): RunningBuildAttempt {


### PR DESCRIPTION
## Summary

Subsystem 2 of 4 for #152 stage 3. Reordered ahead of the SSE hub and EpochStore with one sentence of justification: the scheduler is a single self-contained seam inside `DevCoordinator` with unit-pool-only owning suites, while EpochStore carries cross-process durability contracts — smallest remaining blast radius first. (The SSE hub audit outcome is recorded below.)

- **Build passes are Effect fibers.** `#startBuild` runs `#performBuild` under a `Semaphore(1)` permit (`withPermit`); admission already guarantees a single holder, the permit makes the serialization invariant structural rather than implicit.
- **Coalescing on `Deferred`.** Every rebuild that arrives while a build runs merges (unchanged `mergeInvalidations`) into one queued slot whose requesters share a single `Deferred<ArtifactEpochResult>`; the drain hook (`Effect.onExit`, sitting exactly where the pre-Effect `finally` chain sat) starts the follow-up fiber and completes the deferred with its result, `failure('DevCoordinator is closing.')` on close, or the sentinel failure if the follow-up rejects.
- **Admission stays synchronous by design** (documented in-code): same-turn rebuilds must observe the running build and coalesce into exactly one follow-up — deferring admission into a fiber would split them.
- Startup cancellation (`#awaitStartup` races) is deliberately untouched: it is the startup lifecycle, not the rebuild scheduler, and its three blocked-startup suites pin Promise-level sequencing.

## SSE hub audit note (subsystem decision, code lands separately)

The planned "PubSub-backed SSE hub" fails the honesty test: the hub's public contract is synchronous re-entrant fan-out — `foreground-server.ts` documents "EventHub delivery is synchronous" as the invariant that lets shutdown tombstones reach socket buffers before sockets are destroyed, and ~15 tests pin sync replay/removal/ordering. Effect `PubSub` is an async fan-out structure; fiber delivery changes that observable contract. The hub stays imperative; `docs/effect-conventions.md` gets the record in the closing docs PR.

## Parity (all suites unchanged, zero pin flips)

- Owning suites (`dev-coordinator`, `dev-watcher`, `dev-server`, `dev-events`, `dev-events.contract`): 74 passed / 0 failed
- Full unit pool: 1999 passed / 5 documented skips / 0 failed
- `pnpm lint` + `pnpm typecheck`: green
- Changeset: patch (internal rewrite).

Refs #152.