### PR TITLE
fix(ci): green main — pnpm shim launch, replay head snapshots, workspace-free published manifest

### DIFF
--- a/examples/rsc-agent-runtime/src/runtime/state-file.ts
+++ b/examples/rsc-agent-runtime/src/runtime/state-file.ts
@@ -157,7 +157,10 @@ export const createFileRuntimeKernel = (options: FileRuntimeKernelOptions): Runt
           { host: input.host, path: input.path, sessionId: input.sessionId, toolName: input.toolName },
           { idempotencyKey: input.idempotencyKey, signal: mutationOptions?.signal },
         );
-        return snapshotAt(store, committed.revision, undefined, mutationOptions?.signal);
+        // Idempotent replays return the current head, exactly like the retired
+        // JSONL kernel: a rerun after a later reset must surface the reset
+        // state, not the durable prefix at the original commit.
+        return snapshotAt(store, committed.replayed ? undefined : committed.revision, undefined, mutationOptions?.signal);
       });
     },
 
@@ -169,7 +172,7 @@ export const createFileRuntimeKernel = (options: FileRuntimeKernelOptions): Runt
           ...(input.seed === undefined ? {} : { seed: { edits: [], seed: input.seed } }),
           signal: mutationOptions?.signal,
         });
-        return snapshotAt(store, committed.revision, undefined, mutationOptions?.signal);
+        return snapshotAt(store, committed.replayed ? undefined : committed.revision, undefined, mutationOptions?.signal);
       });
     },
 

--- a/packages/agent-bundle/package.json
+++ b/packages/agent-bundle/package.json
@@ -99,7 +99,6 @@
     "yaml": "2.9.0"
   },
   "devDependencies": {
-    "@agent-bundle/runtime": "workspace:*",
     "@modelcontextprotocol/server": "2.0.0",
     "@types/react": "19.2.18",
     "@types/ws": "8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@agent-bundle/runtime': workspace:*
+
 importers:
 
   .:
@@ -184,6 +187,9 @@ importers:
 
   packages/agent-bundle:
     dependencies:
+      '@agent-bundle/runtime':
+        specifier: workspace:*
+        version: link:../rsc-runtime
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
@@ -254,9 +260,6 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
     devDependencies:
-      '@agent-bundle/runtime':
-        specifier: workspace:*
-        version: link:../rsc-runtime
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,12 @@ packages:
   - packages/*
   - packages/workbench/src/inspector
   - examples/*
+# The published agent-bundle manifest must never carry a `workspace:` range
+# (npm refuses to install such a tarball, and the release audit forbids it),
+# so its optional @agent-bundle/runtime peer is satisfied from the workspace
+# here instead of through a devDependency in the shipped package.json.
+overrides:
+  '@agent-bundle/runtime': workspace:*
 allowBuilds:
   '@google/genai': false
   msgpackr-extract: false

--- a/scripts/run-examples-check.mjs
+++ b/scripts/run-examples-check.mjs
@@ -10,8 +10,14 @@ if (pnpmEntrypoint === undefined || pnpmEntrypoint.length === 0) {
   throw new Error('run-examples-check.mjs must be launched through a pnpm package script.');
 }
 
-const child = spawn(process.execPath, [
-  pnpmEntrypoint,
+// npm_execpath is a JavaScript entrypoint under corepack and pnpm's own
+// installer, but a native shim (or a bare command name) under standalone
+// setups such as pnpm/setup on hosted CI. Only JavaScript files can be
+// launched through the current Node executable.
+const isJavaScriptEntrypoint = /\.[cm]?js$/u.test(pnpmEntrypoint);
+const command = isJavaScriptEntrypoint ? process.execPath : pnpmEntrypoint;
+const child = spawn(command, [
+  ...(isJavaScriptEntrypoint ? [pnpmEntrypoint] : []),
   '--filter',
   './examples/*',
   '--workspace-concurrency=3',


### PR DESCRIPTION
## Summary

Hosted CI on main has been red across three independent failure classes; this makes the post-merge safety net green again.

1. **Examples check infra failure** — `Cannot find module '.../pnpm'`: `scripts/run-examples-check.mjs` launched `npm_execpath` through the current Node executable, but `pnpm/setup` on hosted runners exposes pnpm as a native shim / bare command name rather than a JavaScript entrypoint, so `node pnpm` failed with `MODULE_NOT_FOUND` before any example check ran. The script now execs non-JavaScript entrypoints directly (verified against absolute-shim and bare-name shapes; the corepack JS path is covered by `examples-check-script.test.ts`).

2. **Runtime playground e2e failing on every Node line** (not the #122 flake family — deterministic): the sqlite migration (#149) changed the example kernel to return the durable prefix **at the original commit revision** on idempotent replays, where the retired JSONL kernel returned the **current head**. Re-running the seeded fixture after a reset replays the input-derived idempotency key and reported the pre-reset state version (1 instead of 2), failing `runtime-playground.e2e.test.ts > resets the selected Claude fixture…` on Node 22/24/26. Replays now read the head snapshot again; fresh commits keep the exact commit revision.

3. **Release gates**: #151 added `"@agent-bundle/runtime": "workspace:*"` to the published `agent-bundle` devDependencies, tripping the release audit (`release-audit.test.ts` forbids `workspace:` in the shipped manifest because npm refuses such tarballs). The optional peer is now satisfied through a `pnpm-workspace.yaml` override instead of a shipped range, so auto-install-peers links the workspace package without touching the registry.

## Test plan

- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` clean
- [x] `runtime-playground.e2e.test.ts -t 'resets the selected Claude fixture'` passes (previously red)
- [x] `node scripts/run-packed-tests.mjs packages/agent-bundle/tests/release-audit.test.ts` — all 4 pass (previously 2 red)
- [x] `examples-check-script.test.ts`, `test-harness-manifest.test.ts`, example `state-and-definition.test.ts` pass
- [x] Simulated non-JS pnpm shim (absolute path and bare name) through `run-examples-check.mjs`
- [ ] Watch the post-merge main run for the previously failing jobs