### PR TITLE
fix(create): validate the local framework tarball for framework-only templates

### DIFF
--- a/.changeset/scaffold-framework-tarball-validation.md
+++ b/.changeset/scaffold-framework-tarball-validation.md
@@ -1,0 +1,5 @@
+---
+"create-agent-bundle": patch
+---
+
+Validate a local `file:` framework tarball for framework-only templates too, so a missing, corrupt, or misnamed archive fails the scaffold with a usage error instead of reporting the project ready with an unusable dependency.

--- a/packages/create-agent-bundle/src/framework.ts
+++ b/packages/create-agent-bundle/src/framework.ts
@@ -76,6 +76,24 @@ const localTarballPackageName = async (packageSpec: string): Promise<string> => 
   }
 };
 
+/**
+ * Verifies a local framework tarball for templates that pin no runtime
+ * dependency, so a missing, corrupt, or misnamed archive fails the scaffold
+ * instead of surfacing as an install failure — or, under `--no-install`, as a
+ * project reported ready with an unusable dependency. Non-`file:` specs stay
+ * npm's business: no filesystem read, no registry lookup.
+ */
+export const assertLocalFrameworkTarball = async (frameworkSpec: string): Promise<void> => {
+  if (!frameworkSpec.startsWith('file:')) return;
+  const frameworkName = await localTarballPackageName(frameworkSpec);
+  if (frameworkName !== 'agent-bundle') {
+    throw new UsageError(
+      `Local package tarball "${frameworkSpec}" is not the agent-bundle package: expected agent-bundle, `
+      + `received ${JSON.stringify(frameworkName)}.`,
+    );
+  }
+};
+
 /** Derives and verifies a coherent local framework/runtime tarball pair. */
 export const validatedRuntimeSpecForFramework = async (frameworkSpec: string): Promise<string> => {
   const runtimeSpec = runtimeSpecForFramework(frameworkSpec);

--- a/packages/create-agent-bundle/src/scaffold.ts
+++ b/packages/create-agent-bundle/src/scaffold.ts
@@ -2,7 +2,7 @@ import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { UsageError, type TargetName } from './options.ts';
-import { validatedRuntimeSpecForFramework } from './framework.ts';
+import { assertLocalFrameworkTarball, validatedRuntimeSpecForFramework } from './framework.ts';
 
 /**
  * The literal project name every template is written under. Templates stay
@@ -94,9 +94,12 @@ export const scaffold = async (request: ScaffoldRequest): Promise<readonly strin
   ) as TemplateManifest;
   const usesWorkspaceRuntime = [templateManifest.dependencies, templateManifest.devDependencies]
     .some((section) => section?.['@agent-bundle/runtime'] === 'workspace:*');
-  const runtimeSpec = usesWorkspaceRuntime
-    ? await validatedRuntimeSpecForFramework(request.frameworkSpec)
-    : undefined;
+  let runtimeSpec: string | undefined;
+  if (usesWorkspaceRuntime) {
+    runtimeSpec = await validatedRuntimeSpecForFramework(request.frameworkSpec);
+  } else {
+    await assertLocalFrameworkTarball(request.frameworkSpec);
+  }
   const emitted: string[] = [];
   const copyDirectory = async (from: string, to: string, relative: string): Promise<void> => {
     await mkdir(to, { recursive: true });

--- a/packages/create-agent-bundle/tests/framework.test.ts
+++ b/packages/create-agent-bundle/tests/framework.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from '@rstest/core';
 
-import { previewPackageSpec, resolveFrameworkSpec, runtimeSpecForFramework } from '../src/framework.ts';
+import {
+  assertLocalFrameworkTarball,
+  previewPackageSpec,
+  resolveFrameworkSpec,
+  runtimeSpecForFramework,
+} from '../src/framework.ts';
 import { UsageError } from '../src/options.ts';
 
 describe('previewPackageSpec', () => {
@@ -68,5 +73,18 @@ describe('runtimeSpecForFramework', () => {
   it('fails closed when a paired runtime spec cannot be derived', () => {
     expect(() => runtimeSpecForFramework('file:/tmp/framework.tgz')).toThrow(UsageError);
     expect(() => runtimeSpecForFramework('file:/tmp/framework.tgz')).toThrow('npm registry version, range, or tag');
+  });
+});
+
+describe('assertLocalFrameworkTarball', () => {
+  it('leaves registry and preview specs to npm', async () => {
+    await expect(assertLocalFrameworkTarball('0.1.0')).resolves.toBeUndefined();
+    await expect(assertLocalFrameworkTarball('next')).resolves.toBeUndefined();
+    await expect(assertLocalFrameworkTarball('https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@da5df1d'))
+      .resolves.toBeUndefined();
+  });
+
+  it('rejects a local tarball that cannot be read', async () => {
+    await expect(assertLocalFrameworkTarball('file:/tmp/absent-agent-bundle.tgz')).rejects.toThrow(UsageError);
   });
 });

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -179,6 +179,65 @@ describe('scaffold', () => {
       await rm(root, { force: true, recursive: true });
     }
   });
+
+  const scaffoldFrameworkOnly = async (
+    tarball: Buffer | undefined,
+    check: (
+      scaffolded: Promise<readonly string[]>,
+      targetDirectory: string,
+      frameworkSpec: string,
+    ) => Promise<void>,
+  ): Promise<void> => {
+    const root = await mkdtemp(join(tmpdir(), 'create-agent-bundle-framework-only-'));
+    const frameworkTarball = join(root, 'agent-bundle-0.0.0.tgz');
+    const targetDirectory = join(root, 'project');
+    const frameworkSpec = `file:${frameworkTarball}`;
+    try {
+      if (tarball !== undefined) await writeFile(frameworkTarball, tarball);
+      await check(scaffold({
+        frameworkSpec,
+        packageName: 'status-plugin',
+        pluginName: 'status-plugin',
+        targetDirectory,
+        targets: ['portable', 'codex', 'claude'],
+        templateRoot: join(templatesRoot, 'minimal'),
+      }), targetDirectory, frameworkSpec);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  };
+
+  it('rejects a missing local framework tarball for a template with no runtime dependency', async () => {
+    await scaffoldFrameworkOnly(undefined, async (scaffolded, targetDirectory) => {
+      await expect(scaffolded).rejects.toThrow(UsageError);
+      await expect(readdir(targetDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('rejects a corrupt local framework tarball for a template with no runtime dependency', async () => {
+    await scaffoldFrameworkOnly(Buffer.from('not a gzip archive'), async (scaffolded, targetDirectory) => {
+      await expect(scaffolded).rejects.toThrow(UsageError);
+      await expect(readdir(targetDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('rejects a misnamed local framework tarball for a template with no runtime dependency', async () => {
+    await scaffoldFrameworkOnly(packageTarball('@scope/not-agent-bundle'), async (scaffolded, targetDirectory) => {
+      await expect(scaffolded).rejects.toThrow(UsageError);
+      await expect(scaffolded).rejects.toThrow('expected agent-bundle');
+      await expect(readdir(targetDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('scaffolds a template with no runtime dependency from a valid local framework tarball', async () => {
+    await scaffoldFrameworkOnly(packageTarball('agent-bundle'), async (scaffolded, targetDirectory, frameworkSpec) => {
+      await expect(scaffolded).resolves.toContain('package.json');
+      const manifest = JSON.parse(await readFile(join(targetDirectory, 'package.json'), 'utf8')) as {
+        readonly devDependencies: Record<string, string>;
+      };
+      expect(manifest.devDependencies['agent-bundle']).toBe(frameworkSpec);
+    });
+  });
 });
 
 describe('assertScaffoldTarget', () => {


### PR DESCRIPTION
## Summary
- Framework-only templates (`minimal`, `cli-tool` — no `@agent-bundle/runtime` dependency) previously skipped local tarball validation entirely, so `--framework-version file:...` pointing at a missing, corrupt, or misnamed tarball scaffolded a "ready" project with an unusable dependency.
- `scaffold()` now validates a `file:` framework tarball via the new `assertLocalFrameworkTarball` helper (reusing the existing `localTarballPackageName` reader) before emitting anything; non-`file:` specs remain untouched.

Addresses the unresolved P2 Codex finding on #217 (`packages/create-agent-bundle/src/scaffold.ts:95-99`).

## Test plan
- [x] `pnpm test:unit packages/create-agent-bundle/tests/scaffold.test.ts packages/create-agent-bundle/tests/framework.test.ts` (pass; missing/misnamed cases fail without the fix)
- [x] `pnpm typecheck` (clean after runtime build)
- [x] `pnpm lint` (0 errors, 0 warnings)