### PR TITLE
feat(workbench): route editor state on effect-atom (#105 phase 2)

### DIFF
--- a/.changeset/workbench-atom-phase2.md
+++ b/.changeset/workbench-atom-phase2.md
@@ -1,0 +1,7 @@
+---
+"agent-bundle": patch
+---
+
+The Workbench route input editor migrated its coordinated local state to
+`@effect/atom-react` atoms keyed by manifest digest and compiled route id,
+preserving typed and raw validation behavior while releasing state on unmount.

--- a/docs/effect-conventions.md
+++ b/docs/effect-conventions.md
@@ -182,7 +182,8 @@ static assets.
 
 Exact-pin `effect` + `@effect/atom-react` (synchronized with the repo's effect
 pin, currently `4.0.0-rc.112`) are allowed there, but only in dedicated
-browser-state modules (the first is `src/runtime/agent-document-atoms.ts`).
+browser-state modules (`src/runtime/agent-document-atoms.ts` and
+`src/routes/route-editor-atoms.ts`).
 Atoms live in `effect/unstable/reactivity`; React bindings come from
 `@effect/atom-react`.
 
@@ -227,7 +228,7 @@ The #99 notice ledger also adopts none: it needs only stable `Effect` and
 
 | Module | Adopted in | Re-verify |
 | --- | --- | --- |
-| `effect/unstable/reactivity` (+ `@effect/atom-react` bindings) | Workbench Agent Document panel (#105 phase 1) | re-pin bumps @effect/atom-react in lockstep; re-run disposal regression + bundle measurement; stream-backed derived atoms stay banned until the rc.112 disposal fix ships |
+| `effect/unstable/reactivity` (+ `@effect/atom-react` bindings) | Workbench Agent Document panel (#105 phase 1) and route editor (#105 phase 2) | re-pin bumps @effect/atom-react in lockstep; re-run disposal regression + bundle measurement; stream-backed derived atoms stay banned until the rc.112 disposal fix ships |
 
 ## Language service
 

--- a/packages/workbench/src/routes/route-editor-atoms.ts
+++ b/packages/workbench/src/routes/route-editor-atoms.ts
@@ -1,0 +1,13 @@
+import { Atom } from 'effect/unstable/reactivity';
+
+import type { RouteEditorState } from './routes-model.ts';
+
+/**
+ * Digest plus compiled route id isolates editor state across manifests. The
+ * undefined sentinel lets provider-less SSR derive schema defaults locally.
+ */
+export const routeEditorKey = (digest: string, routeId: string): string => `${digest}\u0000${routeId}`;
+
+export const routeEditorStateAtom = Atom.family(
+  (key: string) => Atom.make<RouteEditorState | undefined>(undefined),
+);

--- a/packages/workbench/src/routes/routes-model.ts
+++ b/packages/workbench/src/routes/routes-model.ts
@@ -96,6 +96,16 @@ export interface RawRouteInputValidation {
   readonly error?: string;
 }
 
+export interface RouteEditorState {
+  readonly attempted: boolean;
+  readonly arguments?: RouteInputArguments;
+  readonly argv?: string;
+  readonly draft: RouteInputDraft;
+  readonly errors: Readonly<Record<string, string>>;
+  readonly raw: string;
+  readonly rawError?: string;
+}
+
 export interface McpToolPrefill {
   readonly arguments: RouteInputArguments;
   readonly serverName: string;
@@ -242,6 +252,13 @@ export const createRouteInputDraft = (schema: RouteInputSchema): RouteInputDraft
     }),
   ));
 };
+
+export const initialRouteEditorState = (schema?: RouteInputSchema): RouteEditorState => Object.freeze({
+  attempted: false,
+  draft: schema === undefined ? Object.freeze({}) : createRouteInputDraft(schema),
+  errors: Object.freeze({}),
+  raw: '{}',
+});
 
 export const routeInputLabel = (key: string): string => {
   const words = key
@@ -409,6 +426,77 @@ export const cliCommandInvocation = (
     if (!appendValues(option, false)) return undefined;
   }
   return argv.join(' ');
+};
+
+const routeEditorArgv = (
+  command: RouteManifestCliCommand | undefined,
+  argumentsValue: RouteInputArguments | undefined,
+): string | undefined => argumentsValue === undefined || command === undefined
+  ? undefined
+  : cliCommandInvocation(command, argumentsValue);
+
+export const setRouteEditorDraftValue = (
+  state: RouteEditorState,
+  schema: RouteInputSchema | undefined,
+  command: RouteManifestCliCommand | undefined,
+  key: string,
+  value: RouteInputDraftValue | undefined,
+): RouteEditorState => {
+  const entries = { ...state.draft };
+  if (value === undefined) {
+    delete entries[key];
+  } else {
+    entries[key] = value;
+  }
+  const draft = Object.freeze(entries);
+  if (!state.attempted || schema === undefined) return Object.freeze({ ...state, draft });
+  const validated = validateRouteInput(schema, draft);
+  return Object.freeze({
+    ...state,
+    arguments: validated.arguments,
+    argv: routeEditorArgv(command, validated.arguments),
+    draft,
+    errors: Object.freeze({ ...validated.errors }),
+  });
+};
+
+export const setRouteEditorRaw = (
+  state: RouteEditorState,
+  raw: string,
+): RouteEditorState => {
+  if (!state.attempted) return Object.freeze({ ...state, raw });
+  const validated = validateRawRouteInput(raw);
+  return Object.freeze({
+    ...state,
+    arguments: validated.arguments,
+    raw,
+    rawError: validated.error,
+  });
+};
+
+export const validateRouteEditor = (
+  state: RouteEditorState,
+  schema: RouteInputSchema | undefined,
+  command: RouteManifestCliCommand | undefined,
+): RouteEditorState => {
+  if (schema === undefined) {
+    const validated = validateRawRouteInput(state.raw);
+    return Object.freeze({
+      ...state,
+      arguments: validated.arguments,
+      argv: routeEditorArgv(command, validated.arguments),
+      attempted: true,
+      rawError: validated.error,
+    });
+  }
+  const validated = validateRouteInput(schema, state.draft);
+  return Object.freeze({
+    ...state,
+    arguments: validated.arguments,
+    argv: routeEditorArgv(command, validated.arguments),
+    attempted: true,
+    errors: Object.freeze({ ...validated.errors }),
+  });
 };
 
 export const mcpToolPrefillFor = (

--- a/packages/workbench/src/routes/routes-page.tsx
+++ b/packages/workbench/src/routes/routes-page.tsx
@@ -1,21 +1,21 @@
-import React, { useState } from 'react';
+import { useAtom } from '@effect/atom-react';
+import React from 'react';
 
 import type { RouteInputPropertySchema } from '../../../agent-bundle/src/contracts/routes.ts';
+import { routeEditorKey, routeEditorStateAtom } from './route-editor-atoms.ts';
 import {
-  cliCommandInvocation,
   cliCommandUsage,
-  createRouteInputDraft,
+  initialRouteEditorState,
   mcpToolPrefillFor,
   routeInputLabel,
-  validateRawRouteInput,
-  validateRouteInput,
+  setRouteEditorDraftValue,
+  setRouteEditorRaw,
+  validateRouteEditor,
   type McpToolPrefill,
   type RouteCatalog,
   type RouteCatalogEntry,
   type RouteCatalogGroup,
   type RouteCatalogServer,
-  type RouteInputArguments,
-  type RouteInputDraft,
   type RouteInputDraftValue,
 } from './routes-model.ts';
 import './routes-page.css';
@@ -113,57 +113,38 @@ const scalarControl = (
   }
 };
 
-const RouteInputEditor = ({ entry, group, onOpenMcp }: {
+const RouteInputEditor = ({ digest, entry, group, onOpenMcp }: {
+  readonly digest: string;
   readonly entry: RouteCatalogEntry;
   readonly group: RouteCatalogGroup;
   readonly onOpenMcp?: (prefill: McpToolPrefill) => void;
 }) => {
   const schema = entry.inputSchema;
-  const [draft, setDraft] = useState<RouteInputDraft>(() => schema === undefined ? Object.freeze({}) : createRouteInputDraft(schema));
-  const [raw, setRaw] = useState('{}');
-  const [errors, setErrors] = useState<Readonly<Record<string, string>>>({});
-  const [rawError, setRawError] = useState<string>();
-  const [attempted, setAttempted] = useState(false);
-  const [argumentsValue, setArgumentsValue] = useState<RouteInputArguments>();
-  const [argv, setArgv] = useState<string>();
-
-  const commitValidation = (next: RouteInputDraft): void => {
-    if (schema === undefined || !attempted) return;
-    const validated = validateRouteInput(schema, next);
-    setErrors(validated.errors);
-    setArgumentsValue(validated.arguments);
-    setArgv(validated.arguments === undefined || entry.command === undefined
-      ? undefined
-      : cliCommandInvocation(entry.command, validated.arguments));
-  };
+  const [stored, setStored] = useAtom(routeEditorStateAtom(routeEditorKey(digest, entry.id)));
+  const state = stored ?? initialRouteEditorState(schema);
+  const {
+    arguments: argumentsValue,
+    argv,
+    draft,
+    errors,
+    raw,
+    rawError,
+  } = state;
   const setValue = (key: string, value: RouteInputDraftValue | undefined): void => {
-    const entries = { ...draft };
-    if (value === undefined) {
-      delete entries[key];
-    } else {
-      entries[key] = value;
-    }
-    const next = Object.freeze(entries);
-    setDraft(next);
-    commitValidation(next);
+    setStored((current) => setRouteEditorDraftValue(
+      current ?? initialRouteEditorState(schema),
+      schema,
+      entry.command,
+      key,
+      value,
+    ));
   };
   const validate = (): void => {
-    setAttempted(true);
-    if (schema === undefined) {
-      const validated = validateRawRouteInput(raw);
-      setRawError(validated.error);
-      setArgumentsValue(validated.arguments);
-      setArgv(validated.arguments === undefined || entry.command === undefined
-        ? undefined
-        : cliCommandInvocation(entry.command, validated.arguments));
-      return;
-    }
-    const validated = validateRouteInput(schema, draft);
-    setErrors(validated.errors);
-    setArgumentsValue(validated.arguments);
-    setArgv(validated.arguments === undefined || entry.command === undefined
-      ? undefined
-      : cliCommandInvocation(entry.command, validated.arguments));
+    setStored((current) => validateRouteEditor(
+      current ?? initialRouteEditorState(schema),
+      schema,
+      entry.command,
+    ));
   };
   const openMcp = (): void => {
     if (argumentsValue === undefined || onOpenMcp === undefined) return;
@@ -180,12 +161,10 @@ const RouteInputEditor = ({ entry, group, onOpenMcp }: {
             id={editorId(entry.id, 'raw')}
             onChange={(event) => {
               const next = event.currentTarget.value;
-              setRaw(next);
-              if (attempted) {
-                const validated = validateRawRouteInput(next);
-                setRawError(validated.error);
-                setArgumentsValue(validated.arguments);
-              }
+              setStored((current) => setRouteEditorRaw(
+                current ?? initialRouteEditorState(schema),
+                next,
+              ));
             }}
             rows={4}
             value={raw}
@@ -251,7 +230,8 @@ const RouteInputEditor = ({ entry, group, onOpenMcp }: {
 const commandSummary = (entry: RouteCatalogEntry): string | undefined =>
   entry.command === undefined ? undefined : cliCommandUsage(entry.command);
 
-const RouteGroup = ({ group, onOpenMcp }: {
+const RouteGroup = ({ digest, group, onOpenMcp }: {
+  readonly digest: string;
   readonly group: RouteCatalogGroup;
   readonly onOpenMcp?: (prefill: McpToolPrefill) => void;
 }) => <section
@@ -274,7 +254,7 @@ const RouteGroup = ({ group, onOpenMcp }: {
       <td className="route-source">{entry.source}<span className="route-provenance">{entry.provenance}</span></td>
       <td className="route-config">
         <p className="route-config-summary">{configSummary(entry)}</p>
-        <RouteInputEditor entry={entry} group={group} onOpenMcp={onOpenMcp} />
+        <RouteInputEditor digest={digest} entry={entry} group={group} onOpenMcp={onOpenMcp} />
       </td>
     </tr>)}</tbody>
   </table>
@@ -307,6 +287,7 @@ export const RoutesPage = ({ catalog, onOpenMcp }: RoutesPageProps) => <div clas
           {catalog.servers.filter((server) => server.routeCount === 0)
             .map((server) => <EmptyServerSurface key={server.id} server={server} />)}
           {catalog.groups.map((group) => <RouteGroup
+            digest={catalog.digest}
             group={group}
             key={`${catalog.digest}-${group.serverId ?? 'project'}-${group.kind}`}
             onOpenMcp={onOpenMcp}

--- a/packages/workbench/tests/route-editor-atoms-disposal.test.ts
+++ b/packages/workbench/tests/route-editor-atoms-disposal.test.ts
@@ -1,0 +1,189 @@
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join, normalize, relative } from 'node:path';
+
+import { createRsbuild, type RsbuildConfig } from '@rsbuild/core';
+import { chromium } from 'playwright';
+import { describe, expect, it } from '@rstest/core';
+
+import { createWorkbenchConfig } from '../rsbuild.config.ts';
+
+declare global {
+  interface Window {
+    __routeEditorAtoms: {
+      mount(digest: string): void;
+      unmount(): void;
+    };
+  }
+}
+
+const contentType = (path: string): string => path.endsWith('.css')
+  ? 'text/css'
+  : path.endsWith('.js')
+    ? 'text/javascript'
+    : 'text/html';
+
+const startStaticServer = async (root: string) => {
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+    const file = pathname === '/' ? 'route-editor-atoms-fixture.html' : pathname.slice(1);
+    const path = normalize(join(root, file));
+    if (relative(root, path).startsWith('..')) {
+      response.writeHead(404).end();
+      return;
+    }
+    void readFile(path).then((body) => response.writeHead(200, { 'content-type': contentType(path) }).end(body), () => response.writeHead(404).end());
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new Error('Route editor atom fixture did not expose a TCP address.');
+  return { server, url: `http://127.0.0.1:${address.port}` };
+};
+
+const fixtureSource = (root: string): string => `
+  import { RegistryProvider } from '@effect/atom-react';
+  import React, { useState } from 'react';
+  import { createRoot } from 'react-dom/client';
+  import type { RouteManifest } from ${JSON.stringify(join(root, 'packages/agent-bundle/src/contracts/routes.ts'))};
+  import { routeEditorKey } from ${JSON.stringify(join(root, 'packages/workbench/src/routes/route-editor-atoms.ts'))};
+  import { routeCatalogFor } from ${JSON.stringify(join(root, 'packages/workbench/src/routes/routes-model.ts'))};
+  import { RoutesPage } from ${JSON.stringify(join(root, 'packages/workbench/src/routes/routes-page.tsx'))};
+
+  const catalogFor = (digest: string) => routeCatalogFor({
+    cli: {
+      commands: [{
+        aliases: [],
+        exitCode: 'zero',
+        options: [
+          { key: 'input', kind: 'string', option: 'input', positional: 0, repeated: false, required: true },
+        ],
+        path: ['library', 'audit'],
+        routeId: 'cli:library/audit',
+      }],
+      mode: 'generated',
+      routes: [{
+        config: [],
+        id: 'cli:library/audit',
+        inputSchema: {
+          additionalProperties: false,
+          properties: { input: { type: 'string' } },
+          required: ['input'],
+          type: 'object',
+        },
+        kind: 'cli',
+        provenance: { kind: 'conventional' },
+        source: 'src/cli/library/audit.ts',
+      }],
+    },
+    diagnostics: [],
+    digest,
+    events: [],
+    providers: [],
+    scripts: [],
+    servers: [{
+      id: 'mcp:library',
+      mode: 'generated',
+      name: 'library',
+      routes: [{
+        config: [],
+        id: 'tool:library/search',
+        inputSchema: {
+          additionalProperties: false,
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          type: 'object',
+        },
+        kind: 'tool',
+        provenance: { kind: 'conventional' },
+        serverId: 'mcp:library',
+        source: 'src/mcp/library/tools/search.ts',
+      }],
+    }],
+    sourceRevision: 'source',
+  } satisfies RouteManifest);
+
+  const Fixture = () => {
+    const [state, setState] = useState({ digest: '', mounted: false });
+    window.__routeEditorAtoms = {
+      mount: (digest: string) => { setState({ digest, mounted: true }); },
+      unmount: () => { setState((current) => ({ ...current, mounted: false })); },
+    };
+    return state.mounted
+      ? <div data-editor-key={routeEditorKey(state.digest, 'cli:library/audit')}>
+          <RoutesPage catalog={catalogFor(state.digest)} />
+        </div>
+      : <p>Routes unmounted</p>;
+  };
+
+  createRoot(document.getElementById('root')!).render(
+    <RegistryProvider><Fixture /></RegistryProvider>,
+  );
+`;
+
+describe('Route editor atoms', () => {
+  it('releases editor state across repeated unmounts and digest switches', async () => {
+    const root = process.cwd();
+    const temp = await mkdtemp(join(root, 'packages/workbench/.route-editor-atoms-'));
+    const entry = join(temp, 'route-editor-atoms-fixture.tsx');
+    const output = join(temp, 'dist');
+    await writeFile(entry, fixtureSource(root));
+    const config: RsbuildConfig = createWorkbenchConfig();
+    config.source = {
+      define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+      entry: { 'route-editor-atoms-fixture': entry },
+    };
+    config.output = { ...config.output, distPath: { root: output } };
+    const rsbuild = await createRsbuild({ config });
+    const buildResult = await rsbuild.build();
+    await buildResult.close();
+    const { server, url } = await startStaticServer(output);
+    const browser = await chromium.launch({ channel: 'chrome' });
+    try {
+      const page = await browser.newPage();
+      const errors: string[] = [];
+      page.on('pageerror', (error) => errors.push(error.stack ?? error.message));
+      await page.goto(url, { timeout: 5_000, waitUntil: 'domcontentloaded' });
+      await page.getByText('Routes unmounted', { exact: true }).waitFor({ timeout: 5_000 });
+
+      const cliEditor = page.getByRole('region', { name: 'Input for cli:library/audit' });
+      const input = cliEditor.getByLabel('Input (required)');
+      const invocation = cliEditor.getByLabel('Generated argv invocation');
+      const digestA = 'a'.repeat(64);
+      const digestB = 'b'.repeat(64);
+
+      for (let cycle = 1; cycle <= 5; cycle += 1) {
+        await page.evaluate(({ digest }) => window.__routeEditorAtoms.mount(digest), { digest: digestA });
+        await input.fill(`cycle-${String(cycle)}`);
+        await cliEditor.getByRole('button', { name: 'Validate input' }).click();
+        await expect.poll(() => invocation.inputValue()).toBe(`library audit cycle-${String(cycle)}`);
+
+        await page.evaluate(() => window.__routeEditorAtoms.unmount());
+        await page.getByText('Routes unmounted', { exact: true }).waitFor({ timeout: 5_000 });
+        await page.evaluate(({ digest }) => window.__routeEditorAtoms.mount(digest), { digest: digestA });
+        await expect.poll(() => input.inputValue()).toBe('');
+        await expect.poll(() => invocation.count()).toBe(0);
+        await expect.poll(() => cliEditor.locator('.route-input-error').count()).toBe(0);
+        await page.evaluate(() => window.__routeEditorAtoms.unmount());
+      }
+
+      await page.evaluate(({ digest }) => window.__routeEditorAtoms.mount(digest), { digest: digestA });
+      await input.fill('digest-a');
+      await cliEditor.getByRole('button', { name: 'Validate input' }).click();
+      await expect.poll(() => invocation.inputValue()).toBe('library audit digest-a');
+      await page.evaluate(({ digest }) => window.__routeEditorAtoms.mount(digest), { digest: digestB });
+      await expect.poll(() => input.inputValue()).toBe('');
+      await expect.poll(() => invocation.count()).toBe(0);
+      await page.evaluate(({ digest }) => window.__routeEditorAtoms.mount(digest), { digest: digestA });
+      await expect.poll(() => input.inputValue()).toBe('');
+      await expect.poll(() => invocation.count()).toBe(0);
+      expect(errors).toEqual([]);
+    } finally {
+      await browser.close();
+      await new Promise<void>((resolve, reject) => server.close((error) => error === undefined ? resolve() : reject(error)));
+      await rm(temp, { force: true, recursive: true });
+    }
+  }, 60_000);
+});

--- a/packages/workbench/tests/routes-editor-state.test.ts
+++ b/packages/workbench/tests/routes-editor-state.test.ts
@@ -1,0 +1,151 @@
+import { expect, it } from '@rstest/core';
+
+import type {
+  RouteInputSchema,
+  RouteManifestCliCommand,
+} from '../../agent-bundle/src/contracts/routes.ts';
+import {
+  createRouteInputDraft,
+  initialRouteEditorState,
+  setRouteEditorDraftValue,
+  setRouteEditorRaw,
+  validateRouteEditor,
+  type RouteEditorState,
+} from '../src/routes/routes-model.ts';
+
+const typedSchema: RouteInputSchema = {
+  additionalProperties: false,
+  properties: {
+    enabled: { type: 'boolean' },
+    source: { items: { type: 'string' }, type: 'array' },
+  },
+  required: ['source'],
+  type: 'object',
+};
+
+const repeatedCommand: RouteManifestCliCommand = {
+  aliases: [],
+  exitCode: 'zero',
+  options: [
+    { key: 'source', kind: 'string', option: 'source', repeated: true, required: true },
+    { key: 'enabled', kind: 'boolean', option: 'enabled', repeated: false, required: false },
+  ],
+  path: ['library', 'import'],
+  routeId: 'cli:library/import',
+};
+
+const rawCommand: RouteManifestCliCommand = {
+  aliases: [],
+  exitCode: 'zero',
+  options: [
+    { key: 'input', kind: 'string', option: 'input', positional: 0, repeated: false, required: true },
+  ],
+  path: ['library', 'audit'],
+  routeId: 'cli:library/audit',
+};
+
+it('creates frozen initial editor state with the existing draft defaults', () => {
+  const typed = initialRouteEditorState(typedSchema);
+  const raw = initialRouteEditorState();
+
+  expect(typed).toEqual({
+    attempted: false,
+    draft: createRouteInputDraft(typedSchema),
+    errors: {},
+    raw: '{}',
+  });
+  expect(raw).toEqual({
+    attempted: false,
+    draft: {},
+    errors: {},
+    raw: '{}',
+  });
+  expect(Object.isFrozen(typed)).toBe(true);
+  expect(Object.isFrozen(typed.draft)).toBe(true);
+  expect(Object.isFrozen(typed.errors)).toBe(true);
+});
+
+it('changes the draft before validation without producing validation output', () => {
+  const initial = initialRouteEditorState(typedSchema);
+  const edited = setRouteEditorDraftValue(initial, typedSchema, repeatedCommand, 'source', ['audio']);
+
+  expect(edited).toEqual({
+    attempted: false,
+    draft: { source: ['audio'] },
+    errors: {},
+    raw: '{}',
+  });
+});
+
+it('revalidates typed input after an attempt and projects repeated argv options', () => {
+  const attempted = validateRouteEditor(initialRouteEditorState(typedSchema), typedSchema, repeatedCommand);
+  expect(attempted.errors).toEqual({ source: 'Source is required.' });
+
+  const valid = setRouteEditorDraftValue(attempted, typedSchema, repeatedCommand, 'source', ['audio', 'books']);
+
+  expect(valid.errors).toEqual({});
+  expect(valid.arguments).toEqual({ source: ['audio', 'books'] });
+  expect(valid.argv).toBe('library import --source audio --source books');
+  expect(Object.isFrozen(valid)).toBe(true);
+  expect(Object.isFrozen(valid.errors)).toBe(true);
+});
+
+it('preserves optional boolean omission through true, false, and undefined', () => {
+  const attempted = validateRouteEditor(initialRouteEditorState(typedSchema), typedSchema, repeatedCommand);
+  const withSource = setRouteEditorDraftValue(attempted, typedSchema, repeatedCommand, 'source', ['audio']);
+  const enabled = setRouteEditorDraftValue(withSource, typedSchema, repeatedCommand, 'enabled', true);
+  const disabled = setRouteEditorDraftValue(enabled, typedSchema, repeatedCommand, 'enabled', false);
+  const omitted = setRouteEditorDraftValue(disabled, typedSchema, repeatedCommand, 'enabled', undefined);
+
+  expect(enabled.arguments).toEqual({ enabled: true, source: ['audio'] });
+  expect(disabled.arguments).toEqual({ enabled: false, source: ['audio'] });
+  expect(omitted.arguments).toEqual({ source: ['audio'] });
+  expect(Object.hasOwn(omitted.draft, 'enabled')).toBe(false);
+});
+
+it('deletes a draft key when the next value is undefined', () => {
+  const withValue = setRouteEditorDraftValue(
+    initialRouteEditorState(typedSchema),
+    typedSchema,
+    repeatedCommand,
+    'source',
+    ['audio'],
+  );
+  const deleted = setRouteEditorDraftValue(withValue, typedSchema, repeatedCommand, 'source', undefined);
+
+  expect(Object.hasOwn(deleted.draft, 'source')).toBe(false);
+});
+
+it('revalidates raw text after an attempt without changing the prior argv', () => {
+  const withRaw = setRouteEditorRaw(initialRouteEditorState(), '{"input":"before"}');
+  const attempted = validateRouteEditor(withRaw, undefined, rawCommand);
+  expect(attempted.argv).toBe('library audit before');
+
+  const changed = setRouteEditorRaw(attempted, '{"input":"after"}');
+  expect(changed.arguments).toEqual({ input: 'after' });
+  expect(changed.rawError).toBeUndefined();
+  expect(changed.argv).toBe('library audit before');
+
+  const invalid = setRouteEditorRaw(changed, '{');
+  expect(invalid.arguments).toBeUndefined();
+  expect(invalid.rawError).toBe('Enter a valid JSON object.');
+  expect(invalid.argv).toBe('library audit before');
+});
+
+it('keeps typed and raw validation errors isolated to their respective paths', () => {
+  const rawSeed: RouteEditorState = Object.freeze({
+    ...initialRouteEditorState(),
+    errors: Object.freeze({ retained: 'typed error' }),
+  });
+  const rawValidated = validateRouteEditor(setRouteEditorRaw(rawSeed, '{'), undefined, rawCommand);
+  expect(rawValidated.errors).toEqual({ retained: 'typed error' });
+  expect(rawValidated.rawError).toBe('Enter a valid JSON object.');
+
+  const typedSeed: RouteEditorState = Object.freeze({
+    ...initialRouteEditorState(typedSchema),
+    rawError: 'retained raw error',
+  });
+  const typedValidated = validateRouteEditor(typedSeed, typedSchema, repeatedCommand);
+  expect(typedValidated.errors).toEqual({ source: 'Source is required.' });
+  expect(typedValidated.rawError).toBe('retained raw error');
+});

--- a/rstest.integration-tests.ts
+++ b/rstest.integration-tests.ts
@@ -65,6 +65,7 @@ export const integrationTestFiles: readonly string[] = [
   'packages/workbench/tests/playground-real.e2e.test.ts',
   'packages/workbench/tests/rsbuild-closure.test.ts',
   'packages/workbench/tests/rsbuild-workbench.test.ts',
+  'packages/workbench/tests/route-editor-atoms-disposal.test.ts',
   'packages/workbench/tests/runtime-document-atoms-disposal.test.ts',
   'packages/workbench/tests/runtime-inspector.test.ts',
   'packages/workbench/tests/runtime-consent-dialog.test.ts',


### PR DESCRIPTION
## Summary

Phase 2 of the #105 effect-atom migration (phase 1: #250). The routes-page route-input editor state — previously seven coordinated `useState`/derivation clusters per editor (draft, raw JSON, errors, rawError, attempted, arguments, argv) — moves onto an `Atom.family` keyed by manifest digest + compiled route id, in a new dedicated browser-state module per the `docs/effect-conventions.md` "Workbench browser state" convention.

- `packages/workbench/src/routes/route-editor-atoms.ts`: writable `Atom.family` keyed `digest\u0000routeId`, initial value `undefined` (uninitialized sentinel). No effects, no streams (stream-backed derived atoms remain banned until the post-rc.112 re-pin), no `Atom`/`AsyncResult` in any public export.
- `packages/workbench/src/routes/routes-model.ts`: stays pure — adds `RouteEditorState` + pure transitions (`initialRouteEditorState`, `setRouteEditorDraftValue`, `setRouteEditorRaw`, `validateRouteEditor`) that derive from the untouched `validateRouteInput` / `validateRawRouteInput` / `cliCommandInvocation` projections.
- `packages/workbench/src/routes/routes-page.tsx`: `RouteInputEditor` consumes the atom via `useAtom` with functional updaters; markup unchanged; `RoutesPage` public props unchanged.

The `undefined` sentinel is what keeps provider-less static SSR rendering byte-identical initial markup (`useAtomValue`'s `getServerSnapshot` returns the initial atom value), so the existing contract tests pass **unmodified**.

## Preserved behavior contracts (#222/#224 fixes)

`routes-model.test.ts`, `routes-page.test.ts`, and `examples-real.e2e.test.ts` are untouched and green. Pinned explicitly by new unit tests: optional-boolean omitted/true/false three-state, stale-prefill fail-closed paths untouched (`mcpToolPrefillFor` gating on validated arguments preserved), variadic/repeated-option argv + usage projection, attempted-gated re-validation, and the raw-path asymmetry (raw edits after Validate update rawError/arguments but never argv).

## Disposal regression (phase-1 pattern)

`route-editor-atoms-disposal.test.ts` (integration pool): rsbuild browser fixture mounting the real `RoutesPage` under a bare `RegistryProvider`; 5 mount → type → validate → unmount → remount cycles assert fresh initial state each remount, plus an A→B→A digest-switch cycle; zero page errors.

## Verification (local, after rebasing over #259)

- lint: 0 errors / 0 warnings (915 files)
- typecheck: this diff is clean; `pnpm typecheck` currently fails on **pristine origin/main** (TS7016 in `classify-docs-only.test.ts` from #259) — pre-existing, reproduced on a clean main worktree
- scoped units (`routes-model` + `routes-page` + new `routes-editor-state`): 40/40
- full integration + workbench browser e2e: 61 files / 629 tests — 625 passed, 3 skipped, 1 failed: `public-api.test.ts :: keeps bundled config extension types in emitted root declarations`, **pre-existing** (fails identically on a pristine origin/main worktree; unrelated to workbench)
- new disposal regression: 1/1 pass

## Bundle delta (workbench production build)

| | raw | gzip |
| --- | --- | --- |
| before (main) | 2770.4 kB | 595.3 kB |
| after | 2770.7 kB | 594.9 kB |
| **delta** | **+0.3 kB (+0.01%)** | **−0.4 kB (−0.07%)** |

Near-zero as predicted — the effect core + atom runtime entered the shared chunk in phase 1.

Patch changeset included (`agent-bundle` ships the Workbench dist).