### PR TITLE
fix(test): honest registry version gate, binary-faithful CLI cwd, README field

### DIFF
--- a/.changeset/honest-harness-registry-cwd.md
+++ b/.changeset/honest-harness-registry-cwd.md
@@ -1,0 +1,7 @@
+---
+"agent-bundle": patch
+---
+
+Reject stale consumer test registries before projection helpers read fields
+they do not contain, and derive CLI dispatch workspace context from the
+invocation working directory to match generated executables.

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -252,7 +252,7 @@ import { cliJson, expectEvents, invokeCli, invokeMcpTool } from 'agent-bundle/te
 
 // mcp-in-memory: the generated server projects the document to protocol content.
 const call = await invokeMcpTool('summarize', { input: { title: 'Dune' } });
-expect(call.result.structuredContent).toEqual({ chapters: 24 });
+expect(call.structuredContent).toEqual({ chapters: 24 });
 
 // cli-dispatch: the routed CLI resolves the command, parses argv, and maps the exit code.
 const run = await invokeCli(['library', 'audit', './books', '--max-files', '8']);

--- a/packages/agent-bundle/src/test/cli.ts
+++ b/packages/agent-bundle/src/test/cli.ts
@@ -181,7 +181,7 @@ export const invokeCli = async (
       } catch (error) {
         throw new CliInputError(error instanceof Error ? error.message : String(error));
       }
-      const root = manifest.projectRoot;
+      const root = process.cwd();
       const result = await runtime.runAgentRequest({
         capabilities: {
           command: runtime.unavailable(),

--- a/packages/agent-bundle/src/test/registry.ts
+++ b/packages/agent-bundle/src/test/registry.ts
@@ -14,7 +14,7 @@ export const AGENT_TEST_REGISTRY_SYMBOL_KEY = 'agent-bundle/test-route-registry'
 
 const REGISTRY_SYMBOL = Symbol.for(AGENT_TEST_REGISTRY_SYMBOL_KEY);
 
-export const AGENT_TEST_REGISTRY_VERSION = 1;
+export const AGENT_TEST_REGISTRY_VERSION = 2;
 
 export interface AgentTestRouteRegistry {
   /** Lazy loaders keyed by compiled route id, so a test only compiles the routes it renders. */

--- a/packages/agent-bundle/tests/projection/cli-dispatch.test.ts
+++ b/packages/agent-bundle/tests/projection/cli-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 
+import { agent } from '@agent-bundle/runtime';
 import { cliJson, invokeCli } from '../../src/test/cli.ts';
 
 /**
@@ -83,5 +84,28 @@ describe('the CLI dispatch level', () => {
 
     expect(run.exitCode).toBe(0);
     expect(progress.map((update) => update.message)).toEqual(['reading inventory', 'inventory ready']);
+  });
+
+  it('derives the request workspace from the invocation cwd like the generated binary', async () => {
+    const invocationCwd = process.cwd();
+    let observed: { readonly projectRoot: string | null; readonly workspace: string | null } | undefined;
+    const run = await invokeCli(['inventory', 'fiction'], {
+      context: {
+        progress: {
+          report: async () => {
+            const context = await agent();
+            observed = {
+              projectRoot: context.capabilities.projectRoot.state === 'available'
+                ? context.capabilities.projectRoot.value.root
+                : null,
+              workspace: context.workspace.state === 'available' ? context.workspace.value.root : null,
+            };
+          },
+        },
+      },
+    });
+
+    expect(invocationCwd).not.toBe(run.provenance.projectRoot);
+    expect(observed).toEqual({ projectRoot: invocationCwd, workspace: invocationCwd });
   });
 });

--- a/packages/agent-bundle/tests/test-harness-manifest.test.ts
+++ b/packages/agent-bundle/tests/test-harness-manifest.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from '@rstest/core';
 
 import { routeTestSetupSource } from '../src/rstest/setup-module.ts';
 import { AgentTestError } from '../src/test/errors.ts';
+import { invokeCli } from '../src/test/cli.ts';
 import { compileTestManifest, testManifestFromRouteGraph } from '../src/test/manifest.ts';
 import {
   AGENT_TEST_REGISTRY_SYMBOL_KEY,
@@ -143,6 +144,28 @@ describe('the generated route registry', () => {
     await withRealmRegistry({ loaders: {}, manifest, version: 99 }, () => {
       expect(() => testManifest()).toThrow('Incompatible Agent Bundle test registry version');
     });
+  });
+
+  it('refuses a version-1 manifest before a helper reads fields that version did not carry', async () => {
+    const versionOneManifest = Object.fromEntries(
+      Object.entries(manifest).filter(([key]) => key !== 'cliCommands' && key !== 'plugin'),
+    );
+    const error = await withRealmRegistry(
+      { loaders: {}, manifest: versionOneManifest, version: 1 },
+      async () => invokeCli(['--help']).catch((thrown: unknown) => thrown),
+    );
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('manifest-unavailable');
+    expect((error as AgentTestError).message).toContain('found 1');
+    expect((error as AgentTestError).message).toContain('Install one agent-bundle version');
+  });
+
+  it('accepts a registry carrying the current manifest version', async () => {
+    await withRealmRegistry(
+      { loaders: {}, manifest, version: AGENT_TEST_REGISTRY_VERSION },
+      () => expect(testManifest()).toBe(manifest),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the three unaddressed Codex post-merge findings on #190:

- **P2 (`src/test/registry.ts`, flagged at manifest.ts:104)** — `AGENT_TEST_REGISTRY_VERSION` stayed 1 while #190 added required `cliCommands`/`plugin` manifest fields, so mixed-version installs passed the version gate and crashed later in `invokeCli`/MCP helpers. Bumped to 2; stale registries now fail the existing gate with the recoverable `AgentTestError` ("found 1, expected 2" + install-one-version recovery) before any helper reads missing fields.
- **P2 (`src/test/cli.ts:193`)** — `invokeCli` resolved the request workspace from `manifest.projectRoot`, but the generated binary resolves from `process.cwd()` (verified in `entry-shell.ts` generated code). The harness now matches the shipped artifact.
- **P2 (`README.md:235`)** — example read `call.result.structuredContent`; the real `McpToolInvocation` field is `call.structuredContent`.

## Tests

Regression tests: version-1 registry refusal with the honest error (`test-harness-manifest.test.ts`) and workspace-from-invocation-cwd (`projection/cli-dispatch.test.ts`). Both verified to fail without the src fixes. Unit (28) + projection (23) tests, `tsc --noEmit`, `rslint` all green after rebase onto latest main.