### PR TITLE
fix(types): add declarations for classify-docs-only.mjs so root typecheck passes

### DIFF
--- a/scripts/classify-docs-only.d.mts
+++ b/scripts/classify-docs-only.d.mts
@@ -1,0 +1,35 @@
+/** Declarations for the docs-only classifier so test imports typecheck. */
+
+export interface GhFilesListingEntry {
+  readonly filename: string;
+  readonly previousFilename: string;
+}
+
+export type DocsOnlyReason =
+  | 'docs-only'
+  | 'empty-listing'
+  | 'invalid-count'
+  | 'listing-error'
+  | 'non-docs-path'
+  | 'truncated-listing';
+
+export interface DocsOnlyClassification {
+  readonly docsOnly: boolean;
+  readonly path?: string;
+  readonly reason: DocsOnlyReason;
+}
+
+export declare const isDocsOnlyPath: (filePath: string) => boolean;
+
+export declare const parseGhFilesListing: (text: string) => GhFilesListingEntry[];
+
+export declare const classifyDocsOnlyListing: (options: {
+  readonly changedFilesCount: string | undefined;
+  readonly entries: readonly GhFilesListingEntry[];
+  readonly listingOk: boolean;
+}) => DocsOnlyClassification;
+
+export declare const runClassify: (options?: {
+  readonly argv?: readonly string[];
+  readonly env?: Record<string, string | undefined>;
+}) => Promise<DocsOnlyClassification>;


### PR DESCRIPTION
## Summary
- `packages/agent-bundle/tests/classify-docs-only.test.ts` (added in #259) imports the untyped `scripts/classify-docs-only.mjs`, so root `tsc --noEmit` fails with TS7016 under `noImplicitAny` — `pnpm typecheck` is currently red on `main`.
- Adds a `scripts/classify-docs-only.d.mts` declaration sibling typing the classifier's exported surface (`isDocsOnlyPath`, `parseGhFilesListing`, `classifyDocsOnlyListing`, `runClassify`).

## Test plan
- [x] `pnpm build` green
- [x] `pnpm typecheck` green (was failing with TS7016 before this change)
- [x] `pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/classify-docs-only.test.ts` green
- [x] `pnpm lint` green

No changeset: repository scripts/test infrastructure, not a published package change.