### PR TITLE
fix: tighten runtime scaffolds and effect lint paths (#199 follow-ups)

### DIFF
--- a/.changeset/create-agent-bundle-runtime-followups.md
+++ b/.changeset/create-agent-bundle-runtime-followups.md
@@ -1,0 +1,5 @@
+---
+"create-agent-bundle": patch
+---
+
+Keep framework-only local scaffolds independent of runtime tarballs and reject framework specs that cannot safely resolve under the runtime package name.

--- a/packages/create-agent-bundle/src/framework.ts
+++ b/packages/create-agent-bundle/src/framework.ts
@@ -6,6 +6,7 @@ import { gunzip } from 'node:zlib';
 import { UsageError } from './options.ts';
 
 const previewPattern = /-preview-([0-9a-f]{7,40})$/u;
+const npmRegistrySelectorPattern = /^[0-9A-Za-z*._+<>=~^|\-\s]+$/u;
 const unzip = promisify(gunzip);
 
 export type PreviewPackageName = 'agent-bundle' | '@agent-bundle/runtime' | 'create-agent-bundle';
@@ -15,7 +16,11 @@ export const previewPackageSpec = (packageName: PreviewPackageName, sha: string)
 
 export const previewFrameworkSpec = (sha: string): string => previewPackageSpec('agent-bundle', sha);
 
-/** Derives the paired runtime package from the selected framework build. */
+/**
+ * Derives a paired runtime package from an exact preview/local framework
+ * build, or reuses an npm version, range, or tag that resolves independently
+ * under each package name.
+ */
 export const runtimeSpecForFramework = (frameworkSpec: string): string => {
   const preview = /^(https:\/\/pkg\.pr\.new\/ScriptedAlchemy\/agent-bundle\/)agent-bundle@([0-9a-f]{7,40})$/u.exec(frameworkSpec);
   if (preview !== null) return `${preview[1]}@agent-bundle/runtime@${preview[2]}`;
@@ -23,12 +28,19 @@ export const runtimeSpecForFramework = (frameworkSpec: string): string => {
   if (localTarball !== null) {
     return `${localTarball[1]}agent-bundle-runtime${localTarball[2] ?? ''}.tgz`;
   }
-  if (!frameworkSpec.startsWith('file:') && !frameworkSpec.startsWith('https://pkg.pr.new/')) {
+  if (
+    frameworkSpec !== ''
+    && frameworkSpec.trim() === frameworkSpec
+    && npmRegistrySelectorPattern.test(frameworkSpec)
+    && !frameworkSpec.endsWith('.tgz')
+    && !frameworkSpec.endsWith('.tar.gz')
+  ) {
     return frameworkSpec;
   }
   throw new UsageError(
     `Cannot derive a paired @agent-bundle/runtime package from agent-bundle spec "${frameworkSpec}". `
-    + 'Use an npm registry version, range, or tag; an exact pkg.pr.new preview URL; or a file: tarball '
+    + 'This package spec cannot be reused for @agent-bundle/runtime. Use an npm registry version, range, or tag; '
+    + 'an exact pkg.pr.new preview URL; or a file: tarball '
     + 'named agent-bundle.tgz or agent-bundle-<version>.tgz.',
   );
 };

--- a/packages/create-agent-bundle/src/scaffold.ts
+++ b/packages/create-agent-bundle/src/scaffold.ts
@@ -55,7 +55,7 @@ interface TemplateManifest {
   name?: string;
 }
 
-const rewriteManifest = (contents: string, request: ScaffoldRequest, runtimeSpec: string): string => {
+const rewriteManifest = (contents: string, request: ScaffoldRequest, runtimeSpec: string | undefined): string => {
   const manifest = JSON.parse(contents) as TemplateManifest;
   manifest.name = request.packageName;
   for (const section of [manifest.dependencies, manifest.devDependencies]) {
@@ -63,6 +63,9 @@ const rewriteManifest = (contents: string, request: ScaffoldRequest, runtimeSpec
     for (const [dependency, range] of Object.entries(section)) {
       if (range !== 'workspace:*') continue;
       if (dependency === '@agent-bundle/runtime') {
+        if (runtimeSpec === undefined) {
+          throw new Error('Template drift: @agent-bundle/runtime was not declared in the root template manifest.');
+        }
         section[dependency] = runtimeSpec;
       } else {
         section[dependency] = request.frameworkSpec;
@@ -86,7 +89,14 @@ const rewriteConfigTargets = (contents: string, targets: readonly TargetName[]):
  * config's target list. Returns the emitted project-relative paths, sorted.
  */
 export const scaffold = async (request: ScaffoldRequest): Promise<readonly string[]> => {
-  const runtimeSpec = await validatedRuntimeSpecForFramework(request.frameworkSpec);
+  const templateManifest = JSON.parse(
+    await readFile(join(request.templateRoot, 'package_json'), 'utf8'),
+  ) as TemplateManifest;
+  const usesWorkspaceRuntime = [templateManifest.dependencies, templateManifest.devDependencies]
+    .some((section) => section?.['@agent-bundle/runtime'] === 'workspace:*');
+  const runtimeSpec = usesWorkspaceRuntime
+    ? await validatedRuntimeSpecForFramework(request.frameworkSpec)
+    : undefined;
   const emitted: string[] = [];
   const copyDirectory = async (from: string, to: string, relative: string): Promise<void> => {
     await mkdir(to, { recursive: true });

--- a/packages/create-agent-bundle/tests/framework.test.ts
+++ b/packages/create-agent-bundle/tests/framework.test.ts
@@ -43,7 +43,26 @@ describe('runtimeSpecForFramework', () => {
   it('mirrors npm registry framework specs onto the runtime package', () => {
     expect(runtimeSpecForFramework('0.1.0')).toBe('0.1.0');
     expect(runtimeSpecForFramework('^0.1.0')).toBe('^0.1.0');
+    expect(runtimeSpecForFramework('>=0.1.0 <1')).toBe('>=0.1.0 <1');
+    expect(runtimeSpecForFramework('1.x')).toBe('1.x');
     expect(runtimeSpecForFramework('next')).toBe('next');
+  });
+
+  it('rejects package specs that cannot resolve independently under the runtime name', () => {
+    const unsupportedSpecs = [
+      'https://example.com/agent-bundle.tgz',
+      'git+ssh://git@github.com/ScriptedAlchemy/agent-bundle.git',
+      'github:ScriptedAlchemy/agent-bundle',
+      'npm:@scope/agent-bundle@1.0.0',
+      '/tmp/agent-bundle.tgz',
+      '../agent-bundle',
+      'agent-bundle.tgz',
+      'agent-bundle.tar.gz',
+    ];
+    for (const spec of unsupportedSpecs) {
+      expect(() => runtimeSpecForFramework(spec)).toThrow(UsageError);
+      expect(() => runtimeSpecForFramework(spec)).toThrow('cannot be reused for @agent-bundle/runtime');
+    }
   });
 
   it('fails closed when a paired runtime spec cannot be derived', () => {

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -22,15 +22,20 @@ const packageTarball = (name: string): Buffer => {
 
 const scaffoldTemplate = async (
   template: string,
-  overrides: Partial<{ packageName: string; pluginName: string; targets: readonly TargetName[] }> = {},
+  overrides: Partial<{
+    packageName: string;
+    pluginName: string;
+    targets: readonly TargetName[];
+    withRuntimeTarball: boolean;
+  }> = {},
 ): Promise<{ readonly files: readonly string[]; readonly frameworkSpec: string; readonly root: string }> => {
   const root = await mkdtemp(join(tmpdir(), `create-agent-bundle-${template}-`));
   const frameworkTarball = join(root, 'agent-bundle-0.0.0.tgz');
   const runtimeTarball = join(root, 'agent-bundle-runtime-0.0.0.tgz');
-  await Promise.all([
-    writeFile(frameworkTarball, packageTarball('agent-bundle')),
-    writeFile(runtimeTarball, packageTarball('@agent-bundle/runtime')),
-  ]);
+  await writeFile(frameworkTarball, packageTarball('agent-bundle'));
+  if (overrides.withRuntimeTarball !== false) {
+    await writeFile(runtimeTarball, packageTarball('@agent-bundle/runtime'));
+  }
   const frameworkSpec = `file:${frameworkTarball}`;
   const files = await scaffold({
     frameworkSpec,
@@ -40,7 +45,7 @@ const scaffoldTemplate = async (
     targets: overrides.targets ?? ['portable', 'codex', 'claude'],
     templateRoot: join(templatesRoot, template),
   });
-  await Promise.all([rm(frameworkTarball), rm(runtimeTarball)]);
+  await Promise.all([rm(frameworkTarball), rm(runtimeTarball, { force: true })]);
   return { files, frameworkSpec, root: join(root, 'project') };
 };
 
@@ -98,6 +103,20 @@ describe('scaffold', () => {
       await rm(root, { force: true, recursive: true });
     }
   });
+
+  for (const template of ['minimal', 'cli-tool'] as const) {
+    it(`scaffolds the ${template} template without a runtime tarball`, async () => {
+      const { root } = await scaffoldTemplate(template, { withRuntimeTarball: false });
+      try {
+        const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+          readonly devDependencies: Record<string, string>;
+        };
+        expect(manifest.devDependencies['agent-bundle']).toMatch(/^file:/u);
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    });
+  }
 
   it('replaces every placeholder and pins the framework spec', async () => {
     const { files, frameworkSpec, root } = await scaffoldTemplate('cli-tool', {

--- a/packages/rsc-runtime/tests/effect-boundary-lint.test.ts
+++ b/packages/rsc-runtime/tests/effect-boundary-lint.test.ts
@@ -100,7 +100,7 @@ describe('effect-boundary lint', () => {
     expect(reports).toEqual([]);
   });
 
-  it('rejects aliased Effect namespaces (named and star imports)', () => {
+  it('rejects aliased Effect namespaces (named and subpath star imports)', () => {
     const named = apply('packages/rsc-runtime/src/dispatcher.ts', (listeners) => {
       listeners.ImportSpecifier?.({
         imported: { name: 'Effect' },
@@ -118,7 +118,7 @@ describe('effect-boundary lint', () => {
     const star = apply('packages/agent-bundle/src/dev/coordinator.ts', (listeners) => {
       listeners.ImportNamespaceSpecifier?.({
         local: { name: 'E' },
-        parent: { source: { value: 'effect' } },
+        parent: { source: { value: 'effect/Runtime' } },
       });
       listeners.MemberExpression?.({
         computed: false,
@@ -129,7 +129,7 @@ describe('effect-boundary lint', () => {
     expect(star).toEqual([{ data: { name: 'E.runSync' }, messageId: 'forbiddenCall' }]);
   });
 
-  it('rejects runners reached through a renamed nested effect namespace', () => {
+  it('rejects Effect and Runtime runners reached through a whole-module namespace', () => {
     const reports = apply('packages/rsc-runtime/src/dispatcher.ts', (listeners) => {
       listeners.ImportNamespaceSpecifier?.({
         local: { name: 'E' },
@@ -146,8 +146,54 @@ describe('effect-boundary lint', () => {
         property: { name: 'runPromise', type: 'Identifier' },
         type: 'MemberExpression',
       });
+      listeners.MemberExpression?.({
+        computed: false,
+        object: {
+          computed: false,
+          object: { name: 'E', type: 'Identifier' },
+          property: { name: 'Runtime', type: 'Identifier' },
+          type: 'MemberExpression',
+        },
+        property: { name: 'runSync', type: 'Identifier' },
+        type: 'MemberExpression',
+      });
     });
-    expect(reports).toEqual([{ data: { name: 'E.Effect.runPromise' }, messageId: 'forbiddenCall' }]);
+    expect(reports).toEqual([
+      { data: { name: 'E.Effect.runPromise' }, messageId: 'forbiddenCall' },
+      { data: { name: 'E.Runtime.runSync' }, messageId: 'forbiddenCall' },
+    ]);
+  });
+
+  it('ignores runner-shaped methods below non-Effect namespaces', () => {
+    const reports = apply('packages/rsc-runtime/src/dispatcher.ts', (listeners) => {
+      listeners.ImportNamespaceSpecifier?.({
+        local: { name: 'E' },
+        parent: { source: { value: 'effect' } },
+      });
+      listeners.MemberExpression?.({
+        computed: false,
+        object: {
+          computed: false,
+          object: { name: 'Effect', type: 'Identifier' },
+          property: { name: 'adapter', type: 'Identifier' },
+          type: 'MemberExpression',
+        },
+        property: { name: 'runPromise', type: 'Identifier' },
+        type: 'MemberExpression',
+      });
+      listeners.MemberExpression?.({
+        computed: false,
+        object: {
+          computed: false,
+          object: { name: 'E', type: 'Identifier' },
+          property: { name: 'worker', type: 'Identifier' },
+          type: 'MemberExpression',
+        },
+        property: { name: 'runSync', type: 'Identifier' },
+        type: 'MemberExpression',
+      });
+    });
+    expect(reports).toEqual([]);
   });
 
   it('does not flag aliased Effect used for non-runners', () => {

--- a/scripts/eslint-plugin-effect-boundary.ts
+++ b/scripts/eslint-plugin-effect-boundary.ts
@@ -20,7 +20,7 @@ const RUN_NAMES = new Set([
 
 const EFFECT_MODULES = new Set(['effect']);
 const EFFECT_NAMESPACES = new Set(['Effect', 'Runtime']);
-const EFFECT_NAMESPACE_MODULES = new Set(['effect', 'effect/Effect', 'effect/Runtime']);
+const EFFECT_RUNNER_NAMESPACE_MODULES = new Set(['effect/Effect', 'effect/Runtime']);
 
 const posixPath = (filename: string): string => filename.replaceAll('\\', '/');
 
@@ -85,6 +85,7 @@ export const effectBoundaryPlugin = {
       }) {
         if (isEffectBoundaryFile(context.filename)) return {};
         const runnerNamespaces = new Set<string>(EFFECT_NAMESPACES);
+        const effectModuleNamespaces = new Set<string>();
         const rememberNamespace = (name: string | undefined): void => {
           if (name !== undefined) runnerNamespaces.add(name);
         };
@@ -106,8 +107,12 @@ export const effectBoundaryPlugin = {
             readonly parent?: { readonly source?: { readonly value?: unknown } };
           }) {
             const source = moduleName(node.parent ?? {});
-            if (source === undefined || !EFFECT_NAMESPACE_MODULES.has(source)) return;
-            rememberNamespace(localName(node));
+            const name = localName(node);
+            if (source === 'effect') {
+              if (name !== undefined) effectModuleNamespaces.add(name);
+              return;
+            }
+            if (source !== undefined && EFFECT_RUNNER_NAMESPACE_MODULES.has(source)) rememberNamespace(name);
           },
           MemberExpression(node: {
             readonly computed?: boolean;
@@ -118,7 +123,12 @@ export const effectBoundaryPlugin = {
             const name = node.property?.name;
             if (name === undefined || !RUN_NAMES.has(name)) return;
             const objectPath = staticMemberPath(node.object);
-            if (objectPath === undefined || !runnerNamespaces.has(objectPath[0]!)) return;
+            if (objectPath === undefined) return;
+            const isDirectRunner = objectPath.length === 1 && runnerNamespaces.has(objectPath[0]!);
+            const isNestedRunner = objectPath.length === 2
+              && effectModuleNamespaces.has(objectPath[0]!)
+              && EFFECT_NAMESPACES.has(objectPath[1]!);
+            if (!isDirectRunner && !isNestedRunner) return;
             context.report({ data: { name: [...objectPath, name].join('.') }, messageId: 'forbiddenCall', node });
           },
         };


### PR DESCRIPTION
## Summary

Addresses the three unresolved P2 Codex findings on #199:

- **`scaffold.ts:89` — require a runtime tarball only when the template uses it**: `scaffold()` now inspects the selected template's checked-in manifest (`package_json`) and only runs `validatedRuntimeSpecForFramework` when the template declares `@agent-bundle/runtime` as `workspace:*`. Framework-only local-tarball scaffolds (`minimal`, `cli-tool`) work again without an adjacent runtime tarball; a drift guard still fails loudly if a manifest unexpectedly needs the runtime spec.
- **`framework.ts:27` — reject non-registry specs instead of mirroring them**: the fallback that copied the framework spec into the `@agent-bundle/runtime` dependency now only accepts specs that resolve independently under each package name (semver versions/ranges/dist-tags). Generic URLs, git specs, `npm:` aliases, and tarball-named specs raise the existing `UsageError` with an updated actionable message.
- **`eslint-plugin-effect-boundary.ts:121` — restrict nested lint paths to actual Effect namespaces**: whole-module `import * as E from 'effect'` bindings are now tracked separately from `Effect`/`Runtime` runner namespaces. Only direct runners (`Effect.runPromise`, aliased `Eff.runSync`, subpath star imports) and true nested runners (`E.Effect.runPromise`, `E.Runtime.runSync`) are flagged; `Effect.adapter.runPromise()` and `E.worker.runSync()` no longer block lint.

## Tests

- `rejects package specs that cannot resolve independently under the runtime name`
- `scaffolds the <template> template without a runtime tarball`
- `rejects aliased Effect namespaces (named and subpath star imports)`
- `rejects Effect and Runtime runners reached through a whole-module namespace`
- `ignores runner-shaped methods below non-Effect namespaces`

Gates: scoped rstest (lint-plugin + framework + scaffold), `pnpm typecheck`, repo-wide `pnpm lint` under the modified plugin — all green.