### PR TITLE
chore(adapters): strip self-pinning of repo-owned capability tables

### DIFF
--- a/.changeset/strip-capability-self-pins.md
+++ b/.changeset/strip-capability-self-pins.md
@@ -1,0 +1,8 @@
+---
+"agent-bundle": minor
+---
+
+Remove `capabilityRevision` and `capabilitySha256` from manifest targets,
+`CapabilityEvidence`, and `TargetAdapterMetadata`, and rename
+`TargetHookContract.capabilityRevision` to `hostContractRevision`. Hash pins
+remain for vendored external schemas, including the Agent Skills schema.

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -353,6 +353,18 @@ Skill Markdown are inert in the workbench renderer.
 
 Top-level `scripts` is a record of stable output names to an entry path or `{ entry, targets? }`. JavaScript/TypeScript entries bundle to `scripts/<name>.mjs`; `.sh`, `.bash`, and `.py` entries copy byte-for-byte while preserving source modes. The generated `agent-bundle.manifest.json` records file digests for stable artifact validation.
 
+### What gets hashed
+
+Hash pins cover vendored external content whose ground truth lives outside this repository and can
+drift: host document schemas under `src/adapters/schemas/*` (with upstream URL, commit, and SHA-256
+recorded in `PROVENANCE.json`), the Agent Skills specification-derived schema pin in the manifest
+`agentSkills` block, and emitted artifact files and source inputs for integrity.
+
+Repository-owned capability tables and evidence are not hashed. Capability evidence records the
+observed host version (`observedVersion`) and target, while adapters carry a monotonic
+`adapterRevision`. Git already versions repository-owned content; hashing it again inside the
+repository is self-referential and causes churn on every table edit.
+
 `AgentBundleConfig` merges bundled portable, Codex, and Claude declarations
 through `AgentBundleConfigExtensions`. `TargetRegistry` owns the unique
 extension descriptor and adapter for each target. Ordinary projects need no

--- a/packages/agent-bundle/src/adapters/capability-state.ts
+++ b/packages/agent-bundle/src/adapters/capability-state.ts
@@ -1,4 +1,4 @@
-import { sha256Hex, stableJson } from '../core/digest.ts';
+import { stableJson } from '../core/digest.ts';
 import { CapabilityStateError, unknownCapabilityStateError } from '../core/capabilities.ts';
 import type { CapabilityEvidence, CapabilityState } from '../core/capabilities.ts';
 import type { TargetAdapterMetadata } from './types.ts';
@@ -8,8 +8,6 @@ export const capabilityEvidence = (
   target: string,
   metadata: TargetAdapterMetadata,
 ): CapabilityEvidence => Object.freeze({
-  capabilityRevision: metadata.capabilityRevision,
-  capabilitySha256: metadata.capabilitySha256,
   observedVersion: metadata.observedVersion,
   target,
 });
@@ -161,8 +159,6 @@ export const mergeCapabilityEvidence = (
     return targetOrder === 0 ? stableJson(first).localeCompare(stableJson(second)) : targetOrder;
   });
   return Object.freeze({
-    capabilityRevision: evidence.map((entry) => `${entry.target}@${entry.capabilityRevision}`).join('+'),
-    capabilitySha256: sha256Hex(stableJson(evidence)),
     observedVersion: evidence.map((entry) => `${entry.target}@${entry.observedVersion}`).join('+'),
     target: evidence.map((entry) => entry.target).join('+'),
   });

--- a/packages/agent-bundle/src/adapters/claude.ts
+++ b/packages/agent-bundle/src/adapters/claude.ts
@@ -126,7 +126,7 @@ const validateLsp = validator.compile(lspSchema);
 /** The pinned Claude hooks validator, shared with the unified bundle adapter. */
 export const claudeHooksValidator = validateHooks;
 const hookContract = Object.freeze({
-  capabilityRevision: capabilityTable.observedCliVersion,
+  hostContractRevision: capabilityTable.observedCliVersion,
   commandRoot: '${CLAUDE_PLUGIN_ROOT}',
   encodePlaygroundInput: encodeNativeHookPlaygroundInput,
   encodePlaygroundOutput: (result, event, nativeEvent) =>
@@ -141,8 +141,6 @@ const hookContract = Object.freeze({
 } satisfies TargetHookContract);
 const metadata = Object.freeze({
   adapterRevision: '1.5.0',
-  capabilityRevision: capabilityTable.observedCliVersion,
-  capabilitySha256: 'd78b76bda7020f7ea64d332c50d73f7ba3213ef69731835d474383ea6ef46612',
   observedVersion: capabilityTable.observedCliVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.observedCliVersion),
 });

--- a/packages/agent-bundle/src/adapters/codex.ts
+++ b/packages/agent-bundle/src/adapters/codex.ts
@@ -108,7 +108,7 @@ export const codexPluginDocumentValidator = (mcpRelativePath: string): TargetArt
   validateJsonSchemaDocument(pluginValidatorFor(mcpRelativePath));
 const validateHooks = validator.compile(hooksSchema);
 const hookContract = Object.freeze({
-  capabilityRevision: capabilityTable.observedCliVersion,
+  hostContractRevision: capabilityTable.observedCliVersion,
   commandRoot: '${PLUGIN_ROOT}',
   encodePlaygroundInput: encodeNativeHookPlaygroundInput,
   encodePlaygroundOutput: (result, event, nativeEvent) =>
@@ -123,8 +123,6 @@ const hookContract = Object.freeze({
 } satisfies TargetHookContract);
 const metadata = Object.freeze({
   adapterRevision: '1.2.0',
-  capabilityRevision: capabilityTable.observedCliVersion,
-  capabilitySha256: 'bb0a685d680ffd95c468acfcf2fc20dc8fec672ea718f3dd1934fccad3b726c5',
   observedVersion: capabilityTable.observedCliVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.observedCliVersion),
 });

--- a/packages/agent-bundle/src/adapters/cursor.ts
+++ b/packages/agent-bundle/src/adapters/cursor.ts
@@ -136,7 +136,7 @@ export interface CursorHookContractOptions {
  * Claude/Codex format; see cursorHookWrapperSource).
  */
 export const createCursorHookContract = (options: CursorHookContractOptions): TargetHookContract => Object.freeze({
-  capabilityRevision: capabilityTable.observedCliVersion,
+  hostContractRevision: capabilityTable.observedCliVersion,
   commandRoot: '${CURSOR_PLUGIN_ROOT}',
   documentEntry: cursorHookDocumentEntry,
   documentEnvelope: cursorHookDocumentEnvelope,
@@ -266,8 +266,6 @@ export const cursorManifest = (
 
 const metadata = Object.freeze({
   adapterRevision: '1.5.0',
-  capabilityRevision: capabilityTable.observedCliVersion,
-  capabilitySha256: 'fd5a8171963f9b1bd05876cc333ba808bdcffb73b49b133bcf681b3a0fd57941',
   observedVersion: capabilityTable.observedCliVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.observedCliVersion),
 });

--- a/packages/agent-bundle/src/adapters/hook-contract.ts
+++ b/packages/agent-bundle/src/adapters/hook-contract.ts
@@ -45,7 +45,7 @@ export interface TargetHookDocumentEntryInput {
 }
 
 export interface TargetHookContract {
-  readonly capabilityRevision?: string;
+  readonly hostContractRevision?: string;
   readonly commandRoot: string;
   /**
    * Shapes one generated hook command into the host's per-event array entry.
@@ -318,7 +318,7 @@ export const eventArtifactEpochToken = '__AGENT_BUNDLE_EVENT_ARTIFACT_EPOCH__';
 
 const eventRouteHookWrapperSource = (
   entry: TargetHookWrapper,
-  capabilityRevision: string,
+  hostContractRevision: string,
 ): string => {
   const route = entry.hook.eventRoute!;
   const standalone = route.runtime === 'standalone' || route.fallback === 'standalone';
@@ -342,7 +342,7 @@ const eventRouteHookWrapperSource = (
     '',
     `const artifactEpoch = ${JSON.stringify(eventArtifactEpochToken)};`,
     `const canonicalEvent = ${JSON.stringify(route.event)};`,
-    `const capabilityRevision = ${JSON.stringify(capabilityRevision)};`,
+    `const capabilityRevision = ${JSON.stringify(hostContractRevision)};`,
     `const nativeEvent = ${JSON.stringify(entry.nativeEvent)};`,
     `const artifactTarget = ${JSON.stringify(entry.target)};`,
     ...targetSource,
@@ -779,7 +779,7 @@ export const planHooks = (
       ...wrapper,
       virtualSource: hook.eventRoute === undefined
         ? contract.wrapperSource(wrapper)
-        : eventRouteHookWrapperSource(wrapper, contract.capabilityRevision ?? target),
+        : eventRouteHookWrapperSource(wrapper, contract.hostContractRevision ?? target),
     });
   }
 

--- a/packages/agent-bundle/src/adapters/plugin.ts
+++ b/packages/agent-bundle/src/adapters/plugin.ts
@@ -1,6 +1,6 @@
 import { createTargetDiagnostics } from './diagnostics.ts';
 import type { Diagnostic } from '../core/diagnostics.ts';
-import { sha256Hex, stableJson } from '../core/digest.ts';
+import { stableJson } from '../core/digest.ts';
 import type { NormalizedHook, NormalizedPlugin } from '../core/types.ts';
 import {
   allMcpPathTokenFields,
@@ -116,7 +116,7 @@ for (const key of new Set([...Object.keys(claudeMatchers), ...Object.keys(codexM
 }
 
 const bundleHookContract: TargetHookContract = Object.freeze({
-  capabilityRevision: `${claudeCapabilityTable.observedCliVersion}+${codexCapabilityTable.observedCliVersion}`,
+  hostContractRevision: `${claudeCapabilityTable.observedCliVersion}+${codexCapabilityTable.observedCliVersion}`,
   // ${CLAUDE_PLUGIN_ROOT} reaches both hosts: Claude substitutes its own
   // token and Codex exports the variable as a documented compatibility alias
   // into a real shell.
@@ -183,15 +183,6 @@ const artifactValidation = deepFreeze({
 
 const metadata = Object.freeze({
   adapterRevision: '1.4.0',
-  capabilityRevision: `claude ${claudeAdapter.metadata.observedVersion} + codex ${codexAdapter.metadata.observedVersion} + cursor ${cursorAdapter.metadata.observedVersion}`,
-  // The composite fingerprint covers every host pin the bundle's capability
-  // claims depend on, so a single-host capability-table correction at the
-  // same observed version still changes this manifest identity.
-  capabilitySha256: sha256Hex(stableJson([
-    { capabilitySha256: claudeAdapter.metadata.capabilitySha256, target: 'claude' },
-    { capabilitySha256: codexAdapter.metadata.capabilitySha256, target: 'codex' },
-    { capabilitySha256: cursorAdapter.metadata.capabilitySha256, target: 'cursor' },
-  ])),
   observedVersion: `${claudeAdapter.metadata.observedVersion}+${codexAdapter.metadata.observedVersion}+${cursorAdapter.metadata.observedVersion}`,
   // Metadata schemas must exactly match the validation contract: each host's
   // documents, with one shared Claude-format hook schema (the pinned Codex

--- a/packages/agent-bundle/src/adapters/portable.ts
+++ b/packages/agent-bundle/src/adapters/portable.ts
@@ -59,8 +59,6 @@ const validatePlugin = schemaValidator.compile(pluginSchema);
 const validateMcp = schemaValidator.compile(mcpSchema);
 const metadata = Object.freeze({
   adapterRevision: '1.2.0',
-  capabilityRevision: capabilityTable.observedSpecificationVersion,
-  capabilitySha256: '60f63a2cf3c6783a178173c5006234a89ae186fe3542fe61339542cac117389e',
   observedVersion: capabilityTable.observedSpecificationVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.version),
 });

--- a/packages/agent-bundle/src/adapters/registry.ts
+++ b/packages/agent-bundle/src/adapters/registry.ts
@@ -102,8 +102,6 @@ const snapshotMetadata = (metadata: unknown): TargetAdapterMetadata => {
 
   return Object.freeze({
     adapterRevision: requireNonempty(candidate.adapterRevision, 'adapter revision'),
-    capabilityRevision: requireNonempty(candidate.capabilityRevision, 'capability revision'),
-    capabilitySha256: requireSha256(candidate.capabilitySha256, 'capability hash'),
     observedVersion: requireNonempty(candidate.observedVersion, 'observed version'),
     schemas: Object.freeze(schemas),
   });

--- a/packages/agent-bundle/src/adapters/types.ts
+++ b/packages/agent-bundle/src/adapters/types.ts
@@ -361,8 +361,6 @@ export const standardPluginArtifactPlan = (input: StandardPluginArtifactsInput):
 
 export interface TargetAdapterMetadata {
   readonly adapterRevision: string;
-  readonly capabilityRevision: string;
-  readonly capabilitySha256: string;
   readonly observedVersion: string;
   readonly schemas: readonly TargetSchemaDescriptor[];
 }

--- a/packages/agent-bundle/src/build/build.ts
+++ b/packages/agent-bundle/src/build/build.ts
@@ -282,8 +282,6 @@ const manifestTargets = (
     const metadata = registry.metadata(name);
     return Object.freeze({
       adapterRevision: metadata.adapterRevision,
-      capabilityRevision: metadata.capabilityRevision,
-      capabilitySha256: metadata.capabilitySha256,
       name,
       observedVersion: metadata.observedVersion,
       schemas: Object.freeze(metadata.schemas

--- a/packages/agent-bundle/src/build/manifest.ts
+++ b/packages/agent-bundle/src/build/manifest.ts
@@ -60,8 +60,6 @@ export interface ArtifactManifestTargetSchema {
 
 export interface ArtifactManifestTarget {
   readonly adapterRevision: string;
-  readonly capabilityRevision: string;
-  readonly capabilitySha256: string;
   readonly name: string;
   readonly observedVersion: string;
   readonly schemas: readonly ArtifactManifestTargetSchema[];
@@ -244,16 +242,12 @@ const parseTargets = (value: unknown): readonly ArtifactManifestTarget[] => {
     const target = requireRecord(candidate, `targets[${index}]`);
     requireExactKeys(target, `targets[${index}]`, [
       'adapterRevision',
-      'capabilityRevision',
-      'capabilitySha256',
       'name',
       'observedVersion',
       'schemas',
     ]);
     return {
       adapterRevision: requireString(target.adapterRevision, `targets[${index}].adapterRevision`),
-      capabilityRevision: requireString(target.capabilityRevision, `targets[${index}].capabilityRevision`),
-      capabilitySha256: requireHash(target.capabilitySha256, `targets[${index}].capabilitySha256`),
       name: requireString(target.name, `targets[${index}].name`),
       observedVersion: requireString(target.observedVersion, `targets[${index}].observedVersion`),
       schemas: parseTargetSchemas(target.schemas, `targets[${index}].schemas`),

--- a/packages/agent-bundle/src/build/validate-artifact.ts
+++ b/packages/agent-bundle/src/build/validate-artifact.ts
@@ -274,8 +274,6 @@ const matchesTargetMetadata = (
   target: ArtifactManifest['targets'][number],
   metadata: ReturnType<TargetRegistry['metadata']>,
 ): boolean => target.adapterRevision === metadata.adapterRevision &&
-  target.capabilityRevision === metadata.capabilityRevision &&
-  target.capabilitySha256 === metadata.capabilitySha256 &&
   target.observedVersion === metadata.observedVersion &&
   sameSchemas(target.schemas, metadata.schemas);
 

--- a/packages/agent-bundle/src/core/capabilities.ts
+++ b/packages/agent-bundle/src/core/capabilities.ts
@@ -2,8 +2,6 @@ import { CodedError } from './errors.ts';
 
 /** Evidence backing a supported or degraded capability judgment. */
 export interface CapabilityEvidence {
-  readonly capabilityRevision: string;
-  readonly capabilitySha256: string;
   readonly observedVersion: string;
   readonly target: string;
 }
@@ -39,9 +37,7 @@ const isCapabilityStateName = (value: unknown): value is CapabilityState['state'
 const isCapabilityEvidence = (value: unknown): value is CapabilityEvidence => {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as Partial<Record<keyof CapabilityEvidence, unknown>>;
-  return typeof candidate.capabilityRevision === 'string' &&
-    typeof candidate.capabilitySha256 === 'string' &&
-    typeof candidate.observedVersion === 'string' &&
+  return typeof candidate.observedVersion === 'string' &&
     typeof candidate.target === 'string';
 };
 

--- a/packages/agent-bundle/tests/adapter-capability-states.test.ts
+++ b/packages/agent-bundle/tests/adapter-capability-states.test.ts
@@ -14,8 +14,6 @@ import { CapabilityStateError, isCapabilityState } from '../src/core/capabilitie
 import type { CapabilityEvidence, CapabilityState } from '../src/core/capabilities.ts';
 
 const evidence = (target: string): CapabilityEvidence => Object.freeze({
-  capabilityRevision: `${target}-capability-revision`,
-  capabilitySha256: target.repeat(64).slice(0, 64),
   observedVersion: `${target}-version`,
   target,
 });
@@ -120,11 +118,9 @@ it('intersects supported composite capabilities and merges both evidence records
   expect(intersection.state).toBe('supported');
   if (intersection.state !== 'supported') throw new Error('Expected a supported capability intersection.');
   expect(intersection.evidence).toMatchObject({
-    capabilityRevision: 'claude@claude-capability-revision+codex@codex-capability-revision',
     observedVersion: 'claude@claude-version+codex@codex-version',
     target: 'claude+codex',
   });
-  expect(intersection.evidence.capabilitySha256).toMatch(/^[0-9a-f]{64}$/);
 });
 
 it('applies prohibited, unavailable, degraded, and supported intersection precedence', () => {
@@ -265,8 +261,6 @@ it('surfaces built-in adapter metadata as immutable capability evidence', () => 
   });
   if (cursor.capabilities.mcp?.state !== 'supported') throw new Error('Expected Cursor MCP support evidence.');
   expect(cursor.capabilities.mcp.evidence).toEqual({
-    capabilityRevision: '2026-08-28',
-    capabilitySha256: 'fd5a8171963f9b1bd05876cc333ba808bdcffb73b49b133bcf681b3a0fd57941',
     observedVersion: '2026-08-28',
     target: 'cursor',
   });

--- a/packages/agent-bundle/tests/adapter-contract.test.ts
+++ b/packages/agent-bundle/tests/adapter-contract.test.ts
@@ -14,8 +14,6 @@ import { validateModel } from '../src/config/validate.ts';
 
 const metadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/adapter-metadata.test.ts
+++ b/packages/agent-bundle/tests/adapter-metadata.test.ts
@@ -7,8 +7,6 @@ import { sha256Hex } from '../src/core/digest.ts';
 
 const validMetadata = () => ({
   adapterRevision: '1.0.0',
-  capabilityRevision: '1.0.0',
-  capabilitySha256: 'a'.repeat(64),
   observedVersion: '1.0.0',
   schemas: [
     { name: 'mcp', revision: '1.0.0', sha256: 'b'.repeat(64) },
@@ -40,8 +38,6 @@ const registryMetadata = (registry: TargetRegistry, name: string) =>
   (registry as unknown as {
     metadata(target: string): {
       readonly adapterRevision: string;
-      readonly capabilityRevision: string;
-      readonly capabilitySha256: string;
       readonly observedVersion: string;
       readonly schemas: readonly {
         readonly name: string;
@@ -56,8 +52,6 @@ it('records exact immutable metadata for every built-in target', () => {
 
   expect(registryMetadata(registry, 'portable')).toEqual({
     adapterRevision: '1.2.0',
-    capabilityRevision: '1.0.0',
-    capabilitySha256: '60f63a2cf3c6783a178173c5006234a89ae186fe3542fe61339542cac117389e',
     observedVersion: '1.0.0',
     schemas: [
       {
@@ -74,8 +68,6 @@ it('records exact immutable metadata for every built-in target', () => {
   });
   expect(registryMetadata(registry, 'codex')).toEqual({
     adapterRevision: '1.2.0',
-    capabilityRevision: '0.147.0',
-    capabilitySha256: 'bb0a685d680ffd95c468acfcf2fc20dc8fec672ea718f3dd1934fccad3b726c5',
     observedVersion: '0.147.0',
     schemas: [
       {
@@ -102,8 +94,6 @@ it('records exact immutable metadata for every built-in target', () => {
   });
   expect(registryMetadata(registry, 'claude')).toEqual({
     adapterRevision: '1.5.0',
-    capabilityRevision: '2.1.250',
-    capabilitySha256: 'd78b76bda7020f7ea64d332c50d73f7ba3213ef69731835d474383ea6ef46612',
     observedVersion: '2.1.250',
     schemas: [
       {
@@ -135,8 +125,6 @@ it('records exact immutable metadata for every built-in target', () => {
   });
   expect(registryMetadata(registry, 'cursor')).toEqual({
     adapterRevision: '1.5.0',
-    capabilityRevision: '2026-08-28',
-    capabilitySha256: 'fd5a8171963f9b1bd05876cc333ba808bdcffb73b49b133bcf681b3a0fd57941',
     observedVersion: '2026-08-28',
     schemas: [
       {
@@ -163,7 +151,7 @@ it('records exact immutable metadata for every built-in target', () => {
   });
 });
 
-it('rehashes every declared capability and schema snapshot against its pinned provenance', async () => {
+it('records observed capability versions and rehashes schema snapshots against pinned provenance', async () => {
   const registry = createDefaultRegistry();
   const targets = [
     { capabilityFile: 'portable-1.0.0.json', provenanceFile: 'portable/PROVENANCE.json', target: 'portable', versionKey: 'version' },
@@ -185,7 +173,6 @@ it('rehashes every declared capability and schema snapshot against its pinned pr
       readonly [key: string]: unknown;
     };
 
-    expect(metadata.capabilitySha256).toBe(sha256Hex(capability));
     expect(metadata.observedVersion).toBe(capabilityTable.observedCliVersion ?? capabilityTable.observedSpecificationVersion);
     expect(metadata.observedVersion).toBe(provenance[versionKey]);
     expect(metadata.schemas.map((schema) => schema.name)).toEqual(
@@ -306,9 +293,7 @@ it('snapshots canonical immutable artifact output suffixes and rejects malformed
 it('rejects malformed metadata atomically and preserves existing collision behavior', () => {
   const malformed = [
     { ...validMetadata(), adapterRevision: '' },
-    { ...validMetadata(), capabilityRevision: '  ' },
     { ...validMetadata(), observedVersion: '' },
-    { ...validMetadata(), capabilitySha256: 'A'.repeat(64) },
     { ...validMetadata(), schemas: [{ ...validMetadata().schemas[0]!, sha256: 'not-a-hash' }] },
     { ...validMetadata(), schemas: [{ ...validMetadata().schemas[0]!, name: '' }] },
     { ...validMetadata(), schemas: [{ ...validMetadata().schemas[0]!, revision: '' }] },

--- a/packages/agent-bundle/tests/api.test.ts
+++ b/packages/agent-bundle/tests/api.test.ts
@@ -52,8 +52,6 @@ const createProject = async (): Promise<string> => {
 
 const syntheticMetadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/artifact-inspection-service.test.ts
+++ b/packages/agent-bundle/tests/artifact-inspection-service.test.ts
@@ -35,8 +35,6 @@ const fixtureInputs = Object.freeze([
 
 const fixtureMetadata: TargetAdapterMetadata = Object.freeze({
   adapterRevision: 'synthetic-adapter-v1',
-  capabilityRevision: 'synthetic-capabilities-v1',
-  capabilitySha256: 'c'.repeat(64),
   observedVersion: 'synthetic-observed-v1',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/artifact-validator.test.ts
+++ b/packages/agent-bundle/tests/artifact-validator.test.ts
@@ -106,8 +106,6 @@ const writeArtifact = async (
 const customTarget = 'custom';
 const customMetadata = Object.freeze({
   adapterRevision: 'custom-adapter-v1',
-  capabilityRevision: 'custom-capabilities-v1',
-  capabilitySha256: 'a'.repeat(64),
   observedVersion: 'custom-observed-v1',
   schemas: Object.freeze([Object.freeze({
     name: 'document',
@@ -124,8 +122,6 @@ const customManifestTarget = Object.freeze({
 const coherenceTarget = 'coherent';
 const coherenceMetadata = Object.freeze({
   adapterRevision: 'coherence-adapter-v1',
-  capabilityRevision: 'coherence-capabilities-v1',
-  capabilitySha256: 'c'.repeat(64),
   observedVersion: 'coherence-observed-v1',
   schemas: Object.freeze([]),
 });
@@ -148,8 +144,6 @@ const coherenceRegistry = (): TargetRegistry => new TargetRegistry().register({
 const hookCoherenceTarget = 'hooked';
 const hookCoherenceMetadata = Object.freeze({
   adapterRevision: 'hook-coherence-adapter-v1',
-  capabilityRevision: 'hook-coherence-capabilities-v1',
-  capabilitySha256: 'd'.repeat(64),
   observedVersion: 'hook-coherence-observed-v1',
   schemas: Object.freeze([]),
 });
@@ -975,8 +969,6 @@ it('does not attribute compiler MCP outputs to an equal-length sibling target', 
   const siblingTarget = 'neighbor';
   const siblingMetadata = Object.freeze({
     adapterRevision: 'neighbor-adapter-v1',
-    capabilityRevision: 'neighbor-capabilities-v1',
-    capabilitySha256: 'e'.repeat(64),
     observedVersion: 'neighbor-observed-v1',
     schemas: Object.freeze([]),
   });
@@ -1656,8 +1648,6 @@ it('requires manifest target metadata to match the supplied registry exactly', a
 
     for (const target of [
       { ...customManifestTarget, adapterRevision: 'different-adapter' },
-      { ...customManifestTarget, capabilityRevision: 'different-capabilities' },
-      { ...customManifestTarget, capabilitySha256: 'c'.repeat(64) },
       { ...customManifestTarget, observedVersion: 'different-observed-version' },
       { ...customManifestTarget, schemas: [{ ...customMetadata.schemas[0]!, sha256: 'c'.repeat(64) }] },
       {

--- a/packages/agent-bundle/tests/build.test.ts
+++ b/packages/agent-bundle/tests/build.test.ts
@@ -37,8 +37,6 @@ interface FileDigest {
 
 const testAdapterMetadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -229,8 +229,6 @@ it('keeps lookalike proxy failures and control-character extension keys redacted
     configExtension: Object.freeze({ key: longKey }),
     metadata: Object.freeze({
       adapterRevision: 'test',
-      capabilityRevision: 'test',
-      capabilitySha256: '0'.repeat(64),
       observedVersion: 'test',
       schemas: Object.freeze([]),
     }),

--- a/packages/agent-bundle/tests/dev-workbench.test.ts
+++ b/packages/agent-bundle/tests/dev-workbench.test.ts
@@ -256,8 +256,6 @@ const workbenchSyntheticAdapter: TargetAdapter = Object.freeze({
   configExtension: Object.freeze({ key: 'workbenchSynthetic' }),
   metadata: Object.freeze({
     adapterRevision: 'test',
-    capabilityRevision: 'test',
-    capabilitySha256: '0'.repeat(64),
     observedVersion: 'test',
     schemas: Object.freeze([]),
   }),

--- a/packages/agent-bundle/tests/hook-playground-service.test.ts
+++ b/packages/agent-bundle/tests/hook-playground-service.test.ts
@@ -271,8 +271,6 @@ it('uses the injected adapter hook contract for custom manifests, mappings, matc
     hookContract: contract,
     metadata: {
       adapterRevision: 'test',
-      capabilityRevision: 'test',
-      capabilitySha256: '0'.repeat(64),
       observedVersion: 'test',
       schemas: [],
     },

--- a/packages/agent-bundle/tests/manifest.test.ts
+++ b/packages/agent-bundle/tests/manifest.test.ts
@@ -56,8 +56,6 @@ const validManifest = (): ArtifactManifest => ({
   targets: [
     {
       adapterRevision: 'codex-adapter-v1',
-      capabilityRevision: 'codex-cli-0.147.0',
-      capabilitySha256: hash('f'),
       name: 'codex',
       observedVersion: '0.147.0',
       schemas: [

--- a/packages/agent-bundle/tests/mcp.test.ts
+++ b/packages/agent-bundle/tests/mcp.test.ts
@@ -34,8 +34,6 @@ const registry: NormalizationTargetRegistry = {
 
 const testAdapterMetadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/portable-adapter.test.ts
+++ b/packages/agent-bundle/tests/portable-adapter.test.ts
@@ -56,8 +56,6 @@ const plugin = (): NormalizedPlugin => ({
 
 const testAdapterMetadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/packages/agent-bundle/tests/public-api.test.ts
+++ b/packages/agent-bundle/tests/public-api.test.ts
@@ -122,8 +122,6 @@ it('exposes advanced adapter registry and contract types only from the advanced 
     mcpRuntime,
     metadata: {
       adapterRevision: 'test',
-      capabilityRevision: 'test',
-      capabilitySha256: '0'.repeat(64),
       observedVersion: 'test',
       schemas: [],
     },
@@ -198,6 +196,11 @@ it('keeps bundled config extension types in emitted root declarations', async ()
     await symlink(
       join(agentBundleNodeModules, '@modelcontextprotocol'),
       join(consumerRoot, 'node_modules', '@modelcontextprotocol'),
+      'dir',
+    );
+    await symlink(
+      join(agentBundleNodeModules, '@agent-bundle'),
+      join(consumerRoot, 'node_modules', '@agent-bundle'),
       'dir',
     );
     await symlink(

--- a/packages/agent-bundle/tests/support/adapter-capabilities.ts
+++ b/packages/agent-bundle/tests/support/adapter-capabilities.ts
@@ -2,8 +2,6 @@ import { supportedCapability } from '../../src/adapters/capability-state.ts';
 import type { CapabilityEvidence, CapabilityState } from '../../src/core/capabilities.ts';
 
 const evidence: CapabilityEvidence = Object.freeze({
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   target: 'test',
 });

--- a/packages/agent-bundle/tests/support/manifest.ts
+++ b/packages/agent-bundle/tests/support/manifest.ts
@@ -22,8 +22,6 @@ export const writeFixtureManifest = async (options: {
       const metadata = registry.metadata(name);
       return {
         adapterRevision: metadata.adapterRevision,
-        capabilityRevision: metadata.capabilityRevision,
-        capabilitySha256: metadata.capabilitySha256,
         name,
         observedVersion: metadata.observedVersion,
         schemas: [...metadata.schemas].sort((left, right) => left.name.localeCompare(right.name)),

--- a/packages/agent-bundle/tests/target-hook-contract.test.ts
+++ b/packages/agent-bundle/tests/target-hook-contract.test.ts
@@ -20,8 +20,6 @@ import { build } from './support/build.ts';
 
 const metadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });
@@ -279,7 +277,7 @@ it('rejects missing and blank native event mappings before creating hook entries
 
 it('plans a thin epoch-bound event-route client and keeps standalone execution explicit', () => {
   const contract: TargetHookContract = {
-    capabilityRevision: 'synthetic-1',
+    hostContractRevision: 'synthetic-1',
     commandRoot: '${SYNTHETIC_PLUGIN_ROOT}',
     ...playgroundCodec,
     eventNames: {},

--- a/packages/agent-bundle/tests/target-mcp-runtime.test.ts
+++ b/packages/agent-bundle/tests/target-mcp-runtime.test.ts
@@ -24,8 +24,6 @@ import { build } from './support/build.ts';
 
 const metadata = Object.freeze({
   adapterRevision: 'test',
-  capabilityRevision: 'test',
-  capabilitySha256: '0'.repeat(64),
   observedVersion: 'test',
   schemas: Object.freeze([]),
 });

--- a/scripts/classify-docs-only.d.mts
+++ b/scripts/classify-docs-only.d.mts
@@ -1,0 +1,32 @@
+interface GhFileListingEntry {
+  filename: string;
+  previousFilename: string;
+}
+
+type DocsOnlyClassification =
+  | { docsOnly: false; reason: 'listing-error' | 'invalid-count' | 'empty-listing' | 'truncated-listing' }
+  | { docsOnly: false; path: string; reason: 'non-docs-path' }
+  | { docsOnly: true; reason: 'docs-only' };
+
+interface ClassifyDocsOnlyOptions {
+  changedFilesCount: unknown;
+  entries: readonly GhFileListingEntry[];
+  listingOk: boolean;
+}
+
+interface RunClassifyOptions {
+  argv?: readonly string[];
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+export declare const isDocsOnlyPath: (filePath: string) => boolean;
+
+export declare const parseGhFilesListing: (text: string) => GhFileListingEntry[];
+
+export declare const classifyDocsOnlyListing: (
+  options: ClassifyDocsOnlyOptions,
+) => DocsOnlyClassification;
+
+export declare const runClassify: (
+  options?: RunClassifyOptions,
+) => Promise<DocsOnlyClassification>;


### PR DESCRIPTION
## Summary

Arc-end cleanup per the standing decision recorded mid-arc (#107): remove self-pinning metadata that hashes/pins repo-owned content, keeping hash verification only for vendored external content.

- **Removed** `capabilityRevision` and `capabilitySha256` from `TargetAdapterMetadata`, `CapabilityEvidence`, manifest targets, registry validation, and `matchesTargetMetadata` (AB6010). The four hardcoded per-adapter table hashes and the recomputed merge-evidence sha are gone — capability-table edits no longer churn shas or spuriously invalidate byte-identical emitted artifacts.
- **#221 composite fingerprint decision**: the plugin bundle's composite `capabilitySha256` hashed the three hosts' capability-table hashes — repo-owned pins, and its stated purpose (manifest identity changes on any table correction "at the same observed version") is exactly the churn being removed. The real consumer contract survives via the existing monotonic `adapterRevision` (1.4.0) + composite `observedVersion` + vendored schema pins, so it was simplified per the mandate rather than kept.
- **Kept**: `observedVersion` (dated external observation of host CLI/spec), `adapterRevision`, the vendored-schema `schemas` pins (name/revision/sha256 backed by PROVENANCE.json upstream URLs/commits, incl. the cursor/plugins marketplace schema from #221), the `agentSkills` spec-derived schema pin, dated doc citations in capability reasons, and manifest file/source-input integrity hashes.
- `TargetHookContract.capabilityRevision` renamed to `hostContractRevision` (same value — the observed host version); generated wrapper source is byte-identical.
- Convention documented in the package README ("What gets hashed"); minor changeset (manifest target shape changes).
- Separate fix-forward commit: #259 landed a test importing `scripts/classify-docs-only.mjs` without a declaration, breaking `pnpm typecheck` on main; added a typed `.d.mts`.

## Test plan

- [x] `pnpm typecheck` — pass (incl. workbench + create-agent-bundle projects)
- [x] `pnpm lint` — 913 files, 0 errors/warnings
- [x] `pnpm test:unit` — all pass
- [x] Fresh `pnpm build` + scoped integration pool over all 9 affected integration tests (api, artifact-validator, build, dev-workbench, hook-playground-service, mcp, public-api, target-hook-contract, target-mcp-runtime) — 236 tests, no failures
- [x] `pnpm test:route-unit`, `pnpm test:projection` — all pass
- [x] `rg capabilitySha256` across src/tests/workbench/examples — zero matches; only deliberate generated-wrapper literals retain the `capabilityRevision` const name (emitted bytes unchanged)