### PR TITLE
fix(test): accept npm 12 pack --json in packed-consumer

### DIFF
--- a/packages/agent-bundle/tests/packed-consumer.test.ts
+++ b/packages/agent-bundle/tests/packed-consumer.test.ts
@@ -20,7 +20,7 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { sha256Hex } from '../src/core/digest.ts';
-import { cachedNpmInstallArguments, installedEnvironment } from './support/shared-pack.ts';
+import { cachedNpmInstallArguments, installedEnvironment, packOutputFromJson } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
 const workspaceRoot = process.cwd();
@@ -92,7 +92,7 @@ it('uses only an installed tarball after source deletion', async () => {
       cwd: packedPackageRoot,
       env: installedEnvironment(),
     });
-    const tarball = join(consumerRoot, (JSON.parse(packed) as Array<{ filename: string }>)[0]!.filename);
+    const tarball = join(consumerRoot, packOutputFromJson(packed).filename);
     await cp(fixtureRoot, projectRoot, { recursive: true });
     const [sourceShellMode, sourcePythonMode] = await Promise.all([
       stat(join(projectRoot, 'src', 'shell.sh')).then((metadata) => metadata.mode & 0o777),

--- a/packages/agent-bundle/tests/support/shared-pack.ts
+++ b/packages/agent-bundle/tests/support/shared-pack.ts
@@ -23,7 +23,7 @@ export interface SharedPack {
 
 export type SharedPackPackage = 'agent-bundle' | 'create-agent-bundle' | 'runtime';
 
-const packOutputFromJson = (stdout: string): SharedPackOutput => {
+export const packOutputFromJson = (stdout: string): SharedPackOutput => {
   const parsed: unknown = JSON.parse(stdout);
   const entries = Array.isArray(parsed)
     ? parsed


### PR DESCRIPTION
## Summary

- Reuse `packOutputFromJson` from `shared-pack.ts` in `packed-consumer.test.ts` so `npm pack --json` parsing accepts npm 12's package-keyed object output as well as npm ≤11's array form.
- PR #225 fixed this pattern at `shared-pack.ts`, `audit-packed-release.mjs`, and `run-packed-tests.mjs`; this file was missed (see #103 closing comment).

## Test plan

- [x] `node scripts/run-packed-tests.mjs packages/agent-bundle/tests/packed-consumer.test.ts` (npm 12.0.2)
- [x] `pnpm typecheck`
- [x] `pnpm lint`