### PR TITLE
fix(examples): export CliCommandDefinition so declaration emit can name it

### DIFF
--- a/examples/audiobook-curator/src/cli-command.ts
+++ b/examples/audiobook-curator/src/cli-command.ts
@@ -17,7 +17,14 @@ interface CliProjection<Input, Result> {
   readonly usage: string;
 }
 
-interface CliCommandDefinition<
+/**
+ * Exported because the operation factories in `src/operations/` export
+ * objects of `defineCliCommand(...)` results: declaration emit for the
+ * package build must be able to name this type from those modules
+ * (TS4023 otherwise fails `agent-bundle build`'s d.ts generation, even
+ * though `tsc --noEmit` passes).
+ */
+export interface CliCommandDefinition<
   InputSchema extends Schema<unknown>,
   ResultSchema extends Schema<unknown>,
   ParsedInput,


### PR DESCRIPTION
## Summary

`pnpm examples:check` fails reproducibly on main: the audiobook-curator `agent-bundle build` dies with

```
error   Failed to generate declaration files. (agent-bundle-index)
[{"code":"AB5000","message":"Error occurred in agent-bundle-index declaration files generation.","severity":"error"}]
```

(observed in #166's report). The underlying TypeScript diagnostics, recovered by replaying the synthesized DTS program (`node_modules/.agent-bundle-dts-*` tsconfig) with `tsc --declaration --emitDeclarationOnly`, are five TS4023s:

```
src/operations/audible.ts(79,14): error TS4023: Exported variable 'audibleOperations' has or is using name 'CliCommandDefinition' from external module ".../src/cli-command" but cannot be named.
```

#150 introduced `src/cli-command.ts` with `CliCommandDefinition` unexported while the exported operations factories (`audibleOperations`, `discoveryOperations`, `evidenceOperations`, `mediaMutationOperations`, `outputOperations`) return objects of `defineCliCommand(...)` results, so their inferred declaration types must name it from other modules. This is emit-only: `tsc --noEmit` (the example's `typecheck`) passes, which is why only the declaration build failed. Fix: export the interface.

Not the dev lock: AB5000 is the CLI's catch-all diagnostic code, and the initial report attributed it to dev-lock contention ("another development process owns this project"). The check pipeline (`validate`/`build`/`typecheck`/`test`/`test:routes`) never acquires the dev lock — its only production acquirer is the DevCoordinator behind `agent-bundle dev` — and dead-pid reclaim is already covered by `tests/dev-lock.test.ts` ("recovers a dead lock only after probing its recorded pid", the eight-contender recovery-gate test). A leaked `dev.lock` with a dead owner pid (998818, from this morning's OOM-killed dev session) existed in the primary checkout's example tree and was deleted surgically, but it could not have caused this failure and reproduction succeeds in a pristine worktree.

## Regression gate

An emit-only TS4023 is invisible to `--noEmit` typecheck and to runtime tests by construction; the executable gate is declaration emit itself, which `pnpm --filter ./examples/audiobook-curator check` (and the examples-check CI job) runs via `agent-bundle build`. That exact reproduction now passes — package build emits all 39 files including the `.d.ts` graph.

## Test plan

- [x] Reproduced on pristine main worktree: audiobook build fails with AB5000/TS4023 (serial and 3-way-concurrent)
- [x] After fix: DTS program replay clean (`tsc --declaration --emitDeclarationOnly`, exit 0)
- [x] `pnpm --filter ./examples/audiobook-curator check` green (validate, build, typecheck, 35+2 tests)
- [x] Full `pnpm examples:check` green
- [x] Root `pnpm typecheck` and scoped `rslint` clean