### PR TITLE
feat(events): define v1 semantic route descriptors

### DIFF
--- a/.changeset/semantic-event-route-descriptors.md
+++ b/.changeset/semantic-event-route-descriptors.md
@@ -1,0 +1,7 @@
+---
+"agent-bundle": minor
+"@agent-bundle/runtime": minor
+---
+
+Add the seven v1 semantic event-route descriptors and the `Agent.Context`
+document vocabulary used for immediate host guidance.

--- a/packages/agent-bundle/src/api.ts
+++ b/packages/agent-bundle/src/api.ts
@@ -12,7 +12,25 @@ import { emptyCompiledRouteGraph } from './routes/graph.ts';
 import { inspectRouteGraph, type RouteGraphInspection } from './routes/inspect.ts';
 import { mcpServerStateDirectory, runMcpForeground } from './services/mcp-run.ts';
 export { compileRouteGraph, emptyCompiledRouteGraph, isEmptyRouteGraph } from './routes/graph.ts';
-export type { AppRouteConfig, PromptConfig, ResourceConfig, RouteSchema, RouteSchemaOutput, ToolConfig, ToolRouteProps } from './routes/public.ts';
+export { canonicalAgentEvents } from './routes/public.ts';
+export type {
+  AgentEventCanonicalIdentity,
+  AgentEventDelivery,
+  AgentEventFallbackMode,
+  AgentEventNativePayload,
+  AgentEventProvenance,
+  AgentEventRouteConfig,
+  AgentEventRouteProps,
+  AgentEventRuntimeMode,
+  AppRouteConfig,
+  CanonicalAgentEvent,
+  PromptConfig,
+  ResourceConfig,
+  RouteSchema,
+  RouteSchemaOutput,
+  ToolConfig,
+  ToolRouteProps,
+} from './routes/public.ts';
 export { inspectRouteGraph } from './routes/inspect.ts';
 export type { RouteGraphInspection } from './routes/inspect.ts';
 export { emptyRouteConfig } from './routes/types.ts';

--- a/packages/agent-bundle/src/build/entry-shell.ts
+++ b/packages/agent-bundle/src/build/entry-shell.ts
@@ -275,6 +275,7 @@ export const generatedRouteMcpEntrySource = (options: GeneratedRouteMcpEntryOpti
     'const appendNode = (node, content) => {',
     '  switch (node.kind) {',
     "    case 'result': for (const child of node.children) appendNode(child, content); break;",
+    "    case 'context':",
     "    case 'markdown':",
     "    case 'text': content.push({ text: node.text, type: 'text' }); break;",
     "    case 'json': content.push({ text: JSON.stringify(node.value), type: 'text' }); break;",

--- a/packages/agent-bundle/src/index.ts
+++ b/packages/agent-bundle/src/index.ts
@@ -4,7 +4,25 @@ import type { PortableConfigExtension } from './adapters/portable.ts';
 import type { AgentBundleConfig as CoreAgentBundleConfig } from './core/types.ts';
 
 export { defineConfig, pathTokens, pluginRootEnvAnchor } from './core/types.ts';
-export type { AppRouteConfig, PromptConfig, ResourceConfig, RouteSchema, RouteSchemaOutput, ToolConfig, ToolRouteProps } from './routes/public.ts';
+export { canonicalAgentEvents } from './routes/public.ts';
+export type {
+  AgentEventCanonicalIdentity,
+  AgentEventDelivery,
+  AgentEventFallbackMode,
+  AgentEventNativePayload,
+  AgentEventProvenance,
+  AgentEventRouteConfig,
+  AgentEventRouteProps,
+  AgentEventRuntimeMode,
+  AppRouteConfig,
+  CanonicalAgentEvent,
+  PromptConfig,
+  ResourceConfig,
+  RouteSchema,
+  RouteSchemaOutput,
+  ToolConfig,
+  ToolRouteProps,
+} from './routes/public.ts';
 export { compareEvals, runEvals, startDevServer } from './api.ts';
 export {
   createCodexEvalHarness,

--- a/packages/agent-bundle/src/routes/contract.ts
+++ b/packages/agent-bundle/src/routes/contract.ts
@@ -28,12 +28,16 @@ const diagnostic = (
   recovery: string,
 ): Diagnostic => ({ code, message, recovery, severity: 'error', sourcePath });
 
-/** Validates G8's one executable route contract without evaluating the module. */
-export const validateRouteModuleContract = (
+interface RouteModuleShape {
+  readonly asyncDefault: boolean;
+  readonly named: ReadonlySet<string>;
+  readonly splitExport: boolean;
+}
+
+const inspectRouteModule = (
   moduleText: string,
   relativePath: string,
-  sourcePath: string,
-): readonly Diagnostic[] => {
+): RouteModuleShape => {
   const sourceFile = ts.createSourceFile(relativePath, moduleText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const named = new Set<string>();
   let asyncDefault = false;
@@ -71,6 +75,16 @@ export const validateRouteModuleContract = (
     }
   }
 
+  return { asyncDefault, named, splitExport };
+};
+
+/** Validates G8's one executable MCP route contract without evaluating the module. */
+export const validateRouteModuleContract = (
+  moduleText: string,
+  relativePath: string,
+  sourcePath: string,
+): readonly Diagnostic[] => {
+  const { asyncDefault, named, splitExport } = inspectRouteModule(moduleText, relativePath);
   const missing = ['inputSchema', 'resultSchema'].filter((name) => !named.has(name));
   const diagnostics: Diagnostic[] = [];
   if (missing.length > 0 || !asyncDefault) {
@@ -89,6 +103,33 @@ export const validateRouteModuleContract = (
     diagnostics.push(diagnostic(
       'AB4811',
       `Route module ${relativePath} exports execute or render; routed modules use one async default Server Component instead of an execute/render split.`,
+      sourcePath,
+      'Move execution into the async default component and render Agent.* elements from that component.',
+    ));
+  }
+  return Object.freeze(diagnostics);
+};
+
+/** Validates an event route's single async component contract without requiring MCP schemas. */
+export const validateEventRouteModuleContract = (
+  moduleText: string,
+  relativePath: string,
+  sourcePath: string,
+): readonly Diagnostic[] => {
+  const { asyncDefault, splitExport } = inspectRouteModule(moduleText, relativePath);
+  const diagnostics: Diagnostic[] = [];
+  if (!asyncDefault) {
+    diagnostics.push(diagnostic(
+      'AB4810',
+      `Event route module ${relativePath} does not satisfy the public route contract: default export is not an async function component.`,
+      sourcePath,
+      'Export one async default Server Component receiving { canonical, native, signal }.',
+    ));
+  }
+  if (splitExport) {
+    diagnostics.push(diagnostic(
+      'AB4811',
+      `Event route module ${relativePath} exports execute or render; routed modules use one async default Server Component instead of an execute/render split.`,
       sourcePath,
       'Move execution into the async default component and render Agent.* elements from that component.',
     ));

--- a/packages/agent-bundle/src/routes/graph.ts
+++ b/packages/agent-bundle/src/routes/graph.ts
@@ -6,12 +6,13 @@ import fastGlob from 'fast-glob';
 
 import { isProjectPathIgnored, readProjectIgnoreRules, toPosixPath } from '../config/ignore.ts';
 import { extractRouteConfig } from './config-extract.ts';
-import { validateRouteModuleContract } from './contract.ts';
+import { validateEventRouteModuleContract, validateRouteModuleContract } from './contract.ts';
 import type { Diagnostic } from '../core/diagnostics.ts';
 import { digest } from '../core/digest.ts';
 import { deepFreeze } from '../core/freeze.ts';
 import { isRecord } from '../core/strict-json.ts';
 import type { AgentBundleConfig } from '../core/types.ts';
+import { canonicalAgentEvents, type CanonicalAgentEvent } from './public.ts';
 import {
   emptyRouteConfig,
   type CompiledAgentRoute,
@@ -35,6 +36,7 @@ type ProjectIgnoreRules = Awaited<ReturnType<typeof readProjectIgnoreRules>>;
 const routeGlobs = [
   'src/mcp/*/{tools,resources,prompts,apps}/*.{ts,tsx}',
   'src/events/*/*.{ts,tsx}',
+  'src/events/stop.{ts,tsx}',
   'src/providers/*.{ts,tsx}',
   'src/cli/**/*.{ts,tsx}',
   // Scripts also discover .jsx: the stage-1 script gate judges rendered
@@ -105,6 +107,7 @@ interface DiscoveredProviderModule {
 }
 
 interface DiscoveredRouteModule {
+  readonly event?: CanonicalAgentEvent;
   readonly id: string;
   /** The path-derived name segments; each must satisfy the safe-identity rule. */
   readonly identitySegments: readonly string[];
@@ -138,10 +141,11 @@ const classifyModule = (source: string, relativePath: string): DiscoveredModule 
     };
   }
   if (collection === 'events') {
-    const family = segments[2]!;
+    const event = segments.length === 3 ? stem : `${segments[2]!}/${stem}`;
     return {
-      id: `event:${family}/${stem}`,
-      identitySegments: [family, stem],
+      event: event as CanonicalAgentEvent,
+      id: `event:${event}`,
+      identitySegments: event.split('/'),
       kind: 'event-route',
       relativePath,
       source,
@@ -302,6 +306,7 @@ const compiledRoute = (
   config: Readonly<Record<string, unknown>>,
 ): CompiledAgentRoute => ({
   config,
+  ...(module.event === undefined ? {} : { event: module.event }),
   id: module.id,
   kind: module.kind,
   provenance: { kind: 'conventional', relativePath: module.relativePath },
@@ -331,6 +336,7 @@ const extractedModuleConfig = async (
 
 const routeIdentity = (route: CompiledAgentRoute): Readonly<Record<string, unknown>> => ({
   config: route.config,
+  ...(route.event === undefined ? {} : { event: route.event }),
   id: route.id,
   kind: route.kind,
   relativePath: route.provenance.relativePath,
@@ -392,6 +398,19 @@ export const compileRouteGraph = async (
     const relativePath = toPosixPath(relative(projectRoot, source));
     if (isPrivateRoutePath(relativePath) || isProjectPathIgnored(rules, projectRoot, source)) continue;
     const module = classifyModule(source, relativePath);
+    if (
+      module.surface === 'route' &&
+      module.kind === 'event-route' &&
+      !canonicalAgentEvents.includes(module.event!)
+    ) {
+      diagnostics.push(routeError(
+        'AB4813',
+        `Event route ${relativePath} declares ${JSON.stringify(module.event)}, which is outside the #97 v1 event vocabulary.`,
+        `Use one of: ${canonicalAgentEvents.join(', ')}.`,
+        source,
+      ));
+      continue;
+    }
     const unsafeSegment = module.identitySegments.find((segment) => !safeIdentitySegment.test(segment));
     if (unsafeSegment !== undefined) {
       diagnostics.push(routeError(
@@ -432,6 +451,17 @@ export const compileRouteGraph = async (
       continue;
     }
     const route = compiledRoute(module, await extractedModuleConfig(module, diagnostics));
+    if (route.kind === 'event-route') {
+      try {
+        diagnostics.push(...validateEventRouteModuleContract(
+          await readFile(route.source, 'utf8'),
+          route.provenance.relativePath,
+          route.source,
+        ));
+      } catch {
+        // Racing deletion is handled by the next source snapshot.
+      }
+    }
     switch (route.kind) {
       case 'tool':
       case 'resource':

--- a/packages/agent-bundle/src/routes/index.ts
+++ b/packages/agent-bundle/src/routes/index.ts
@@ -18,5 +18,23 @@ export type {
   RouteProvenance,
 } from './types.ts';
 export { generateRouteTypes, routeTypesRelativePath, writeRouteTypes } from './typegen.ts';
-export { validateRouteModuleContract } from './contract.ts';
-export type { AppRouteConfig, PromptConfig, ResourceConfig, RouteSchema, RouteSchemaOutput, ToolConfig, ToolRouteProps } from './public.ts';
+export { validateEventRouteModuleContract, validateRouteModuleContract } from './contract.ts';
+export { canonicalAgentEvents } from './public.ts';
+export type {
+  AgentEventCanonicalIdentity,
+  AgentEventDelivery,
+  AgentEventFallbackMode,
+  AgentEventNativePayload,
+  AgentEventProvenance,
+  AgentEventRouteConfig,
+  AgentEventRouteProps,
+  AgentEventRuntimeMode,
+  AppRouteConfig,
+  CanonicalAgentEvent,
+  PromptConfig,
+  ResourceConfig,
+  RouteSchema,
+  RouteSchemaOutput,
+  ToolConfig,
+  ToolRouteProps,
+} from './public.ts';

--- a/packages/agent-bundle/src/routes/public.ts
+++ b/packages/agent-bundle/src/routes/public.ts
@@ -5,6 +5,61 @@ export interface RouteSchema<Output = unknown> {
 
 export type RouteSchemaOutput<Schema> = Schema extends RouteSchema<infer Output> ? Output : never;
 
+/** The event-route families admitted by the recorded #97 v1/G10 decision. */
+export const canonicalAgentEvents = Object.freeze([
+  'session/start',
+  'tool/before',
+  'tool/after',
+  'stop',
+  'agent/start',
+  'agent/stop',
+  'workspace/open',
+] as const);
+
+export type CanonicalAgentEvent = (typeof canonicalAgentEvents)[number];
+
+export interface AgentEventProvenance {
+  readonly host: string;
+  readonly hostContractRevision: string;
+  readonly nativeEvent: string;
+  readonly source: 'native';
+}
+
+/** Cross-host identity supplied to an event route without fabricated host fields. */
+export interface AgentEventCanonicalIdentity {
+  readonly event: CanonicalAgentEvent;
+  readonly idempotencyKey: string;
+  readonly observedAt: string;
+  readonly provenance: AgentEventProvenance;
+  readonly sequence: number;
+}
+
+/** Complete host envelope after the adapter's schema and byte-bound validation. */
+export type AgentEventNativePayload = Readonly<Record<string, unknown>>;
+
+/** Props received by an event route's async default Server Component. */
+export interface AgentEventRouteProps {
+  readonly canonical: AgentEventCanonicalIdentity;
+  readonly native: AgentEventNativePayload;
+  readonly signal: AbortSignal;
+}
+
+export type AgentEventDelivery = 'immediate';
+export type AgentEventRuntimeMode = 'shared' | 'standalone';
+export type AgentEventFallbackMode = 'none' | 'standalone';
+
+/** Statically extractable event-route configuration. */
+export interface AgentEventRouteConfig {
+  readonly delivery?: readonly AgentEventDelivery[];
+  readonly fallback?: AgentEventFallbackMode;
+  readonly runtime?: AgentEventRuntimeMode;
+  readonly targets?: readonly string[];
+  /** Route budget within the adapter's stricter native-host deadline. */
+  readonly timeoutMs?: number;
+  /** Canonical tool selectors for tool/before and tool/after routes. */
+  readonly tools?: readonly string[];
+}
+
 /** Props received by every executable MCP route's async default Server Component. */
 export interface ToolRouteProps<InputSchema extends RouteSchema> {
   readonly input: RouteSchemaOutput<InputSchema>;

--- a/packages/agent-bundle/src/routes/typegen.ts
+++ b/packages/agent-bundle/src/routes/typegen.ts
@@ -31,10 +31,16 @@ export const generateRouteTypes = (graph: CompiledRouteGraph): string => {
     '  input: SchemaOutput<InputSchema>;',
     '  result: SchemaOutput<ResultSchema>;',
     '}>;',
+    'export type EventRouteContract<Component, Event extends string> = Readonly<{',
+    '  component: Component;',
+    '  event: Event;',
+    '}>;',
     '',
     'export interface AgentBundleRoutes {',
     ...routes.map((route, index) =>
-      `  ${JSON.stringify(route.id)}: RouteContract<typeof route${String(index)}.inputSchema, typeof route${String(index)}.resultSchema>;`),
+      route.kind === 'event-route'
+        ? `  ${JSON.stringify(route.id)}: EventRouteContract<typeof route${String(index)}.default, ${JSON.stringify(route.event)}>;`
+        : `  ${JSON.stringify(route.id)}: RouteContract<typeof route${String(index)}.inputSchema, typeof route${String(index)}.resultSchema>;`),
     '}',
     '',
     'export type RouteId = keyof AgentBundleRoutes;',

--- a/packages/agent-bundle/src/routes/types.ts
+++ b/packages/agent-bundle/src/routes/types.ts
@@ -1,4 +1,5 @@
 import type { Diagnostic } from '../core/diagnostics.ts';
+import type { CanonicalAgentEvent } from './public.ts';
 
 /**
  * Every route kind the conventional source tree can declare. Context
@@ -39,6 +40,8 @@ export const emptyRouteConfig: Readonly<Record<string, unknown>> = Object.freeze
 export interface CompiledAgentRoute {
   /** Statically extracted from the module's `export const config` declaration; {@link emptyRouteConfig} when absent or rejected. */
   readonly config: Readonly<Record<string, unknown>>;
+  /** Canonical event identity; present only when {@link kind} is `event-route`. */
+  readonly event?: CanonicalAgentEvent;
   readonly id: string;
   readonly kind: CompiledRouteKind;
   readonly provenance: RouteProvenance;

--- a/packages/agent-bundle/tests/route-graph.test.ts
+++ b/packages/agent-bundle/tests/route-graph.test.ts
@@ -42,7 +42,7 @@ const fixtureConfig = (extra: Readonly<Record<string, unknown>> = {}): AgentBund
 const conventionalTree: Readonly<Record<string, string>> = {
   'src/cli/doctor.tsx': moduleSource,
   'src/cli/library/audit.ts': moduleSource,
-  'src/events/file/saved.tsx': moduleSource,
+  'src/events/workspace/open.tsx': moduleSource,
   'src/mcp/curator/apps/dashboard.tsx': `export const config = { resourceUri: 'ui://curator/dashboard.html' }; ${moduleSource}`,
   'src/mcp/curator/prompts/curate.tsx': moduleSource,
   'src/mcp/curator/resources/catalog.ts': moduleSource,
@@ -87,11 +87,12 @@ it('compiles the conventional tree into one frozen graph with a machine-independ
   ]);
   expect(curator!.routes.map((route) => route.kind)).toEqual(['app', 'prompt', 'resource', 'tool']);
   expect(curator!.routes.every((route) => route.serverId === 'mcp:curator')).toBe(true);
-  expect(graph.events.map((route) => route.id)).toEqual(['event:file/saved']);
+  expect(graph.events.map((route) => route.id)).toEqual(['event:workspace/open']);
   expect(graph.events[0]).toMatchObject({
+    event: 'workspace/open',
     kind: 'event-route',
-    provenance: { kind: 'conventional', relativePath: 'src/events/file/saved.tsx' },
-    source: join(root, 'src/events/file/saved.tsx'),
+    provenance: { kind: 'conventional', relativePath: 'src/events/workspace/open.tsx' },
+    source: join(root, 'src/events/workspace/open.tsx'),
   });
   expect(graph.cli).toMatchObject({ mode: 'generated' });
   expect(graph.cli!.routes.map((route) => route.id)).toEqual(['cli:doctor', 'cli:library/audit']);
@@ -526,4 +527,43 @@ it('validates the single async route-module authoring contract statically', asyn
     'AB4810',
     'AB4811',
   ]);
+});
+
+it('discovers only the seven v1 event families and validates their component contract', async () => {
+  const root = await createRoot();
+  const eventSource = 'export default async function EventRoute() { return undefined; }\n';
+  await writeTree(root, {
+    'src/events/agent/start.tsx': eventSource,
+    'src/events/agent/stop.tsx': eventSource,
+    'src/events/prompt/submit.tsx': eventSource,
+    'src/events/session/start.tsx': eventSource,
+    'src/events/stop.tsx': eventSource,
+    'src/events/tool/after.tsx': eventSource,
+    'src/events/tool/before.tsx': 'export default function BeforeTool() { return undefined; }\n',
+    'src/events/workspace/open.tsx': eventSource,
+  });
+
+  const graph = await compileRouteGraph(root, fixtureConfig());
+
+  expect(graph.events.map((route) => route.id)).toEqual([
+    'event:agent/start',
+    'event:agent/stop',
+    'event:session/start',
+    'event:stop',
+    'event:tool/after',
+    'event:tool/before',
+    'event:workspace/open',
+  ]);
+  expect(graph.events.map((route) => route.event)).toEqual([
+    'agent/start',
+    'agent/stop',
+    'session/start',
+    'stop',
+    'tool/after',
+    'tool/before',
+    'workspace/open',
+  ]);
+  expect(graph.diagnostics.map(({ code }) => code)).toEqual(['AB4813', 'AB4810']);
+  expect(graph.diagnostics[0]?.sourcePath).toBe(join(root, 'src/events/prompt/submit.tsx'));
+  expect(graph.diagnostics[1]?.sourcePath).toBe(join(root, 'src/events/tool/before.tsx'));
 });

--- a/packages/rsc-runtime/src/agent-document.ts
+++ b/packages/rsc-runtime/src/agent-document.ts
@@ -22,6 +22,12 @@ export interface AgentTextNode {
   readonly text: string;
 }
 
+/** Guidance intended for the host's immediate additional-context channel. */
+export interface AgentContextNode {
+  readonly kind: 'context';
+  readonly text: string;
+}
+
 export interface AgentJsonNode {
   readonly kind: 'json';
   readonly value: JsonValue;
@@ -63,6 +69,7 @@ export type AgentDocumentNode =
   | AgentResultNode
   | AgentMarkdownNode
   | AgentTextNode
+  | AgentContextNode
   | AgentJsonNode
   | AgentProgressNode
   | AgentImageNode
@@ -246,6 +253,8 @@ const snapshotNode = (node: AgentDocumentNode, depth: number, state: NodeSnapsho
         return Object.freeze({ kind: 'markdown', text: text(node.text, 'Agent markdown text') });
       case 'text':
         return Object.freeze({ kind: 'text', text: text(node.text, 'Agent text') });
+      case 'context':
+        return Object.freeze({ kind: 'context', text: text(node.text, 'Agent context text') });
       case 'json':
         return Object.freeze({
           kind: 'json',

--- a/packages/rsc-runtime/src/decode-document.ts
+++ b/packages/rsc-runtime/src/decode-document.ts
@@ -13,6 +13,7 @@ const agentElementTypes = Object.freeze([
   'agent-result',
   'agent-markdown',
   'agent-text',
+  'agent-context',
   'agent-json',
   'agent-progress',
   'agent-image',
@@ -71,6 +72,8 @@ const decodeNode = (node: ReactNode, state: DecodeState): AgentDocumentNode => {
       return { kind: 'markdown', text: textChild(props.children, element.type) };
     case 'agent-text':
       return { kind: 'text', text: textChild(props.children, element.type) };
+    case 'agent-context':
+      return { kind: 'context', text: textChild(props.children, element.type) };
     case 'agent-json':
       return { kind: 'json', value: props.value as JsonValue };
     case 'agent-progress':

--- a/packages/rsc-runtime/src/elements.ts
+++ b/packages/rsc-runtime/src/elements.ts
@@ -44,6 +44,8 @@ const AgentMarkdown = ({ children }: AgentTextProps): ReactElement =>
 
 const AgentText = ({ children }: AgentTextProps): ReactElement => createElement('agent-text', null, children);
 
+const AgentContext = ({ children }: AgentTextProps): ReactElement => createElement('agent-context', null, children);
+
 const AgentJson = ({ value }: AgentJsonProps): ReactElement => createElement('agent-json', { value });
 
 const AgentProgress = ({ completed, message, total }: AgentProgressProps): ReactElement =>
@@ -63,6 +65,7 @@ const AgentError = ({ children, code }: AgentErrorProps): ReactElement =>
 
 export const Agent = Object.freeze({
   Audio: AgentAudio,
+  Context: AgentContext,
   Error: AgentError,
   Image: AgentImage,
   Json: AgentJson,

--- a/packages/rsc-runtime/src/index.ts
+++ b/packages/rsc-runtime/src/index.ts
@@ -22,6 +22,7 @@ export {
 export type {
   AgentAudioNode,
   AgentContractErrorCode,
+  AgentContextNode,
   AgentDocument,
   AgentDocumentNode,
   AgentDocumentSnapshot,

--- a/packages/rsc-runtime/tests/agent-document.test.ts
+++ b/packages/rsc-runtime/tests/agent-document.test.ts
@@ -50,6 +50,7 @@ describe('Agent vocabulary', () => {
   it('exposes protocol-oriented leaves without DOM elements', () => {
     expect(Object.keys(Agent)).toEqual([
       'Audio',
+      'Context',
       'Error',
       'Image',
       'Json',
@@ -60,6 +61,7 @@ describe('Agent vocabulary', () => {
       'Text',
     ]);
     expect(Object.isFrozen(Agent)).toBe(true);
+    expect(Agent.Context({ children: 'route guidance' }).type).toBe('agent-context');
     expect(Agent.Markdown({ children: '# Ready' }).type).toBe('agent-markdown');
     expect(Agent.Resource({ name: 'Catalog', uri: 'catalog://root' }).type).toBe('agent-resource');
     expect(Agent.Error({ children: 'represented', code: 'E_DEMO' }).type).toBe('agent-error');

--- a/packages/rsc-runtime/tests/dispatcher.test.ts
+++ b/packages/rsc-runtime/tests/dispatcher.test.ts
@@ -20,6 +20,7 @@ describe('decodeAgentDocument', () => {
     const document = decodeAgentDocument(createElement(
       'agent-result',
       { metadata: { source: 'flight' }, value: { ready: true } },
+      createElement('agent-context', null, 'route guidance'),
       createElement('agent-markdown', null, '# Ready'),
       createElement('agent-error', { code: 'E_REPRESENTED' }, 'Partial result'),
     ));
@@ -27,6 +28,7 @@ describe('decodeAgentDocument', () => {
     expect(document).toEqual({
       root: {
         children: [
+          { kind: 'context', text: 'route guidance' },
           { kind: 'markdown', text: '# Ready' },
           { code: 'E_REPRESENTED', kind: 'error', message: 'Partial result' },
         ],


### PR DESCRIPTION
## Summary
- admit exactly the seven G10 event-route identities, including root `src/events/stop.tsx`
- publish typed canonical/native event props and validate event routes as async default Server Components without MCP schemas
- add `<Agent.Context>` to the Agent Document vocabulary and MCP text projection

## Evidence table additions
- none in this descriptor/discovery slice; host evidence and support states follow in the next PR

## Lane D coordination
- runtime edits are confined to the `Agent.Context` vocabulary node, decoder, exports, and projector support

## Test plan
- [x] `pnpm exec rstest run packages/rsc-runtime/tests/agent-document.test.ts packages/rsc-runtime/tests/dispatcher.test.ts packages/agent-bundle/tests/route-graph.test.ts packages/agent-bundle/tests/entry-shell.test.ts` (56 passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Closes part of #97