### PR TITLE
fix: scaffold validation order, registry framework specs, nested effect-namespace lint

### DIFF
--- a/.changeset/fix-scaffold-framework-specs.md
+++ b/.changeset/fix-scaffold-framework-specs.md
@@ -1,0 +1,5 @@
+---
+"create-agent-bundle": patch
+---
+
+Validate paired local runtime tarballs before scaffolding begins and support npm registry framework versions, ranges, and tags.

--- a/packages/create-agent-bundle/src/framework.ts
+++ b/packages/create-agent-bundle/src/framework.ts
@@ -23,9 +23,13 @@ export const runtimeSpecForFramework = (frameworkSpec: string): string => {
   if (localTarball !== null) {
     return `${localTarball[1]}agent-bundle-runtime${localTarball[2] ?? ''}.tgz`;
   }
+  if (!frameworkSpec.startsWith('file:') && !frameworkSpec.startsWith('https://pkg.pr.new/')) {
+    return frameworkSpec;
+  }
   throw new UsageError(
     `Cannot derive a paired @agent-bundle/runtime package from agent-bundle spec "${frameworkSpec}". `
-    + 'Use a pkg.pr.new preview URL or a file: tarball named agent-bundle.tgz or agent-bundle-<version>.tgz.',
+    + 'Use an npm registry version, range, or tag; an exact pkg.pr.new preview URL; or a file: tarball '
+    + 'named agent-bundle.tgz or agent-bundle-<version>.tgz.',
   );
 };
 

--- a/packages/create-agent-bundle/src/scaffold.ts
+++ b/packages/create-agent-bundle/src/scaffold.ts
@@ -55,16 +55,14 @@ interface TemplateManifest {
   name?: string;
 }
 
-const rewriteManifest = async (contents: string, request: ScaffoldRequest): Promise<string> => {
+const rewriteManifest = (contents: string, request: ScaffoldRequest, runtimeSpec: string): string => {
   const manifest = JSON.parse(contents) as TemplateManifest;
   manifest.name = request.packageName;
-  let runtimeSpec: string | undefined;
   for (const section of [manifest.dependencies, manifest.devDependencies]) {
     if (section === undefined) continue;
     for (const [dependency, range] of Object.entries(section)) {
       if (range !== 'workspace:*') continue;
       if (dependency === '@agent-bundle/runtime') {
-        runtimeSpec ??= await validatedRuntimeSpecForFramework(request.frameworkSpec);
         section[dependency] = runtimeSpec;
       } else {
         section[dependency] = request.frameworkSpec;
@@ -88,6 +86,7 @@ const rewriteConfigTargets = (contents: string, targets: readonly TargetName[]):
  * config's target list. Returns the emitted project-relative paths, sorted.
  */
 export const scaffold = async (request: ScaffoldRequest): Promise<readonly string[]> => {
+  const runtimeSpec = await validatedRuntimeSpecForFramework(request.frameworkSpec);
   const emitted: string[] = [];
   const copyDirectory = async (from: string, to: string, relative: string): Promise<void> => {
     await mkdir(to, { recursive: true });
@@ -101,7 +100,7 @@ export const scaffold = async (request: ScaffoldRequest): Promise<readonly strin
         continue;
       }
       let contents = (await readFile(source, 'utf8')).replaceAll(placeholderName, request.pluginName);
-      if (relativePath === 'package.json') contents = await rewriteManifest(contents, request);
+      if (relativePath === 'package.json') contents = rewriteManifest(contents, request, runtimeSpec);
       if (relativePath === 'agent-bundle.config.ts') contents = rewriteConfigTargets(contents, request.targets);
       await writeFile(destination, contents);
       emitted.push(relativePath);

--- a/packages/create-agent-bundle/tests/framework.test.ts
+++ b/packages/create-agent-bundle/tests/framework.test.ts
@@ -40,8 +40,14 @@ describe('runtimeSpecForFramework', () => {
       .toBe('file:/tmp/agent-bundle-runtime.tgz');
   });
 
+  it('mirrors npm registry framework specs onto the runtime package', () => {
+    expect(runtimeSpecForFramework('0.1.0')).toBe('0.1.0');
+    expect(runtimeSpecForFramework('^0.1.0')).toBe('^0.1.0');
+    expect(runtimeSpecForFramework('next')).toBe('next');
+  });
+
   it('fails closed when a paired runtime spec cannot be derived', () => {
     expect(() => runtimeSpecForFramework('file:/tmp/framework.tgz')).toThrow(UsageError);
-    expect(() => runtimeSpecForFramework('0.1.0')).toThrow(UsageError);
+    expect(() => runtimeSpecForFramework('file:/tmp/framework.tgz')).toThrow('npm registry version, range, or tag');
   });
 });

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
@@ -11,19 +11,20 @@ import { assertScaffoldTarget, placeholderName, scaffold } from '../src/scaffold
 
 const templatesRoot = join(process.cwd(), 'packages', 'create-agent-bundle', 'templates');
 
+const packageTarball = (name: string): Buffer => {
+  const manifest = Buffer.from(JSON.stringify({ name }));
+  const archive = Buffer.alloc(512 + Math.ceil(manifest.length / 512) * 512 + 1024);
+  archive.write('package/package.json', 0, 'utf8');
+  archive.write(`${manifest.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii');
+  manifest.copy(archive, 512);
+  return gzipSync(archive);
+};
+
 const scaffoldTemplate = async (
   template: string,
   overrides: Partial<{ packageName: string; pluginName: string; targets: readonly TargetName[] }> = {},
 ): Promise<{ readonly files: readonly string[]; readonly frameworkSpec: string; readonly root: string }> => {
   const root = await mkdtemp(join(tmpdir(), `create-agent-bundle-${template}-`));
-  const packageTarball = (name: string): Buffer => {
-    const manifest = Buffer.from(JSON.stringify({ name }));
-    const archive = Buffer.alloc(512 + Math.ceil(manifest.length / 512) * 512 + 1024);
-    archive.write('package/package.json', 0, 'utf8');
-    archive.write(`${manifest.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii');
-    manifest.copy(archive, 512);
-    return gzipSync(archive);
-  };
   const frameworkTarball = join(root, 'agent-bundle-0.0.0.tgz');
   const runtimeTarball = join(root, 'agent-bundle-runtime-0.0.0.tgz');
   await Promise.all([
@@ -135,6 +136,26 @@ describe('scaffold', () => {
       const config = await readFile(join(root, 'agent-bundle.config.ts'), 'utf8');
       expect(config).toContain("targets: ['portable', 'cursor'],");
       expect(config).not.toContain("'codex'");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it('validates local runtime tarballs before writing scaffold files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-agent-bundle-validation-'));
+    const frameworkTarball = join(root, 'agent-bundle-0.0.0.tgz');
+    const targetDirectory = join(root, 'project');
+    try {
+      await writeFile(frameworkTarball, packageTarball('agent-bundle'));
+      await expect(scaffold({
+        frameworkSpec: `file:${frameworkTarball}`,
+        packageName: 'status-plugin',
+        pluginName: 'status-plugin',
+        targetDirectory,
+        targets: ['portable', 'codex', 'claude'],
+        templateRoot: join(templatesRoot, 'mcp-server'),
+      })).rejects.toThrow(UsageError);
+      await expect(readdir(targetDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/packages/rsc-runtime/tests/effect-boundary-lint.test.ts
+++ b/packages/rsc-runtime/tests/effect-boundary-lint.test.ts
@@ -10,10 +10,16 @@ type ImportNode = {
   readonly parent?: { readonly source?: { readonly value?: unknown } };
 };
 
+type IdentifierNode = {
+  readonly name?: string;
+  readonly type?: string;
+};
+
 type MemberNode = {
   readonly computed?: boolean;
-  readonly object?: { readonly name?: string; readonly type?: string };
-  readonly property?: { readonly name?: string; readonly type?: string };
+  readonly object?: IdentifierNode | MemberNode;
+  readonly property?: IdentifierNode;
+  readonly type?: string;
 };
 
 type LintListeners = ReturnType<typeof rule.create> & {
@@ -123,6 +129,27 @@ describe('effect-boundary lint', () => {
     expect(star).toEqual([{ data: { name: 'E.runSync' }, messageId: 'forbiddenCall' }]);
   });
 
+  it('rejects runners reached through a renamed nested effect namespace', () => {
+    const reports = apply('packages/rsc-runtime/src/dispatcher.ts', (listeners) => {
+      listeners.ImportNamespaceSpecifier?.({
+        local: { name: 'E' },
+        parent: { source: { value: 'effect' } },
+      });
+      listeners.MemberExpression?.({
+        computed: false,
+        object: {
+          computed: false,
+          object: { name: 'E', type: 'Identifier' },
+          property: { name: 'Effect', type: 'Identifier' },
+          type: 'MemberExpression',
+        },
+        property: { name: 'runPromise', type: 'Identifier' },
+        type: 'MemberExpression',
+      });
+    });
+    expect(reports).toEqual([{ data: { name: 'E.Effect.runPromise' }, messageId: 'forbiddenCall' }]);
+  });
+
   it('does not flag aliased Effect used for non-runners', () => {
     const reports = apply('packages/rsc-runtime/src/reconciler.ts', (listeners) => {
       listeners.ImportSpecifier?.({
@@ -134,6 +161,17 @@ describe('effect-boundary lint', () => {
         computed: false,
         object: { name: 'E', type: 'Identifier' },
         property: { name: 'succeed', type: 'Identifier' },
+      });
+      listeners.MemberExpression?.({
+        computed: false,
+        object: {
+          computed: false,
+          object: { name: 'Other', type: 'Identifier' },
+          property: { name: 'Effect', type: 'Identifier' },
+          type: 'MemberExpression',
+        },
+        property: { name: 'runPromise', type: 'Identifier' },
+        type: 'MemberExpression',
       });
     });
     expect(reports).toEqual([]);

--- a/scripts/eslint-plugin-effect-boundary.ts
+++ b/scripts/eslint-plugin-effect-boundary.ts
@@ -44,6 +44,22 @@ const moduleName = (node: { readonly source?: { readonly value?: unknown } }): s
 const isEffectModule = (source: string | undefined): boolean =>
   source !== undefined && (EFFECT_MODULES.has(source) || source.startsWith('effect/'));
 
+type MemberObject = {
+  readonly computed?: boolean;
+  readonly name?: string;
+  readonly object?: MemberObject;
+  readonly property?: { readonly name?: string };
+  readonly type?: string;
+};
+
+const staticMemberPath = (node: MemberObject | undefined): readonly string[] | undefined => {
+  if (node?.type === 'Identifier') return node.name === undefined ? undefined : [node.name];
+  if (node?.type !== 'MemberExpression' || node.computed === true) return undefined;
+  const objectPath = staticMemberPath(node.object);
+  const propertyName = node.property?.name;
+  return objectPath === undefined || propertyName === undefined ? undefined : [...objectPath, propertyName];
+};
+
 export const effectBoundaryPlugin = {
   meta: {
     name: 'effect-boundary',
@@ -95,15 +111,15 @@ export const effectBoundaryPlugin = {
           },
           MemberExpression(node: {
             readonly computed?: boolean;
-            readonly object?: { readonly name?: string; readonly type?: string };
+            readonly object?: MemberObject;
             readonly property?: { readonly name?: string; readonly type?: string };
           }) {
             if (node.computed === true) return;
             const name = node.property?.name;
             if (name === undefined || !RUN_NAMES.has(name)) return;
-            const objectName = node.object?.name;
-            if (objectName === undefined || !runnerNamespaces.has(objectName)) return;
-            context.report({ data: { name: `${objectName}.${name}` }, messageId: 'forbiddenCall', node });
+            const objectPath = staticMemberPath(node.object);
+            if (objectPath === undefined || !runnerNamespaces.has(objectPath[0]!)) return;
+            context.report({ data: { name: [...objectPath, name].join('.') }, messageId: 'forbiddenCall', node });
           },
         };
       },


### PR DESCRIPTION
## Summary
- **#168 scaffold.ts:104 (P2)**: `scaffold()` now validates the framework/runtime tarball pair BEFORE writing any files — a bad tarball no longer leaves a partial scaffold (test asserts the target dir is never created).
- **#168 framework.ts:29 (P2)**: `--framework-version` accepts npm registry versions/ranges/tags (and npm-compatible URLs) again by mirroring the selected spec onto `@agent-bundle/runtime`, restoring the advertised pre-regression pairing; pkg.pr.new and `file:` tarball derivation unchanged.
- **#164 eslint-plugin-effect-boundary.ts:105 (P2)**: the boundary lint now walks nested static member paths, so `import * as E from 'effect'; E.Effect.runPromise(...)` is flagged; unrelated roots (`Other.Effect.runPromise`) stay clean.

## Test plan
- [x] New unit tests: pre-write tarball validation, registry spec mirroring, nested/renamed namespace runner detection + negative case (23/23 scoped pass)
- [x] `pnpm typecheck`, `pnpm lint` clean