### PR TITLE
fix(create): validate tar header checksums and resolve relative file: specs against the scaffold target

### DIFF
--- a/.changeset/scaffold-tarball-checksum-and-relative-specs.md
+++ b/.changeset/scaffold-tarball-checksum-and-relative-specs.md
@@ -1,0 +1,5 @@
+---
+"create-agent-bundle": patch
+---
+
+Verify every tar header checksum when inspecting a local `file:` framework or runtime tarball, so an archive that inflates but is corrupt fails the scaffold instead of being reported ready. Relative `file:` specs are now resolved against the new project directory — the same base npm uses for the emitted `package.json` — rather than the CLI's working directory.

--- a/packages/create-agent-bundle/src/framework.ts
+++ b/packages/create-agent-bundle/src/framework.ts
@@ -45,12 +45,57 @@ export const runtimeSpecForFramework = (frameworkSpec: string): string => {
   );
 };
 
-const localTarballPackageName = async (packageSpec: string): Promise<string> => {
-  const path = resolve(packageSpec.slice('file:'.length));
+const tarBlockSize = 512;
+const tarChecksumOffset = 148;
+const tarChecksumLength = 8;
+
+/** An all-zero block is the end-of-archive marker, not a header to verify. */
+const isEndOfArchiveBlock = (header: Buffer): boolean => !header.some((byte) => byte !== 0);
+
+/**
+ * ustar checksums the 512-byte header with its own checksum field read as
+ * ASCII spaces. npm packs with node-tar, which writes the unsigned sum, so
+ * that is the authoritative value; the historical signed sum is accepted as
+ * well, as GNU tar does, so an archive written by an older packer is not
+ * reported as corrupt.
+ */
+const tarHeaderChecksumMatches = (header: Buffer): boolean => {
+  const storedText = header
+    .subarray(tarChecksumOffset, tarChecksumOffset + tarChecksumLength)
+    .toString('ascii')
+    .replace(/\0.*$/u, '')
+    .trim();
+  const stored = Number.parseInt(storedText, 8);
+  if (!Number.isSafeInteger(stored)) return false;
+  let unsigned = 0;
+  let signed = 0;
+  for (let index = 0; index < tarBlockSize; index += 1) {
+    if (index >= tarChecksumOffset && index < tarChecksumOffset + tarChecksumLength) {
+      unsigned += 0x20;
+      signed += 0x20;
+      continue;
+    }
+    unsigned += header[index]!;
+    signed += header.readInt8(index);
+  }
+  return stored === unsigned || stored === signed;
+};
+
+/**
+ * `baseDirectory` is the scaffolded project root, because a relative `file:`
+ * spec is written verbatim into that project's `package.json` and npm resolves
+ * it from there — never from this CLI's working directory.
+ */
+const localTarballPackageName = async (packageSpec: string, baseDirectory: string): Promise<string> => {
+  const path = resolve(baseDirectory, packageSpec.slice('file:'.length));
   try {
     const archive = await unzip(await readFile(path));
-    for (let offset = 0; offset + 512 <= archive.length;) {
-      const header = archive.subarray(offset, offset + 512);
+    for (let offset = 0; offset + tarBlockSize <= archive.length;) {
+      const header = archive.subarray(offset, offset + tarBlockSize);
+      if (isEndOfArchiveBlock(header)) break;
+      if (!tarHeaderChecksumMatches(header)) {
+        throw new Error(`Invalid tar header checksum at offset ${offset}: the archive is corrupt.`);
+      }
       const name = header.subarray(0, 100).toString('utf8').replace(/\0.*$/u, '');
       if (name === '') break;
       const sizeText = header.subarray(124, 136).toString('ascii').replace(/\0.*$/u, '').trim();
@@ -58,7 +103,7 @@ const localTarballPackageName = async (packageSpec: string): Promise<string> => 
       if (!Number.isSafeInteger(size) || size < 0) {
         throw new Error(`Invalid tar entry size "${sizeText}".`);
       }
-      const contentsOffset = offset + 512;
+      const contentsOffset = offset + tarBlockSize;
       if (name === 'package/package.json') {
         const manifest = JSON.parse(archive.subarray(contentsOffset, contentsOffset + size).toString('utf8')) as {
           readonly name?: unknown;
@@ -66,7 +111,7 @@ const localTarballPackageName = async (packageSpec: string): Promise<string> => 
         if (typeof manifest.name === 'string') return manifest.name;
         throw new Error('Packed package manifest has no string name.');
       }
-      offset = contentsOffset + Math.ceil(size / 512) * 512;
+      offset = contentsOffset + Math.ceil(size / tarBlockSize) * tarBlockSize;
     }
     throw new Error('Packed package manifest was not found.');
   } catch (error) {
@@ -82,10 +127,13 @@ const localTarballPackageName = async (packageSpec: string): Promise<string> => 
  * instead of surfacing as an install failure — or, under `--no-install`, as a
  * project reported ready with an unusable dependency. Non-`file:` specs stay
  * npm's business: no filesystem read, no registry lookup.
+ *
+ * `baseDirectory` is the scaffold target directory, so a relative `file:` spec
+ * is probed exactly where the emitted `package.json` will point.
  */
-export const assertLocalFrameworkTarball = async (frameworkSpec: string): Promise<void> => {
+export const assertLocalFrameworkTarball = async (frameworkSpec: string, baseDirectory: string): Promise<void> => {
   if (!frameworkSpec.startsWith('file:')) return;
-  const frameworkName = await localTarballPackageName(frameworkSpec);
+  const frameworkName = await localTarballPackageName(frameworkSpec, baseDirectory);
   if (frameworkName !== 'agent-bundle') {
     throw new UsageError(
       `Local package tarball "${frameworkSpec}" is not the agent-bundle package: expected agent-bundle, `
@@ -94,13 +142,19 @@ export const assertLocalFrameworkTarball = async (frameworkSpec: string): Promis
   }
 };
 
-/** Derives and verifies a coherent local framework/runtime tarball pair. */
-export const validatedRuntimeSpecForFramework = async (frameworkSpec: string): Promise<string> => {
+/**
+ * Derives and verifies a coherent local framework/runtime tarball pair,
+ * resolving relative `file:` specs against the scaffold target directory.
+ */
+export const validatedRuntimeSpecForFramework = async (
+  frameworkSpec: string,
+  baseDirectory: string,
+): Promise<string> => {
   const runtimeSpec = runtimeSpecForFramework(frameworkSpec);
   if (!frameworkSpec.startsWith('file:')) return runtimeSpec;
   const [frameworkName, runtimeName] = await Promise.all([
-    localTarballPackageName(frameworkSpec),
-    localTarballPackageName(runtimeSpec),
+    localTarballPackageName(frameworkSpec, baseDirectory),
+    localTarballPackageName(runtimeSpec, baseDirectory),
   ]);
   if (frameworkName !== 'agent-bundle' || runtimeName !== '@agent-bundle/runtime') {
     throw new UsageError(

--- a/packages/create-agent-bundle/src/scaffold.ts
+++ b/packages/create-agent-bundle/src/scaffold.ts
@@ -96,9 +96,9 @@ export const scaffold = async (request: ScaffoldRequest): Promise<readonly strin
     .some((section) => section?.['@agent-bundle/runtime'] === 'workspace:*');
   let runtimeSpec: string | undefined;
   if (usesWorkspaceRuntime) {
-    runtimeSpec = await validatedRuntimeSpecForFramework(request.frameworkSpec);
+    runtimeSpec = await validatedRuntimeSpecForFramework(request.frameworkSpec, request.targetDirectory);
   } else {
-    await assertLocalFrameworkTarball(request.frameworkSpec);
+    await assertLocalFrameworkTarball(request.frameworkSpec, request.targetDirectory);
   }
   const emitted: string[] = [];
   const copyDirectory = async (from: string, to: string, relative: string): Promise<void> => {

--- a/packages/create-agent-bundle/tests/framework.test.ts
+++ b/packages/create-agent-bundle/tests/framework.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from '@rstest/core';
 
 import {
@@ -5,8 +9,21 @@ import {
   previewPackageSpec,
   resolveFrameworkSpec,
   runtimeSpecForFramework,
+  validatedRuntimeSpecForFramework,
 } from '../src/framework.ts';
 import { UsageError } from '../src/options.ts';
+import { packageTarball, tamperedPackageTarball } from './support/package-tarball.ts';
+
+const withTarballDirectory = async (
+  run: (directory: string) => Promise<void>,
+): Promise<void> => {
+  const directory = await mkdtemp(join(tmpdir(), 'create-agent-bundle-tarball-'));
+  try {
+    await run(directory);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+};
 
 describe('previewPackageSpec', () => {
   it('derives the renamed runtime pkg.pr.new URL', () => {
@@ -78,13 +95,73 @@ describe('runtimeSpecForFramework', () => {
 
 describe('assertLocalFrameworkTarball', () => {
   it('leaves registry and preview specs to npm', async () => {
-    await expect(assertLocalFrameworkTarball('0.1.0')).resolves.toBeUndefined();
-    await expect(assertLocalFrameworkTarball('next')).resolves.toBeUndefined();
-    await expect(assertLocalFrameworkTarball('https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@da5df1d'))
-      .resolves.toBeUndefined();
+    await expect(assertLocalFrameworkTarball('0.1.0', tmpdir())).resolves.toBeUndefined();
+    await expect(assertLocalFrameworkTarball('next', tmpdir())).resolves.toBeUndefined();
+    await expect(assertLocalFrameworkTarball(
+      'https://pkg.pr.new/ScriptedAlchemy/agent-bundle/agent-bundle@da5df1d',
+      tmpdir(),
+    )).resolves.toBeUndefined();
   });
 
   it('rejects a local tarball that cannot be read', async () => {
-    await expect(assertLocalFrameworkTarball('file:/tmp/absent-agent-bundle.tgz')).rejects.toThrow(UsageError);
+    await expect(assertLocalFrameworkTarball('file:/tmp/absent-agent-bundle.tgz', tmpdir()))
+      .rejects.toThrow(UsageError);
+  });
+
+  it('accepts a well-formed tarball whose tar header checksum is correct', async () => {
+    await withTarballDirectory(async (directory) => {
+      const tarball = join(directory, 'agent-bundle-0.0.0.tgz');
+      await writeFile(tarball, packageTarball('agent-bundle'));
+      await expect(assertLocalFrameworkTarball(`file:${tarball}`, directory)).resolves.toBeUndefined();
+    });
+  });
+
+  it('rejects an inflatable tarball whose tar header checksum does not match', async () => {
+    await withTarballDirectory(async (directory) => {
+      const tarball = join(directory, 'agent-bundle-0.0.0.tgz');
+      await writeFile(tarball, tamperedPackageTarball('agent-bundle'));
+      await expect(assertLocalFrameworkTarball(`file:${tarball}`, directory)).rejects.toThrow(UsageError);
+      await expect(assertLocalFrameworkTarball(`file:${tarball}`, directory))
+        .rejects.toThrow('Invalid tar header checksum');
+    });
+  });
+
+  it('resolves a relative file: spec against the base directory, not the process working directory', async () => {
+    await withTarballDirectory(async (directory) => {
+      await writeFile(join(directory, 'agent-bundle-0.0.0.tgz'), packageTarball('agent-bundle'));
+      const spec = 'file:../agent-bundle-0.0.0.tgz';
+      await expect(assertLocalFrameworkTarball(spec, join(directory, 'project'))).resolves.toBeUndefined();
+      await expect(assertLocalFrameworkTarball(spec, process.cwd())).rejects.toThrow(UsageError);
+    });
+  });
+});
+
+describe('validatedRuntimeSpecForFramework', () => {
+  it('leaves registry and preview specs to npm', async () => {
+    await expect(validatedRuntimeSpecForFramework('0.1.0', tmpdir())).resolves.toBe('0.1.0');
+  });
+
+  it('resolves a relative file: pair against the base directory', async () => {
+    await withTarballDirectory(async (directory) => {
+      await Promise.all([
+        writeFile(join(directory, 'agent-bundle-0.0.0.tgz'), packageTarball('agent-bundle')),
+        writeFile(join(directory, 'agent-bundle-runtime-0.0.0.tgz'), packageTarball('@agent-bundle/runtime')),
+      ]);
+      const spec = 'file:../agent-bundle-0.0.0.tgz';
+      await expect(validatedRuntimeSpecForFramework(spec, join(directory, 'project')))
+        .resolves.toBe('file:../agent-bundle-runtime-0.0.0.tgz');
+      await expect(validatedRuntimeSpecForFramework(spec, process.cwd())).rejects.toThrow(UsageError);
+    });
+  });
+
+  it('rejects a pair whose runtime tarball has a tampered tar header', async () => {
+    await withTarballDirectory(async (directory) => {
+      await Promise.all([
+        writeFile(join(directory, 'agent-bundle-0.0.0.tgz'), packageTarball('agent-bundle')),
+        writeFile(join(directory, 'agent-bundle-runtime-0.0.0.tgz'), tamperedPackageTarball('@agent-bundle/runtime')),
+      ]);
+      await expect(validatedRuntimeSpecForFramework(`file:${join(directory, 'agent-bundle-0.0.0.tgz')}`, directory))
+        .rejects.toThrow('Invalid tar header checksum');
+    });
   });
 });

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -1,24 +1,15 @@
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { gzipSync } from 'node:zlib';
 
 import { describe, expect, it } from '@rstest/core';
 
 import { runtimeSpecForFramework } from '../src/framework.ts';
 import { UsageError, type TargetName } from '../src/options.ts';
 import { assertScaffoldTarget, placeholderName, scaffold } from '../src/scaffold.ts';
+import { packageTarball, tamperedPackageTarball } from './support/package-tarball.ts';
 
 const templatesRoot = join(process.cwd(), 'packages', 'create-agent-bundle', 'templates');
-
-const packageTarball = (name: string): Buffer => {
-  const manifest = Buffer.from(JSON.stringify({ name }));
-  const archive = Buffer.alloc(512 + Math.ceil(manifest.length / 512) * 512 + 1024);
-  archive.write('package/package.json', 0, 'utf8');
-  archive.write(`${manifest.length.toString(8).padStart(11, '0')}\0`, 124, 'ascii');
-  manifest.copy(archive, 512);
-  return gzipSync(archive);
-};
 
 const scaffoldTemplate = async (
   template: string,
@@ -237,6 +228,62 @@ describe('scaffold', () => {
       };
       expect(manifest.devDependencies['agent-bundle']).toBe(frameworkSpec);
     });
+  });
+
+  it('rejects a local framework tarball with a tampered tar header', async () => {
+    await scaffoldFrameworkOnly(tamperedPackageTarball('agent-bundle'), async (scaffolded, targetDirectory) => {
+      await expect(scaffolded).rejects.toThrow(UsageError);
+      await expect(scaffolded).rejects.toThrow('Invalid tar header checksum');
+      await expect(readdir(targetDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('resolves a relative framework tarball spec against the target directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-agent-bundle-relative-'));
+    try {
+      await writeFile(join(root, 'agent-bundle-0.0.0.tgz'), packageTarball('agent-bundle'));
+      const targetDirectory = join(root, 'project');
+      const frameworkSpec = 'file:../agent-bundle-0.0.0.tgz';
+      await expect(scaffold({
+        frameworkSpec,
+        packageName: 'status-plugin',
+        pluginName: 'status-plugin',
+        targetDirectory,
+        targets: ['portable'],
+        templateRoot: join(templatesRoot, 'minimal'),
+      })).resolves.toContain('package.json');
+      const manifest = JSON.parse(await readFile(join(targetDirectory, 'package.json'), 'utf8')) as {
+        readonly devDependencies: Record<string, string>;
+      };
+      expect(manifest.devDependencies['agent-bundle']).toBe(frameworkSpec);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it('resolves a relative framework/runtime tarball pair against the target directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-agent-bundle-relative-pair-'));
+    try {
+      await Promise.all([
+        writeFile(join(root, 'agent-bundle-0.0.0.tgz'), packageTarball('agent-bundle')),
+        writeFile(join(root, 'agent-bundle-runtime-0.0.0.tgz'), packageTarball('@agent-bundle/runtime')),
+      ]);
+      const targetDirectory = join(root, 'project');
+      await expect(scaffold({
+        frameworkSpec: 'file:../agent-bundle-0.0.0.tgz',
+        packageName: 'status-plugin',
+        pluginName: 'status-plugin',
+        targetDirectory,
+        targets: ['portable'],
+        templateRoot: join(templatesRoot, 'mcp-server'),
+      })).resolves.toContain('package.json');
+      const manifest = JSON.parse(await readFile(join(targetDirectory, 'package.json'), 'utf8')) as {
+        readonly dependencies: Record<string, string>;
+      };
+      expect(manifest.dependencies['@agent-bundle/runtime']).toBe('file:../agent-bundle-runtime-0.0.0.tgz');
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/create-agent-bundle/tests/support/package-tarball.ts
+++ b/packages/create-agent-bundle/tests/support/package-tarball.ts
@@ -1,0 +1,54 @@
+import { gzipSync } from 'node:zlib';
+
+const tarBlockSize = 512;
+const tarChecksumOffset = 148;
+const tarChecksumLength = 8;
+const tarModeOffset = 100;
+
+const writeOctalField = (header: Buffer, value: number, offset: number, length: number): void => {
+  header.write(`${value.toString(8).padStart(length - 1, '0')}\0`, offset, 'ascii');
+};
+
+const applyHeaderChecksum = (header: Buffer): void => {
+  header.fill(0x20, tarChecksumOffset, tarChecksumOffset + tarChecksumLength);
+  let sum = 0;
+  for (let index = 0; index < tarBlockSize; index += 1) sum += header[index]!;
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, tarChecksumOffset, 'ascii');
+};
+
+/**
+ * The smallest archive `localTarballPackageName` accepts: one ustar entry for
+ * `package/package.json` naming the package, then the end-of-archive blocks.
+ */
+export const packageTarArchive = (name: string): Buffer => {
+  const manifest = Buffer.from(JSON.stringify({ name }));
+  const archive = Buffer.alloc(
+    tarBlockSize + Math.ceil(manifest.length / tarBlockSize) * tarBlockSize + tarBlockSize * 2,
+  );
+  const header = archive.subarray(0, tarBlockSize);
+  header.write('package/package.json', 0, 'utf8');
+  writeOctalField(header, 0o644, tarModeOffset, 8);
+  writeOctalField(header, 0, 108, 8);
+  writeOctalField(header, 0, 116, 8);
+  writeOctalField(header, manifest.length, 124, 12);
+  writeOctalField(header, 0, 136, 12);
+  header.write('0', 156, 'ascii');
+  header.write('ustar', 257, 'ascii');
+  header.write('00', 263, 'ascii');
+  applyHeaderChecksum(header);
+  manifest.copy(archive, tarBlockSize);
+  return archive;
+};
+
+export const packageTarball = (name: string): Buffer => gzipSync(packageTarArchive(name));
+
+/**
+ * A gzip stream that still inflates cleanly, carrying a header whose mode was
+ * rewritten without refreshing the checksum. The parser never reads the mode,
+ * so only checksum verification can tell this archive from a sound one.
+ */
+export const tamperedPackageTarball = (name: string): Buffer => {
+  const archive = packageTarArchive(name);
+  writeOctalField(archive, 0o777, tarModeOffset, 8);
+  return gzipSync(archive);
+};


### PR DESCRIPTION
## Summary

Addresses the two unresolved post-merge Codex P2 findings on #228:

- **Tar header checksums** (`framework.ts`): `localTarballPackageName` accepted any archive whose gzip stream inflated, so a corrupt tar header could still pass framework-tarball validation. Every 512-byte header is now verified against the ustar checksum (unsigned sum authoritative, historical GNU signed sum also accepted) before its entry is trusted; all-zero end-of-archive blocks terminate the walk without a checksum error.
- **Relative `file:` spec resolution** (`framework.ts` / `scaffold.ts`): relative `file:` specs were resolved from the CLI's process CWD, so a valid `file:../agent-bundle.tgz` was probed at the wrong path and rejected. Validation now resolves relative specs against the scaffold target directory — the same base npm uses for the spec emitted into the generated `package.json`.

## Tests

- Corrupt-archive rejection: a tarball whose header `mode` was rewritten without refreshing the checksum (a corruption only checksum verification can detect) is rejected in `assertLocalFrameworkTarball`, `validatedRuntimeSpecForFramework`, and end-to-end `scaffold`; a well-formed archive still passes.
- Relative-spec resolution: framework-only and framework/runtime-pair scaffolds succeed with `file:../...` specs resolved against the target directory, and the same specs fail when resolved against an unrelated CWD (the old behavior).
- Test fixture tarballs now carry correct ustar checksums (shared `tests/support/package-tarball.ts`).

Scoped gates: unit tests (framework/scaffold/options), `pnpm typecheck`, `pnpm lint` — all green.