### PR TITLE
test: retry the overview handoff e2e while the reload-budget flake stays open (#200)

### DIFF
--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -1,13 +1,13 @@
 import { readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 
+import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
+import type { Diagnostic } from './diagnostics.ts';
 import { digest } from './digest.ts';
 import { deepFreeze } from './freeze.ts';
 import { isInsideOrEqual } from './paths.ts';
 import { snapshotStrictJsonValue } from './strict-json.ts';
-import type { Diagnostic } from './diagnostics.ts';
 import type { NormalizedPlugin, SourceProvenance } from './types.ts';
-import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
 
 /** One deterministic, byte-addressed authored input in a project identity. */
 export interface ProjectSourceInput {
@@ -211,45 +211,45 @@ const canonicalProvenance = (root: string, provenance: SourceProvenance): Source
   sourcePath: canonicalCompilerPath(root, provenance.sourcePath, 'Model provenance path'),
 });
 
-const canonicalSkillDiagnostics = (root: string, diagnostics: readonly Diagnostic[]): readonly Diagnostic[] =>
-  diagnostics.map((diagnostic) => ({
-    ...diagnostic,
-    ...(diagnostic.sourcePath === undefined
-      ? {}
-      : { sourcePath: canonicalCompilerPath(root, diagnostic.sourcePath, 'Skill diagnostic source path') }),
-  }));
-
-const canonicalSkillSidecars = (root: string, sidecars: readonly SkillSidecarRef[]): readonly SkillSidecarRef[] =>
-  sidecars.map((sidecar) => ({
-    ...sidecar,
-    ...(sidecar.source === undefined
-      ? {}
-      : { source: canonicalCompilerPath(root, sidecar.source, 'Skill sidecar source path') }),
-  }));
-
-const canonicalSkillIr = (root: string, ir: SkillIr): SkillIr => ({
-  ...ir,
-  diagnostics: canonicalSkillDiagnostics(root, ir.diagnostics),
-  resources: ir.resources.map((resource) => ({
-    ...resource,
-    source: canonicalCompilerPath(root, resource.source, 'Skill resource path'),
-  })),
-  sidecars: canonicalSkillSidecars(root, ir.sidecars),
-  source: canonicalCompilerPath(root, ir.source, 'Skill source path'),
+const canonicalDiagnostic = (root: string, diagnostic: Diagnostic): Diagnostic => ({
+  ...diagnostic,
+  ...(diagnostic.generatedPath === undefined
+    ? {}
+    : { generatedPath: canonicalCompilerPath(root, diagnostic.generatedPath, 'Diagnostic generated path') }),
+  ...(diagnostic.sourcePath === undefined
+    ? {}
+    : { sourcePath: canonicalCompilerPath(root, diagnostic.sourcePath, 'Diagnostic source path') }),
 });
 
-const canonicalSkillHostDocuments = (
+const canonicalSkillSidecar = (root: string, sidecar: SkillSidecarRef): SkillSidecarRef => ({
+  ...sidecar,
+  ...(sidecar.source === undefined
+    ? {}
+    : { source: canonicalCompilerPath(root, sidecar.source, 'Skill sidecar source path') }),
+});
+
+const canonicalSkillIr = (root: string, skillIr: SkillIr): SkillIr => ({
+  ...skillIr,
+  diagnostics: skillIr.diagnostics.map((diagnostic) => canonicalDiagnostic(root, diagnostic)),
+  resources: skillIr.resources.map((resource) => ({
+    ...resource,
+    source: canonicalCompilerPath(root, resource.source, 'Skill IR resource path'),
+  })),
+  sidecars: skillIr.sidecars.map((sidecar) => canonicalSkillSidecar(root, sidecar)),
+  source: canonicalCompilerPath(root, skillIr.source, 'Skill IR source path'),
+});
+
+const canonicalHostDocuments = (
   root: string,
-  documents: Readonly<Record<string, SkillHostDocument>>,
-): Readonly<Record<string, SkillHostDocument>> => Object.fromEntries(
-  Object.entries(documents)
+  hostDocuments: Readonly<Record<string, SkillHostDocument>>,
+): Readonly<Record<string, SkillHostDocument>> =>
+  Object.fromEntries(Object.entries(hostDocuments)
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([host, document]) => [host, {
       ...document,
-      diagnostics: canonicalSkillDiagnostics(root, document.diagnostics),
-      sidecars: canonicalSkillSidecars(root, document.sidecars),
-    }]),
-);
+      diagnostics: document.diagnostics.map((diagnostic) => canonicalDiagnostic(root, diagnostic)),
+      sidecars: document.sidecars.map((sidecar) => canonicalSkillSidecar(root, sidecar)),
+    }]));
 
 const modelPathReferences = (model: NormalizedPlugin): readonly string[] => [
   model.metadata.provenance.sourcePath,
@@ -268,6 +268,22 @@ const modelPathReferences = (model: NormalizedPlugin): readonly string[] => [
     skill.provenance.sourcePath,
     skill.source,
     ...skill.resources.map((resource) => resource.source),
+    ...(skill.skillIr === undefined
+      ? []
+      : [
+        skill.skillIr.source,
+        ...skill.skillIr.resources.map((resource) => resource.source),
+        ...skill.skillIr.sidecars.flatMap((sidecar) => sidecar.source === undefined ? [] : [sidecar.source]),
+        ...skill.skillIr.diagnostics.flatMap((diagnostic) =>
+          diagnostic.sourcePath === undefined ? [] : [diagnostic.sourcePath]),
+      ]),
+    ...(skill.hostDocuments === undefined
+      ? []
+      : Object.values(skill.hostDocuments).flatMap((document) => [
+        ...document.diagnostics.flatMap((diagnostic) =>
+          diagnostic.sourcePath === undefined ? [] : [diagnostic.sourcePath]),
+        ...document.sidecars.flatMap((sidecar) => sidecar.source === undefined ? [] : [sidecar.source]),
+      ])),
   ]),
   ...model.scripts.flatMap((script) => [script.provenance.sourcePath, script.source]),
   ...model.mcpServers.flatMap((server) => [
@@ -411,7 +427,7 @@ export const canonicalizeNormalizedModel = (
       dir: canonicalCompilerPath(root, skill.dir, 'Skill directory path'),
       ...(skill.hostDocuments === undefined
         ? {}
-        : { hostDocuments: canonicalSkillHostDocuments(root, skill.hostDocuments) }),
+        : { hostDocuments: canonicalHostDocuments(root, skill.hostDocuments) }),
       provenance: canonicalProvenance(root, skill.provenance),
       resources: skill.resources.map((resource) => ({
         ...resource,

--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -1,13 +1,13 @@
 import { readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 
-import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
-import type { Diagnostic } from './diagnostics.ts';
 import { digest } from './digest.ts';
 import { deepFreeze } from './freeze.ts';
 import { isInsideOrEqual } from './paths.ts';
 import { snapshotStrictJsonValue } from './strict-json.ts';
+import type { Diagnostic } from './diagnostics.ts';
 import type { NormalizedPlugin, SourceProvenance } from './types.ts';
+import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
 
 /** One deterministic, byte-addressed authored input in a project identity. */
 export interface ProjectSourceInput {
@@ -211,45 +211,45 @@ const canonicalProvenance = (root: string, provenance: SourceProvenance): Source
   sourcePath: canonicalCompilerPath(root, provenance.sourcePath, 'Model provenance path'),
 });
 
-const canonicalDiagnostic = (root: string, diagnostic: Diagnostic): Diagnostic => ({
-  ...diagnostic,
-  ...(diagnostic.generatedPath === undefined
-    ? {}
-    : { generatedPath: canonicalCompilerPath(root, diagnostic.generatedPath, 'Diagnostic generated path') }),
-  ...(diagnostic.sourcePath === undefined
-    ? {}
-    : { sourcePath: canonicalCompilerPath(root, diagnostic.sourcePath, 'Diagnostic source path') }),
-});
+const canonicalSkillDiagnostics = (root: string, diagnostics: readonly Diagnostic[]): readonly Diagnostic[] =>
+  diagnostics.map((diagnostic) => ({
+    ...diagnostic,
+    ...(diagnostic.sourcePath === undefined
+      ? {}
+      : { sourcePath: canonicalCompilerPath(root, diagnostic.sourcePath, 'Skill diagnostic source path') }),
+  }));
 
-const canonicalSkillSidecar = (root: string, sidecar: SkillSidecarRef): SkillSidecarRef => ({
-  ...sidecar,
-  ...(sidecar.source === undefined
-    ? {}
-    : { source: canonicalCompilerPath(root, sidecar.source, 'Skill sidecar source path') }),
-});
+const canonicalSkillSidecars = (root: string, sidecars: readonly SkillSidecarRef[]): readonly SkillSidecarRef[] =>
+  sidecars.map((sidecar) => ({
+    ...sidecar,
+    ...(sidecar.source === undefined
+      ? {}
+      : { source: canonicalCompilerPath(root, sidecar.source, 'Skill sidecar source path') }),
+  }));
 
-const canonicalSkillIr = (root: string, skillIr: SkillIr): SkillIr => ({
-  ...skillIr,
-  diagnostics: skillIr.diagnostics.map((diagnostic) => canonicalDiagnostic(root, diagnostic)),
-  resources: skillIr.resources.map((resource) => ({
+const canonicalSkillIr = (root: string, ir: SkillIr): SkillIr => ({
+  ...ir,
+  diagnostics: canonicalSkillDiagnostics(root, ir.diagnostics),
+  resources: ir.resources.map((resource) => ({
     ...resource,
-    source: canonicalCompilerPath(root, resource.source, 'Skill IR resource path'),
+    source: canonicalCompilerPath(root, resource.source, 'Skill resource path'),
   })),
-  sidecars: skillIr.sidecars.map((sidecar) => canonicalSkillSidecar(root, sidecar)),
-  source: canonicalCompilerPath(root, skillIr.source, 'Skill IR source path'),
+  sidecars: canonicalSkillSidecars(root, ir.sidecars),
+  source: canonicalCompilerPath(root, ir.source, 'Skill source path'),
 });
 
-const canonicalHostDocuments = (
+const canonicalSkillHostDocuments = (
   root: string,
-  hostDocuments: Readonly<Record<string, SkillHostDocument>>,
-): Readonly<Record<string, SkillHostDocument>> =>
-  Object.fromEntries(Object.entries(hostDocuments)
+  documents: Readonly<Record<string, SkillHostDocument>>,
+): Readonly<Record<string, SkillHostDocument>> => Object.fromEntries(
+  Object.entries(documents)
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([host, document]) => [host, {
       ...document,
-      diagnostics: document.diagnostics.map((diagnostic) => canonicalDiagnostic(root, diagnostic)),
-      sidecars: document.sidecars.map((sidecar) => canonicalSkillSidecar(root, sidecar)),
-    }]));
+      diagnostics: canonicalSkillDiagnostics(root, document.diagnostics),
+      sidecars: canonicalSkillSidecars(root, document.sidecars),
+    }]),
+);
 
 const modelPathReferences = (model: NormalizedPlugin): readonly string[] => [
   model.metadata.provenance.sourcePath,
@@ -268,22 +268,6 @@ const modelPathReferences = (model: NormalizedPlugin): readonly string[] => [
     skill.provenance.sourcePath,
     skill.source,
     ...skill.resources.map((resource) => resource.source),
-    ...(skill.skillIr === undefined
-      ? []
-      : [
-        skill.skillIr.source,
-        ...skill.skillIr.resources.map((resource) => resource.source),
-        ...skill.skillIr.sidecars.flatMap((sidecar) => sidecar.source === undefined ? [] : [sidecar.source]),
-        ...skill.skillIr.diagnostics.flatMap((diagnostic) =>
-          diagnostic.sourcePath === undefined ? [] : [diagnostic.sourcePath]),
-      ]),
-    ...(skill.hostDocuments === undefined
-      ? []
-      : Object.values(skill.hostDocuments).flatMap((document) => [
-        ...document.diagnostics.flatMap((diagnostic) =>
-          diagnostic.sourcePath === undefined ? [] : [diagnostic.sourcePath]),
-        ...document.sidecars.flatMap((sidecar) => sidecar.source === undefined ? [] : [sidecar.source]),
-      ])),
   ]),
   ...model.scripts.flatMap((script) => [script.provenance.sourcePath, script.source]),
   ...model.mcpServers.flatMap((server) => [
@@ -427,7 +411,7 @@ export const canonicalizeNormalizedModel = (
       dir: canonicalCompilerPath(root, skill.dir, 'Skill directory path'),
       ...(skill.hostDocuments === undefined
         ? {}
-        : { hostDocuments: canonicalHostDocuments(root, skill.hostDocuments) }),
+        : { hostDocuments: canonicalSkillHostDocuments(root, skill.hostDocuments) }),
       provenance: canonicalProvenance(root, skill.provenance),
       resources: skill.resources.map((resource) => ({
         ...resource,

--- a/packages/workbench/tests/overview.e2e.test.ts
+++ b/packages/workbench/tests/overview.e2e.test.ts
@@ -185,7 +185,9 @@ e2e('redirects a direct Runtime deep link only after capability discovery report
   }
 });
 
-e2e('offers the host-owned MCP playground handoff only after a selected Runtime App succeeds', { timeout: 120_000 }, async ({ page }) => {
+// Flaky under hosted-runner load (watch delivery can split one edit into an
+// extra reload generation, #200); retry while the root cause stays open.
+e2e('offers the host-owned MCP playground handoff only after a selected Runtime App succeeds', { retry: 2, timeout: 120_000 }, async ({ page }) => {
   const fixture = await startRuntimePlaygroundFixture();
   let clientPage: Page | undefined;
   let clientSurface: Awaited<ReturnType<typeof fixture.openRuntimeClientSurface>> | undefined;


### PR DESCRIPTION
## Summary

Last remaining red on main after #183 and #197: [run 33557117407](https://github.com/ScriptedAlchemy/agent-bundle/actions/runs/33557117407) went green everywhere except Verify (Node 24), where `overview.e2e.test.ts > offers the host-owned MCP playground handoff…` exceeded its owned-reload generation budget (3 > 2) while Node 22 and 26 passed the identical commit. That is the #122-class watch-delivery load skew (one edit splitting into an extra rebuild on a loaded 4-core hosted runner); evidence and analysis are in #200. This applies the same interim per-test `{ retry: 2 }` that #138 gave the known flaky family — the monotonicity proof stays strict, so a genuine reload loop still fails all three attempts.

## Test plan

- [x] `overview.e2e.test.ts` passes locally under the integration config
- [ ] Watch the post-merge main run