### PR TITLE
test(examples): prove worktree-proximity journeys across real processes and worktrees (#104)

### DIFF
--- a/examples/worktree-proximity/README.md
+++ b/examples/worktree-proximity/README.md
@@ -95,20 +95,31 @@ mounted handle, they return an unavailable result and the route renders that
 reason as `Agent.Context`; there is no fallback write path.
 
 Notice admission runs once per event invocation in the render scope.
-Recipient matching uses the actor identity mounted in that request, and
-`(await agent()).notices.read()` exposes only deliveries attempted for that
-invocation. The coordinator status therefore reports topology facts only and
-does not claim a whole-ledger pending count.
+Generated event principals in v1 mount host, session, and workspace identity,
+but not actor identity. Proximity notices therefore target the recipient
+worktree through `recipient.workspace.root`, while their content and dedupe
+keys continue to name the target actor. Actor-directed delivery remains future
+work tied to actor-principal mounting in the #99/#233 lineage.
+`(await agent()).notices.read()` exposes only deliveries attempted for the
+current invocation. The coordinator status therefore reports topology facts
+only and does not claim a whole-ledger pending count.
 
 ## Evidence boundary
 
 The route-unit suite is in-process real-renderer evidence: it compiles the
 manifest, mounts the real state and notice handles, renders the event routes,
 and exercises the documented journeys against one shared durable runtime
-owner. The multi-process artifact/contract suite is the next slice and has
-not run here. Neither level is proof that Claude, Codex, or another commercial
-host dispatches a hook, preserves its envelope, or displays projected context
-in production.
+owner. The root integration-pool suite
+`packages/agent-bundle/tests/worktree-proximity-journeys.test.ts` builds the
+real artifact, invokes generated hooks as separate processes against linked
+Git worktrees, and proves warning, workspace-directed delivery, replay
+idempotency, and exact-revision restart durability through the generated MCP
+server. Journey 8 has two honesty layers: the generated wrapper fails closed
+on an identity-less `SubagentStart` for host contracts that require
+`agent_id`, while the route-unit suite proves the route records a refusal for
+host contracts that genuinely omit it. Neither level proves that Claude,
+Codex, or another commercial host dispatches a hook, preserves its envelope,
+or displays projected context in production.
 
 ## External-driver boundary
 

--- a/examples/worktree-proximity/src/domain/proximity.ts
+++ b/examples/worktree-proximity/src/domain/proximity.ts
@@ -9,6 +9,7 @@ export interface ProximityIntent {
 export interface ProximityConflict {
   readonly actorId: string;
   readonly summary: string;
+  readonly worktreeRoot: string;
 }
 
 const normalizeSegments = (value: string): string => {
@@ -69,6 +70,7 @@ export const findProximity = (
         actorId: actor.id,
         summary:
           `Worktrees ${currentWorktree} and ${actor.worktreeRoot} both intend to change path ${sharedPath}.`,
+        worktreeRoot: actor.worktreeRoot,
       });
     }
 
@@ -80,6 +82,7 @@ export const findProximity = (
         actorId: actor.id,
         summary:
           `Worktrees ${currentWorktree} and ${actor.worktreeRoot} both depend on ${sharedDependency}.`,
+        worktreeRoot: actor.worktreeRoot,
       });
     }
   }

--- a/examples/worktree-proximity/src/events/tool/before.tsx
+++ b/examples/worktree-proximity/src/events/tool/before.tsx
@@ -78,7 +78,7 @@ export default async function BeforeTool({
         dedupeKey: `proximity:${resolution.actor.id}:${conflict.actorId}:${conflict.summary}`,
         priority: 'high',
         recipient: {
-          actor: { id: conflict.actorId },
+          workspace: { root: conflict.worktreeRoot },
         },
       }, {
         idempotencyKey: `${canonical.idempotencyKey}:notice:${String(index)}`,

--- a/examples/worktree-proximity/src/mcp/coordinator/tools/status.tsx
+++ b/examples/worktree-proximity/src/mcp/coordinator/tools/status.tsx
@@ -23,6 +23,7 @@ export const resultSchema = z
     actors: z.array(ActorSchema),
     reason: z.string().optional(),
     refusals: z.number().int().nonnegative(),
+    revision: z.number().int().nonnegative(),
     state: z.enum(['available', 'unavailable']),
   })
   .strict();
@@ -32,7 +33,7 @@ type StatusResult = z.output<typeof resultSchema>;
 export default async function Status({
   input,
 }: ToolRouteProps<typeof inputSchema>) {
-  const topologyResult = await withTopology(async (store) => (await store.read()).state);
+  const topologyResult = await withTopology(async (store) => store.read());
   let result: StatusResult;
   if (topologyResult.state === 'unavailable') {
     result = {
@@ -40,10 +41,11 @@ export default async function Status({
       actors: [],
       reason: topologyResult.reason,
       refusals: 0,
+      revision: 0,
       state: 'unavailable',
     };
   } else {
-    const topology = topologyResult.value;
+    const { revision, state: topology } = topologyResult.value;
     const actors = input.actorId === undefined
       ? topology.actors
       : topology.actors.filter((actor) => actor.id === input.actorId);
@@ -56,6 +58,7 @@ export default async function Status({
       ).length,
       actors,
       refusals: topology.refusals.length,
+      revision,
       state: 'available',
     };
   }

--- a/examples/worktree-proximity/tests/proximity.test.ts
+++ b/examples/worktree-proximity/tests/proximity.test.ts
@@ -63,6 +63,7 @@ describe('findProximity', () => {
       actorId: 'agent-b',
       summary:
         'Worktrees /repo/worktrees/a and /repo/worktrees/b both intend to change path src/shared.ts.',
+      worktreeRoot: '/repo/worktrees/b',
     }]);
   });
 
@@ -75,6 +76,7 @@ describe('findProximity', () => {
       actorId: 'agent-b',
       summary:
         'Worktrees /repo/worktrees/a and /repo/worktrees/b both depend on zod.',
+      worktreeRoot: '/repo/worktrees/b',
     }]);
   });
 

--- a/examples/worktree-proximity/tests/route-unit/routes.test.ts
+++ b/examples/worktree-proximity/tests/route-unit/routes.test.ts
@@ -81,7 +81,7 @@ const renderEventInput = async (
         providers: { gitWorktree: provider(worktreeRoot) },
         session: available({ sessionId: 'root-session' }, 'native'),
         state: bindings.state,
-        workspace: available({ root: '/repo' }, 'native'),
+        workspace: available({ root: worktreeRoot }, 'native'),
       },
       input,
     });
@@ -224,7 +224,7 @@ describe('worktree proximity journeys', () => {
       const snapshot = await bindings.noticeLedger.read();
       expect(snapshot.notices).toEqual([
         expect.objectContaining({
-          recipient: { actor: { id: 'agent-a' } },
+          recipient: { workspace: { root: worktrees.a } },
           state: 'pending',
         }),
       ]);
@@ -370,6 +370,7 @@ describe('worktree proximity journeys', () => {
         expect.objectContaining({ id: 'agent-b', worktreeRoot: worktrees.b }),
       ]),
       refusals: 0,
+      revision: expect.any(Number),
     });
   });
 

--- a/packages/agent-bundle/tests/worktree-proximity-journeys.test.ts
+++ b/packages/agent-bundle/tests/worktree-proximity-journeys.test.ts
@@ -1,0 +1,424 @@
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { execFile as executeFile, spawn } from 'node:child_process';
+import { cp, mkdtemp, mkdir, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterAll, beforeAll, expect, it } from '@rstest/core';
+
+import { build } from '../src/api.ts';
+import { eventRuntimeEndpoint } from '../src/events/ipc.ts';
+
+const execFile = promisify(executeFile);
+const exampleRoot = resolve(import.meta.dirname, '../../../examples/worktree-proximity');
+const sessionId = 'root-session';
+
+interface ActorStatus {
+  readonly id: string;
+  readonly kind: 'child' | 'root';
+  readonly parentSessionId?: string;
+  readonly provenance: {
+    readonly id: 'derived' | 'native';
+    readonly parentSessionId?: 'derived' | 'native';
+    readonly worktreeRoot?: 'derived' | 'native';
+  };
+  readonly status: 'active' | 'stopped';
+  readonly worktreeRoot?: string;
+}
+
+interface StatusResult {
+  readonly activeActivities: number;
+  readonly actors: readonly ActorStatus[];
+  readonly reason?: string;
+  readonly refusals: number;
+  readonly revision: number;
+  readonly state: 'available' | 'unavailable';
+}
+
+interface JourneyFixture {
+  readonly endpoint: string;
+  readonly entry: string;
+  readonly hooks: {
+    readonly afterTool: string;
+    readonly agentStart: string;
+    readonly beforeTool: string;
+    readonly sessionStart: string;
+  };
+  readonly pluginRoot: string;
+  readonly repoRoot: string;
+  readonly tempRoot: string;
+  readonly worktreeA: string;
+  readonly worktreeB: string;
+}
+
+interface ServerSession {
+  readonly client: Client;
+  readonly diagnostics: () => string;
+  readonly pid: number;
+  readonly stop: () => Promise<void>;
+}
+
+let fixture: JourneyFixture;
+let liveSession: ServerSession | undefined;
+
+const environment = (
+  extra: Readonly<Record<string, string>>,
+): Record<string, string> => {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return { ...env, ...extra };
+};
+
+const runGit = async (
+  cwd: string,
+  ...args: readonly string[]
+): Promise<string> => {
+  const result = await execFile('git', args, { cwd, encoding: 'utf8' });
+  return result.stdout.trim();
+};
+
+const runHook = async (
+  entry: string,
+  cwd: string,
+  input: Readonly<Record<string, unknown>>,
+  env: Readonly<Record<string, string>>,
+): Promise<Readonly<Record<string, unknown>> | undefined> => new Promise((resolvePromise, reject) => {
+  const child = spawn(process.execPath, [entry], {
+    cwd,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  let stdout = '';
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGKILL');
+  }, 15_000);
+  child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+  child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+  child.once('error', (error) => {
+    clearTimeout(timeout);
+    reject(error);
+  });
+  child.once('close', (code) => {
+    clearTimeout(timeout);
+    if (timedOut) {
+      reject(new Error(`Generated hook timed out.\nstderr:\n${stderr}`));
+      return;
+    }
+    if (code !== 0) {
+      reject(new Error(`Generated hook exited with code ${String(code)}.\nstderr:\n${stderr}`));
+      return;
+    }
+    const output = stdout.trim();
+    resolvePromise(output === '' ? undefined : JSON.parse(output) as Readonly<Record<string, unknown>>);
+  });
+  child.stdin.end(JSON.stringify(input));
+});
+
+const startServer = async (): Promise<ServerSession> => {
+  const client = new Client({ name: 'worktree-proximity-journeys', version: '0.0.0' });
+  const transport = new StdioClientTransport({
+    args: [fixture.entry],
+    command: process.execPath,
+    cwd: fixture.repoRoot,
+    env: environment({ AGENT_BUNDLE_PLUGIN_ROOT: fixture.pluginRoot }),
+    stderr: 'pipe',
+  });
+  let diagnostics = '';
+  transport.stderr?.on('data', (chunk) => { diagnostics += String(chunk); });
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    throw new Error(`Worktree proximity server failed to connect.\nstderr:\n${diagnostics}`, { cause: error });
+  }
+  const pid = transport.pid;
+  if (pid === null) throw new Error('Expected the stdio transport to expose its server process id.');
+  return {
+    client,
+    diagnostics: () => diagnostics,
+    pid,
+    stop: async () => {
+      await client.close();
+    },
+  };
+};
+
+const callStatus = async (client: Client): Promise<StatusResult> => {
+  const response = await client.callTool(
+    { arguments: {}, name: 'status' },
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  const result = response.structuredContent as unknown;
+  expect(result).toBeDefined();
+  expect(Object.keys(result as Record<string, unknown>).sort()).toEqual([
+    'activeActivities',
+    'actors',
+    'refusals',
+    'revision',
+    'state',
+  ]);
+  return result as StatusResult;
+};
+
+const hookText = (
+  output: Readonly<Record<string, unknown>> | undefined,
+): string => JSON.stringify(output) ?? '';
+
+beforeAll(async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'worktree-proximity-journeys-'));
+  const repoRoot = join(tempRoot, 'repo');
+  const worktreeA = join(tempRoot, 'worktree-a');
+  const worktreeB = join(tempRoot, 'worktree-b');
+  const projectRoot = join(tempRoot, 'project');
+  const artifactRoot = join(projectRoot, 'artifact');
+  await mkdir(join(repoRoot, 'src'), { recursive: true });
+  await runGit(tempRoot, 'init', '--initial-branch=main', repoRoot);
+  await runGit(repoRoot, 'config', 'user.email', 'journeys@example.invalid');
+  await runGit(repoRoot, 'config', 'user.name', 'Journey Fixture');
+  await writeFile(join(repoRoot, 'src', 'shared.ts'), 'export const shared = true;\n');
+  await runGit(repoRoot, 'add', '.');
+  await runGit(repoRoot, 'commit', '-m', 'fixture');
+  await runGit(repoRoot, 'worktree', 'add', '-b', 'journey-a', worktreeA);
+  await runGit(repoRoot, 'worktree', 'add', '-b', 'journey-b', worktreeB);
+  await mkdir(projectRoot, { recursive: true });
+  await Promise.all([
+    cp(join(exampleRoot, 'agent-bundle.config.ts'), join(projectRoot, 'agent-bundle.config.ts')),
+    cp(join(exampleRoot, 'package.json'), join(projectRoot, 'package.json')),
+    cp(join(exampleRoot, 'src'), join(projectRoot, 'src'), { recursive: true }),
+    symlink(join(exampleRoot, 'node_modules'), join(projectRoot, 'node_modules'), 'dir'),
+  ]);
+
+  const compiled = await build({
+    output: artifactRoot,
+    root: projectRoot,
+    targets: ['claude'],
+  });
+  const mcp = compiled.build.compiledMcpEntries.find((entry) => entry.target === 'claude');
+  if (mcp === undefined) throw new Error('Expected a generated Claude MCP entry.');
+  const hook = (event: string): string => {
+    const compiledHook = compiled.build.compiledHooks.find(
+      (entry) => entry.target === 'claude' && entry.event === event,
+    );
+    if (compiledHook === undefined) throw new Error(`Expected a generated Claude ${event} hook.`);
+    return compiledHook.output;
+  };
+  const pluginRoot = dirname(dirname(resolve(mcp.output)));
+  const endpointId = `${compiled.build.manifest.project.revision}:claude:${pluginRoot}`;
+  fixture = {
+    endpoint: eventRuntimeEndpoint(endpointId),
+    entry: mcp.output,
+    hooks: {
+      afterTool: hook('afterTool'),
+      agentStart: hook('agentStart'),
+      beforeTool: hook('beforeTool'),
+      sessionStart: hook('sessionStart'),
+    },
+    pluginRoot,
+    repoRoot,
+    tempRoot,
+    worktreeA,
+    worktreeB,
+  };
+}, 120_000);
+
+afterAll(async () => {
+  await liveSession?.stop();
+  if (fixture !== undefined) {
+    await rm(fixture.tempRoot, { force: true, recursive: true });
+  }
+});
+
+it('proves worktree proximity journeys across real processes and linked worktrees', { timeout: 120_000 }, async () => {
+  const rootHead = await runGit(fixture.repoRoot, 'rev-parse', 'HEAD');
+  expect(await runGit(fixture.worktreeA, 'rev-parse', 'HEAD')).toBe(rootHead);
+  expect(await runGit(fixture.worktreeB, 'rev-parse', 'HEAD')).toBe(rootHead);
+  expect(await runGit(fixture.worktreeA, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('journey-a');
+  expect(await runGit(fixture.worktreeB, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('journey-b');
+  const commonDir = resolve(
+    fixture.repoRoot,
+    await runGit(fixture.repoRoot, 'rev-parse', '--git-common-dir'),
+  );
+  for (const worktree of [fixture.worktreeA, fixture.worktreeB]) {
+    const worktreeCommonDir = resolve(worktree, await runGit(worktree, 'rev-parse', '--git-common-dir'));
+    const worktreeGitDir = resolve(worktree, await runGit(worktree, 'rev-parse', '--git-dir'));
+    expect(worktreeCommonDir).toBe(commonDir);
+    expect(worktreeGitDir).not.toBe(commonDir);
+  }
+
+  liveSession = await startServer();
+  expect(liveSession.pid).toBeGreaterThan(0);
+  await expect(stat(fixture.endpoint)).resolves.toMatchObject({ mode: expect.any(Number) });
+  await expect(callStatus(liveSession.client)).resolves.toEqual({
+    activeActivities: 0,
+    actors: [],
+    refusals: 0,
+    revision: 0,
+    state: 'available',
+  });
+
+  const hookEnvironment = environment({ AGENT_BUNDLE_PLUGIN_ROOT: fixture.pluginRoot });
+  const transcriptPath = join(fixture.repoRoot, 'transcript.jsonl');
+  await runHook(fixture.hooks.sessionStart, fixture.repoRoot, {
+    cwd: fixture.repoRoot,
+    hook_event_name: 'SessionStart',
+    session_id: sessionId,
+    source: 'startup',
+    transcript_path: transcriptPath,
+  }, hookEnvironment);
+  await runHook(fixture.hooks.agentStart, fixture.worktreeA, {
+    agent_id: 'agent-a',
+    agent_type: 'implementation',
+    cwd: fixture.worktreeA,
+    hook_event_name: 'SubagentStart',
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+  }, hookEnvironment);
+  await runHook(fixture.hooks.agentStart, fixture.worktreeB, {
+    agent_id: 'agent-b',
+    agent_type: 'implementation',
+    cwd: fixture.worktreeB,
+    hook_event_name: 'SubagentStart',
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+  }, hookEnvironment);
+
+  const intentA = {
+    cwd: fixture.worktreeA,
+    hook_event_name: 'PreToolUse',
+    session_id: sessionId,
+    tool_input: { deps: 'deps:react', file_path: 'src/shared.ts' },
+    tool_name: 'Edit',
+    tool_use_id: 'intent-a',
+    transcript_path: transcriptPath,
+  } as const;
+  const intentB = {
+    cwd: fixture.worktreeB,
+    hook_event_name: 'PreToolUse',
+    session_id: sessionId,
+    tool_input: { deps: 'deps:zod', file_path: 'src/shared.ts' },
+    tool_name: 'Edit',
+    tool_use_id: 'intent-b',
+    transcript_path: transcriptPath,
+  } as const;
+  const firstIntent = await runHook(
+    fixture.hooks.beforeTool,
+    fixture.worktreeA,
+    intentA,
+    hookEnvironment,
+  );
+  expect(hookText(firstIntent)).not.toContain('Proximity warning');
+
+  const warning =
+    `Proximity warning for agent-b: Worktrees ${fixture.worktreeB} and ${fixture.worktreeA} both intend to change path src/shared.ts.`;
+  const secondIntent = await runHook(
+    fixture.hooks.beforeTool,
+    fixture.worktreeB,
+    intentB,
+    hookEnvironment,
+  );
+  expect(hookText(secondIntent)).toContain(warning);
+
+  const delivered = await runHook(fixture.hooks.afterTool, fixture.worktreeA, {
+    cwd: fixture.worktreeA,
+    hook_event_name: 'PostToolUse',
+    session_id: sessionId,
+    tool_input: { file_path: 'src/shared.ts' },
+    tool_name: 'Edit',
+    tool_response: { ok: true },
+    tool_use_id: 'intent-a-after',
+    transcript_path: transcriptPath,
+  }, hookEnvironment);
+  expect(hookText(delivered)).toContain(
+    `Directed proximity notice (attempted, next-event): Worktrees ${fixture.worktreeB} and ${fixture.worktreeA} both intend to change path src/shared.ts.`,
+  );
+
+  const beforeReplay = await callStatus(liveSession.client);
+  expect(beforeReplay.activeActivities).toBe(1);
+  await runHook(
+    fixture.hooks.beforeTool,
+    fixture.worktreeB,
+    intentB,
+    hookEnvironment,
+  );
+  await expect(callStatus(liveSession.client)).resolves.toEqual(beforeReplay);
+
+  const beforeMalformedEnvelope = await callStatus(liveSession.client);
+  // Required-identity host contracts fail closed in the generated wrapper; the
+  // route-unit suite proves route-level refusal for hosts that omit identity.
+  await expect(runHook(fixture.hooks.agentStart, fixture.worktreeA, {
+    agent_type: 'fixture-without-identity',
+    cwd: fixture.worktreeA,
+    hook_event_name: 'SubagentStart',
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+  }, hookEnvironment)).rejects.toThrow(
+    /Generated hook exited with code [1-9]\d*\.[\s\S]*native agent_id must be a nonempty string/u,
+  );
+  await expect(callStatus(liveSession.client)).resolves.toEqual(beforeMalformedEnvelope);
+
+  const expectedActors: readonly ActorStatus[] = [
+    {
+      id: `session:${sessionId}`,
+      kind: 'root',
+      provenance: { id: 'native', worktreeRoot: 'native' },
+      status: 'active',
+      worktreeRoot: fixture.repoRoot,
+    },
+    {
+      id: 'agent-a',
+      kind: 'child',
+      parentSessionId: sessionId,
+      provenance: {
+        id: 'native',
+        parentSessionId: 'native',
+        worktreeRoot: 'native',
+      },
+      status: 'active',
+      worktreeRoot: fixture.worktreeA,
+    },
+    {
+      id: 'agent-b',
+      kind: 'child',
+      parentSessionId: sessionId,
+      provenance: {
+        id: 'native',
+        parentSessionId: 'native',
+        worktreeRoot: 'native',
+      },
+      status: 'active',
+      worktreeRoot: fixture.worktreeB,
+    },
+  ];
+  const beforeRestart = await callStatus(liveSession.client);
+  expect(beforeRestart).toMatchObject({
+    activeActivities: 1,
+    actors: expectedActors,
+    refusals: 0,
+    state: 'available',
+  });
+  expect(beforeRestart.revision).toBeGreaterThan(0);
+
+  const firstPid = liveSession.pid;
+  await liveSession.stop();
+  liveSession = undefined;
+  expect(() => process.kill(firstPid, 0)).toThrow();
+
+  liveSession = await startServer();
+  expect(liveSession.pid).not.toBe(firstPid);
+  await expect(stat(fixture.endpoint)).resolves.toMatchObject({ mode: expect.any(Number) });
+  const afterRestart = await callStatus(liveSession.client);
+  expect(afterRestart).toEqual(beforeRestart);
+  expect(afterRestart).toMatchObject({
+    activeActivities: 1,
+    actors: expectedActors,
+    refusals: 0,
+    state: 'available',
+  });
+  expect(liveSession.diagnostics()).not.toContain('"jsonrpc"');
+});

--- a/rstest.integration-tests.ts
+++ b/rstest.integration-tests.ts
@@ -48,6 +48,7 @@ export const integrationTestFiles: readonly string[] = [
   'packages/agent-bundle/tests/script-playground-service.test.ts',
   'packages/agent-bundle/tests/target-hook-contract.test.ts',
   'packages/agent-bundle/tests/target-mcp-runtime.test.ts',
+  'packages/agent-bundle/tests/worktree-proximity-journeys.test.ts',
   'packages/rsc-runtime/tests/notices-sqlite-cross-process.test.ts',
   'packages/rsc-runtime/tests/state-packaging.test.ts',
   'packages/rsc-runtime/tests/state-sqlite-cross-process.test.ts',


### PR DESCRIPTION
## Summary

Completes #104's evidence boundary: one serialized integration suite (`packages/agent-bundle/tests/worktree-proximity-journeys.test.ts`, root integration pool) that builds the `examples/worktree-proximity` artifact once, creates a REAL git repository with two linked worktrees, spawns the generated MCP server over stdio, and drives every journey through real generated hook thin-client child processes over the artifact IPC endpoint — artifact/contract evidence, explicitly not commercial-host dispatch proof.

**Journeys 1–9, cross-process**
- 1–2: root + two child actors observed with native parent provenance, each bound to a distinct real worktree.
- 3: non-overlapping intent → no warning.
- 4–5: overlapping path intent from worktree B → exact proximity warning in the hook's additional context; a durable directed notice published for the other worktree.
- 6: worktree A's next event renders the attempted notice.
- 7: replaying the identical native envelope leaves activities and the state `revision` unchanged.
- 8, two honesty layers: the generated wrapper fail-closes a SubagentStart missing `agent_id` (nonzero exit, `native agent_id must be a nonempty string`, durable state untouched) because the pinned hosts' contracts always carry identity; the route-level refusal for hosts that genuinely omit identity stays proven at route-unit level.
- 9: SIGKILL the server, respawn on the same artifact — identical `revision`, actors, activities, refusals from durable sqlite.

**Example adjustment (workspace recipient axis)**
Generated event request scopes mount host/session/workspace principals (workspace = native `cwd`) and no actor principal, so actor-directed notices are un-attemptable in generated runtimes v1. Directed notices now target the recipient worktree via the supported `AgentRecipient.workspace` axis; the target actor stays named in content and dedupe keys, and the README documents the boundary (actor-principal mounting remains #99/#233 lineage follow-up). `tool:coordinator/status` gains an honest `revision` field for exact-revision assertions.

## Gates (local)

- journey suite via root integration pool — 1/1 (all nine journeys inside)
- `pnpm --filter @agent-bundle-example/worktree-proximity check` — validate/build/typecheck, 4/4 domain, 8/8 route-unit
- rslint on touched files — clean

Refs #104, #99, #233.