### PR TITLE
feat(test): generated plugin contract matrix, stage 1 (#218)

### DIFF
--- a/.changeset/contract-matrix-stage1.md
+++ b/.changeset/contract-matrix-stage1.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": minor
+---
+
+Add stage-1 generated-plugin contract matrix (`runContractMatrix`) at the `mcp-in-memory` proof level (#218). The matrix runs framework-owned wire-contract checks — surface completeness, fixture coverage, invocation sweep, JSON serialized round-trip, declared additive/closed result compat, version-skew fixtures, negative inputs from advertised JSON Schema, and cancellation hygiene — with project-supplied fixtures only.

--- a/.changeset/contract-matrix-stage1.md
+++ b/.changeset/contract-matrix-stage1.md
@@ -2,4 +2,4 @@
 "agent-bundle": minor
 ---
 
-Add stage-1 generated-plugin contract matrix (`runContractMatrix`) at the `mcp-in-memory` proof level (#218). The matrix runs framework-owned wire-contract checks — surface completeness, fixture coverage, invocation sweep, JSON serialized round-trip, declared additive/closed result compat, version-skew fixtures, negative inputs from advertised JSON Schema, and cancellation hygiene — with project-supplied fixtures only.
+Add stage-1 generated-plugin contract matrix at the `mcp-in-memory` and packed stdio proof boundaries (#218). `runContractMatrix` runs framework-owned wire-contract checks — surface completeness, fixture coverage, invocation sweep, JSON serialized round-trip, declared additive/closed result compat, version-skew fixtures, negative inputs from advertised JSON Schema, and cancellation hygiene — with project-supplied fixtures only. `runPackedContractMatrix` reuses the same implementation against an already-open packed session for process stdio evidence (including MCP App resource registration), reporting module-backed checks as not-applicable when project source may be absent.

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -275,8 +275,8 @@ is never a receipt for another.
 | `route-unit` | `renderRoute`, `renderRouteEvents` | a route module renders to the document (and render-event stream) it claims |
 | `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface`, `runContractMatrix` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
 | `cli-dispatch` | `invokeCli`, `cliJson`, `cliNdjson` | a plain or rendered argv vector resolved and run through the routed CLI's own shell, including rendered Markdown, explicit TTY, JSON, and NDJSON modes, in-process |
-| `packed-stdio` | `openPackedMcpServer` | a built artifact's generated entry running as a real process over stdio |
-| `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer({ deletedSource })` | the packed stdio process still runs after project source and configuration are removed and verified absent |
+| `packed-stdio` | `openPackedMcpServer`, `runPackedContractMatrix` | a built artifact's generated entry running as a real process over stdio |
+| `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer({ deletedSource })`, `runPackedContractMatrix` | the packed stdio process still runs after project source and configuration are removed and verified absent |
 | `host-install` | repository real-host install proof | a built bundle installed into an isolated real host home through the public install path, with registration observed through the host's own CLI |
 
 ```ts
@@ -316,32 +316,48 @@ artifact elsewhere. `host-install` is separate real-host process evidence for
 built-bundle acceptance and registration, not packed provenance or session
 behavior.
 
-### Contract matrix (`runContractMatrix`)
+### Contract matrix (`runContractMatrix` / `runPackedContractMatrix`)
 
-`runContractMatrix` is the framework-owned generated-plugin contract matrix at
-the `mcp-in-memory` proof level. It opens one real MCP client against the real
-generated server and runs a fixed suite of checks per compiled route. The
-project supplies only fixtures — valid inputs, a declared `resultCompat`
-policy for every tool route, optional `previousResults` payloads, and optional
-`cancellation` cases.
+The contract matrix is the framework-owned generated-plugin wire-contract suite.
+Two entry points share one implementation; boundary differences are explicit
+capability flags, not forked check logic. The project supplies only fixtures —
+valid inputs, a declared `resultCompat` policy for every in-memory tool route,
+optional `previousResults` payloads, and optional `cancellation` cases.
 
-At `mcp-in-memory` the matrix proves: wire surface completeness against the
-compiler manifest, fixture coverage, successful-path invocation sweeps,
-JSON serialized round-trip through each tool route's own `resultSchema`,
-declared additive/closed compat behavior on serialized payloads, acceptance of
-previous-server payloads under the current schema, rejection of negative inputs
-derived from the advertised `listTools` input JSON Schema, and mid-flight
-cancellation hygiene. In-memory transport may pass structured values without
-serialization; the matrix closes that gap with an explicit
-`JSON.parse(JSON.stringify(...))` round-trip before validation.
+**`runContractMatrix` (`mcp-in-memory`)** opens one real MCP client against
+the real generated server over the SDK's in-memory transport and runs the full
+matrix. It proves: wire surface completeness against the compiler manifest,
+fixture coverage, successful-path invocation sweeps, JSON serialized round-trip
+through each tool route's own `resultSchema`, declared additive/closed compat
+behavior on serialized payloads, acceptance of previous-server payloads under
+the current schema, rejection of negative inputs derived from the advertised
+`listTools` input JSON Schema, and mid-flight cancellation hygiene. In-memory
+transport may pass structured values without serialization; the matrix closes
+that gap with an explicit `JSON.parse(JSON.stringify(...))` round-trip before
+validation. MCP Apps are reported as not-applicable for surface registration
+because the in-memory level does not register them.
 
-It deliberately does not prove process spawn, stdio framing, packed tarball
-contents, host install, or browser App HTML. MCP Apps are reported as
-not-applicable for surface registration because the in-memory level does not
-register them.
+**`runPackedContractMatrix` (`packed-stdio` / `packed-deleted-source`)** runs
+against an already-open packed session (the single packed journey owns session
+open/close). It proves process stdio evidence for surface completeness
+(including compiled MCP App resource URIs in `listResources`), fixture coverage,
+successful-path sweeps, advertised input-schema rejection, and client-side
+cancellation hygiene. It cannot load project route modules — source may be
+deleted and verified absent — so serialized-round-trip, compat-probe, and
+version-skew are reported `not-applicable` with an honest reason. The packed
+server validates every tool result through its bundled `resultSchema` before
+returning; a successful sweep invocation is that evidence.
+
+**Neither boundary proves:** host install, browser App HTML, or lifecycle replay
+across artifact rebuilds (stage 2+).
+
+When the advertised input schema declares `additionalProperties: false`, plain
+`z.object` tool routes may still strip unknown keys without a protocol failure.
+The negative-inputs check records that tolerance when other generated negatives
+still prove rejection paths.
 
 ```ts
-import { runContractMatrix } from 'agent-bundle/test';
+import { runContractMatrix, runPackedContractMatrix } from 'agent-bundle/test';
 
 await runContractMatrix({
   fixtures: {
@@ -352,11 +368,18 @@ await runContractMatrix({
     },
   },
 });
+
+// Packed: pass an already-open session and a manifest compiled before source removal.
+await runPackedContractMatrix({
+  session: packedSession,
+  manifest: compiledManifest,
+  fixtures: { /* same shape */ },
+});
 ```
 
 A failing matrix throws one aggregated `AgentTestError` with code
-`contract-violation`, naming every failing route, check, and the
-`mcp-in-memory` proof-level label.
+`contract-violation`, naming every failing route, check, and the proof-level
+label the run actually carried.
 
 ## Evaluation
 

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -273,7 +273,7 @@ is never a receipt for another.
 | level | helpers | what it proves |
 | --- | --- | --- |
 | `route-unit` | `renderRoute`, `renderRouteEvents` | a route module renders to the document (and render-event stream) it claims |
-| `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
+| `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface`, `runContractMatrix` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
 | `cli-dispatch` | `invokeCli`, `cliJson`, `cliNdjson` | a plain or rendered argv vector resolved and run through the routed CLI's own shell, including rendered Markdown, explicit TTY, JSON, and NDJSON modes, in-process |
 | `packed-stdio` | `openPackedMcpServer` | a built artifact's generated entry running as a real process over stdio |
 | `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer({ deletedSource })` | the packed stdio process still runs after project source and configuration are removed and verified absent |
@@ -315,6 +315,48 @@ prove native-host install or dispatch, or an install mode that copies the
 artifact elsewhere. `host-install` is separate real-host process evidence for
 built-bundle acceptance and registration, not packed provenance or session
 behavior.
+
+### Contract matrix (`runContractMatrix`)
+
+`runContractMatrix` is the framework-owned generated-plugin contract matrix at
+the `mcp-in-memory` proof level. It opens one real MCP client against the real
+generated server and runs a fixed suite of checks per compiled route. The
+project supplies only fixtures — valid inputs, a declared `resultCompat`
+policy for every tool route, optional `previousResults` payloads, and optional
+`cancellation` cases.
+
+At `mcp-in-memory` the matrix proves: wire surface completeness against the
+compiler manifest, fixture coverage, successful-path invocation sweeps,
+JSON serialized round-trip through each tool route's own `resultSchema`,
+declared additive/closed compat behavior on serialized payloads, acceptance of
+previous-server payloads under the current schema, rejection of negative inputs
+derived from the advertised `listTools` input JSON Schema, and mid-flight
+cancellation hygiene. In-memory transport may pass structured values without
+serialization; the matrix closes that gap with an explicit
+`JSON.parse(JSON.stringify(...))` round-trip before validation.
+
+It deliberately does not prove process spawn, stdio framing, packed tarball
+contents, host install, or browser App HTML. MCP Apps are reported as
+not-applicable for surface registration because the in-memory level does not
+register them.
+
+```ts
+import { runContractMatrix } from 'agent-bundle/test';
+
+await runContractMatrix({
+  fixtures: {
+    'tool:library/summarize': {
+      input: { title: 'Dune' },
+      resultCompat: 'additive',
+      previousResults: [{ chapters: 24 }],
+    },
+  },
+});
+```
+
+A failing matrix throws one aggregated `AgentTestError` with code
+`contract-violation`, naming every failing route, check, and the
+`mcp-in-memory` proof-level label.
 
 ## Evaluation
 

--- a/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/strict-report.tsx
+++ b/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/strict-report.tsx
@@ -1,0 +1,24 @@
+import { Agent } from '@agent-bundle/runtime';
+import { z } from 'zod';
+
+export const config = {
+  description: 'Returns a closed-object report that rejects unknown serialized keys.',
+  title: 'Strict report',
+};
+
+export const inputSchema = z.object({ reportId: z.string().optional() });
+
+export const resultSchema = z.strictObject({
+  reportId: z.string(),
+  summary: z.string(),
+});
+
+export default async function StrictReport({ input }: { readonly input: z.infer<typeof inputSchema> }) {
+  const reportId = input.reportId ?? 'report-1';
+  const value = { reportId, summary: `summary for ${reportId}` };
+  return (
+    <Agent.Result value={value}>
+      <Agent.Text>{value.summary}</Agent.Text>
+    </Agent.Result>
+  );
+}

--- a/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/ticket.tsx
+++ b/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/ticket.tsx
@@ -1,0 +1,36 @@
+import { Agent } from '@agent-bundle/runtime';
+import { z } from 'zod';
+
+export const config = {
+  description: 'Returns a cargo-conductor-shaped ticket status with optional diagnostics fields.',
+  title: 'Ticket',
+};
+
+export const inputSchema = z.object({
+  includeDiagnostics: z.boolean().optional(),
+  includeExecArgv: z.boolean().optional(),
+  includeTail: z.boolean().optional(),
+  status: z.enum(['pending', 'running', 'completed', 'failed']).optional(),
+});
+
+export const resultSchema = z.object({
+  diagnostics: z.array(z.string()).optional(),
+  execArgv: z.array(z.string()).optional(),
+  status: z.enum(['pending', 'running', 'completed', 'failed']),
+  tail: z.string().optional(),
+});
+
+export default async function Ticket({ input }: { readonly input: z.infer<typeof inputSchema> }) {
+  const status = input.status ?? 'completed';
+  const value = {
+    status,
+    ...(input.includeExecArgv === true ? { execArgv: ['node', 'run.mjs'] } : {}),
+    ...(input.includeDiagnostics === true ? { diagnostics: ['ready'] } : {}),
+    ...(input.includeTail === true ? { tail: 'done' } : {}),
+  };
+  return (
+    <Agent.Result value={value}>
+      <Agent.Text>{`ticket: ${status}`}</Agent.Text>
+    </Agent.Result>
+  );
+}

--- a/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/wait.tsx
+++ b/packages/agent-bundle/fixtures/route-harness/src/mcp/harness/tools/wait.tsx
@@ -1,0 +1,47 @@
+import { Agent } from '@agent-bundle/runtime';
+import { z } from 'zod';
+
+const maxHoldMs = 5000;
+
+export const config = {
+  description: 'Waits until aborted or holdMs elapses, for cancellation contract proof.',
+  title: 'Wait',
+};
+
+export const inputSchema = z.object({ holdMs: z.number().int().positive().optional() });
+
+export const resultSchema = z.object({ waitedMs: z.number().int().nonnegative() });
+
+const waitForAbortOrTimeout = async (
+  signal: AbortSignal,
+  holdMs: number,
+): Promise<'aborted' | 'elapsed'> => new Promise((resolve) => {
+  if (signal.aborted) {
+    resolve('aborted');
+    return;
+  }
+  const timeout = setTimeout(() => resolve('elapsed'), holdMs);
+  signal.addEventListener('abort', () => {
+    clearTimeout(timeout);
+    resolve('aborted');
+  }, { once: true });
+});
+
+export default async function Wait({
+  input,
+  signal,
+}: {
+  readonly input: z.infer<typeof inputSchema>;
+  readonly signal: AbortSignal;
+}) {
+  const holdMs = Math.min(input.holdMs ?? maxHoldMs, maxHoldMs);
+  const outcome = await waitForAbortOrTimeout(signal, holdMs);
+  if (outcome === 'aborted') {
+    throw new DOMException('Wait was aborted', 'AbortError');
+  }
+  return (
+    <Agent.Result value={{ waitedMs: holdMs }}>
+      <Agent.Text>{`waited ${String(holdMs)}ms`}</Agent.Text>
+    </Agent.Result>
+  );
+}

--- a/packages/agent-bundle/src/test/contract.ts
+++ b/packages/agent-bundle/src/test/contract.ts
@@ -1,0 +1,802 @@
+/**
+ * The generated-plugin contract matrix at the `mcp-in-memory` proof level.
+ *
+ * A matrix run opens one real MCP client against the real generated server
+ * (same registration and projection as a built artifact) and executes a fixed
+ * suite of framework-owned checks per compiled route. The project supplies
+ * only fixtures — valid inputs, declared result-compat policy, version-skew
+ * payloads, and optional cancellation cases — not the check logic itself.
+ *
+ * What this level proves: wire surface completeness against the compiler
+ * manifest, fixture coverage, successful invocation sweeps, JSON serialized
+ * round-trip through the route's own `resultSchema`, declared additive/closed
+ * compat behavior, previous-server payload acceptance, advertised input-schema
+ * rejection, and mid-flight cancellation hygiene — all over the SDK's
+ * in-memory transport with a real MCP client.
+ *
+ * What it deliberately does NOT prove: process spawn, stdio framing, packed
+ * tarball contents, host install, or browser App HTML. Those belong to
+ * `packed-stdio`, `host-install`, and `browser-app` respectively. In-memory
+ * transport may pass structured values without JSON serialization; the
+ * explicit `JSON.parse(JSON.stringify(...))` round-trip in the serialized
+ * round-trip check closes that gap.
+ */
+import type { Client } from '@modelcontextprotocol/client';
+
+import { AgentTestError, captured } from './errors.ts';
+import {
+  MCP_IN_MEMORY_PROOF_LEVEL,
+  proofLevelLabel,
+  type AgentBundleTestManifest,
+} from './manifest.ts';
+import {
+  openInMemoryMcpServer,
+  type InMemoryMcpSessionOptions,
+  type McpProjectionProvenance,
+} from './mcp.ts';
+import { registeredRouteLoader, testManifest } from './registry.ts';
+import type { AgentRouteModule, TestableRouteDescriptor } from './types.ts';
+
+/** Declared serialized-result compatibility policy for tool routes. */
+export type ResultCompatPolicy = 'additive' | 'closed';
+
+export interface ContractRouteFixture {
+  /** Valid input for the sweep invocation (tools/prompts; resources need none). */
+  readonly input?: unknown;
+  /** Additional valid inputs — e.g. one per declared status/discriminant value. */
+  readonly inputs?: readonly unknown[];
+  /** Declared serialized-result compatibility policy. REQUIRED for tool routes. */
+  readonly resultCompat?: ResultCompatPolicy;
+  /**
+   * Serialized payloads captured from previous server versions; each must parse
+   * under the CURRENT `resultSchema` (previous-server + current-client skew).
+   */
+  readonly previousResults?: readonly unknown[];
+  /**
+   * Cancellation case: invocation aborted mid-flight must settle rejected and
+   * leave the session usable.
+   */
+  readonly cancellation?: { readonly abortAfterMs?: number; readonly input?: unknown };
+}
+
+export interface ContractMatrixOptions extends InMemoryMcpSessionOptions {
+  readonly manifest?: AgentBundleTestManifest;
+  readonly server?: string;
+  /** Route id -> fixture. Every compiled non-app route on the server must be covered. */
+  readonly fixtures: Readonly<Record<string, ContractRouteFixture>>;
+}
+
+export type ContractCheckStatus = 'failed' | 'not-applicable' | 'passed';
+
+export interface ContractCheckOutcome {
+  readonly reason?: string;
+  readonly status: ContractCheckStatus;
+}
+
+export interface ContractRouteReport {
+  readonly checks: Readonly<Record<string, ContractCheckOutcome>>;
+}
+
+export interface ContractMatrixReport {
+  readonly provenance: McpProjectionProvenance;
+  readonly routes: Readonly<Record<string, ContractRouteReport>>;
+}
+
+const COMPAT_PROBE_KEY = '__agentBundleContractProbe';
+
+const CHECK_SURFACE = 'surface-completeness';
+const CHECK_COVERAGE = 'coverage';
+const CHECK_SWEEP = 'sweep';
+const CHECK_SERIALIZED_ROUND_TRIP = 'serialized-round-trip';
+const CHECK_COMPAT_PROBE = 'compat-probe';
+const CHECK_VERSION_SKEW = 'version-skew';
+const CHECK_NEGATIVE_INPUTS = 'negative-inputs';
+const CHECK_CANCELLATION = 'cancellation';
+
+interface MatrixFailure {
+  readonly check: string;
+  readonly reason: string;
+  readonly routeId: string;
+}
+
+interface ToolListingEntry {
+  readonly inputSchema?: Record<string, unknown>;
+  readonly name: string;
+}
+
+interface LiveSurface {
+  readonly prompts: readonly string[];
+  readonly resources: readonly string[];
+  readonly tools: readonly ToolListingEntry[];
+}
+
+const routeProtocolName = (descriptor: TestableRouteDescriptor): string =>
+  descriptor.id.slice(descriptor.id.lastIndexOf('/') + 1);
+
+const routeResourceUri = (descriptor: TestableRouteDescriptor): string | undefined => {
+  const uri = descriptor.config.uri;
+  return typeof uri === 'string' ? uri : undefined;
+};
+
+const serverRoutes = (
+  manifest: AgentBundleTestManifest,
+  serverName: string,
+): readonly TestableRouteDescriptor[] => Object.values(manifest.routes)
+  .filter((route) => route.serverId === `mcp:${serverName}` && route.kind !== 'app')
+  .sort((left, right) => left.id.localeCompare(right.id));
+
+const serverAppRoutes = (
+  manifest: AgentBundleTestManifest,
+  serverName: string,
+): readonly TestableRouteDescriptor[] => Object.values(manifest.routes)
+  .filter((route) => route.serverId === `mcp:${serverName}` && route.kind === 'app')
+  .sort((left, right) => left.id.localeCompare(right.id));
+
+const compiledServerNames = (manifest: AgentBundleTestManifest): readonly string[] => [
+  ...new Set(Object.values(manifest.routes).flatMap((route) =>
+    (route.serverId === undefined ? [] : [route.serverId.replace(/^mcp:/u, '')]))),
+].sort((left, right) => left.localeCompare(right));
+
+const resolveServerName = (
+  manifest: AgentBundleTestManifest,
+  requested: string | undefined,
+): string => {
+  const names = compiledServerNames(manifest);
+  if (requested !== undefined) {
+    if (!names.includes(requested)) {
+      throw new AgentTestError('server-not-found', `No compiled MCP server is named ${JSON.stringify(requested)}.`, {
+        details: [
+          `project root: ${manifest.projectRoot}`,
+          `compiled:     ${names.length === 0 ? 'this project compiled no MCP servers' : names.join(', ')}`,
+        ],
+        recovery: 'Name one of the compiled servers, or add route modules under src/mcp/<server>/.',
+      });
+    }
+    return requested;
+  }
+  if (names.length === 1) return names[0]!;
+  throw new AgentTestError(
+    'server-not-found',
+    names.length === 0
+      ? 'This project compiled no MCP servers.'
+      : 'This project compiled more than one MCP server, so the contract matrix cannot pick one.',
+    {
+      details: [
+        `project root: ${manifest.projectRoot}`,
+        `compiled:     ${names.length === 0 ? 'none' : names.join(', ')}`,
+      ],
+      recovery: 'Pass { server: "<name>" }.',
+    },
+  );
+};
+
+const passed = (): ContractCheckOutcome => ({ status: 'passed' });
+const failed = (reason: string): ContractCheckOutcome => ({ reason, status: 'failed' });
+const notApplicable = (reason: string): ContractCheckOutcome => ({ reason, status: 'not-applicable' });
+
+const recordFailure = (
+  failures: MatrixFailure[],
+  routeId: string,
+  check: string,
+  reason: string,
+): void => {
+  failures.push({ check, reason, routeId });
+};
+
+const outcomeFromCheck = (
+  failures: MatrixFailure[],
+  routeId: string,
+  check: string,
+  outcome: ContractCheckOutcome,
+): ContractCheckOutcome => {
+  if (outcome.status === 'failed') {
+    recordFailure(failures, routeId, check, outcome.reason ?? 'check failed');
+  }
+  return outcome;
+};
+
+const fixtureInputs = (fixture: ContractRouteFixture): readonly unknown[] => {
+  const inputs = [
+    ...(fixture.input === undefined ? [{}] : [fixture.input]),
+    ...(fixture.inputs ?? []),
+  ];
+  return inputs.length === 0 ? [{}] : inputs;
+};
+
+const loadRouteModule = async (
+  manifest: AgentBundleTestManifest,
+  descriptor: TestableRouteDescriptor,
+): Promise<AgentRouteModule & { readonly resultSchema: { parse: (value: unknown) => unknown } }> => {
+  const loader = registeredRouteLoader(manifest, descriptor.id);
+  if (loader === undefined) {
+    throw new AgentTestError(
+      'manifest-unavailable',
+      `Route ${descriptor.id} is compiled but no test-time module loader is registered for it.`,
+      { recovery: 'Build the Rstest configuration with agentBundleRstest() so the generated setup registers route loaders.' },
+    );
+  }
+  const module = await loader();
+  if (module.resultSchema === undefined) {
+    throw new AgentTestError(
+      'invalid-route-module',
+      `Route ${descriptor.id} exports no resultSchema, which the contract matrix requires for validation checks.`,
+    );
+  }
+  return { ...module, resultSchema: module.resultSchema };
+};
+
+const listLiveSurface = async (client: Client): Promise<LiveSurface> => {
+  const [tools, resources, prompts] = await Promise.all([
+    client.listTools(),
+    client.listResources(),
+    client.listPrompts(),
+  ]);
+  return {
+    prompts: Object.freeze(prompts.prompts.map((entry) => entry.name).sort()),
+    resources: Object.freeze(resources.resources.map((entry) => entry.uri).sort()),
+    tools: Object.freeze(tools.tools.map((entry) => ({
+      inputSchema: entry.inputSchema as Record<string, unknown> | undefined,
+      name: entry.name,
+    })).sort((left, right) => left.name.localeCompare(right.name))),
+  };
+};
+
+type ToolInvocationResult =
+  | { readonly isError: boolean; readonly structuredContent?: unknown; readonly threw: false }
+  | { readonly threw: true; readonly error: unknown };
+
+const invocationCacheKey = (name: string, input: unknown): string =>
+  `${name}\0${JSON.stringify(input ?? {})}`;
+
+const callToolResult = async (
+  client: Client,
+  name: string,
+  input: unknown,
+  options?: {
+    readonly cache?: Map<string, ToolInvocationResult>;
+    readonly signal?: AbortSignal;
+    readonly timeout?: number;
+  },
+): Promise<ToolInvocationResult> => {
+  if (options?.signal === undefined && options?.cache !== undefined) {
+    const cached = options.cache.get(invocationCacheKey(name, input));
+    if (cached !== undefined) return cached;
+  }
+  try {
+    const result = await client.callTool(
+      { arguments: (input ?? {}) as Record<string, unknown>, name },
+      {
+        ...(options?.signal === undefined ? {} : { signal: options.signal }),
+        ...(options?.timeout === undefined ? {} : { timeout: options.timeout }),
+      },
+    ) as { isError?: boolean; structuredContent?: unknown };
+    const settled: ToolInvocationResult = {
+      isError: result.isError === true,
+      ...(result.structuredContent === undefined ? {} : { structuredContent: result.structuredContent }),
+      threw: false,
+    };
+    if (options?.signal === undefined && options?.cache !== undefined) {
+      options.cache.set(invocationCacheKey(name, input), settled);
+    }
+    return settled;
+  } catch (error) {
+    const settled: ToolInvocationResult = { error, threw: true };
+    if (options?.signal === undefined && options?.cache !== undefined) {
+      options.cache.set(invocationCacheKey(name, input), settled);
+    }
+    return settled;
+  }
+};
+
+const serializedRoundTrip = (value: unknown): unknown =>
+  JSON.parse(JSON.stringify(value)) as unknown;
+
+const compatProbe = (
+  payload: unknown,
+  policy: ResultCompatPolicy,
+  parse: (value: unknown) => unknown,
+): { readonly accepted: boolean; readonly error?: unknown } => {
+  const probed = {
+    ...(typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+      ? payload as Record<string, unknown>
+      : {}),
+    [COMPAT_PROBE_KEY]: true,
+  };
+  try {
+    parse(probed);
+    return { accepted: true };
+  } catch (error) {
+    return { accepted: false, error };
+  }
+};
+
+const wrongJsonType = (schemaType: unknown): unknown => {
+  switch (schemaType) {
+    case 'string':
+      return 0;
+    case 'number':
+    case 'integer':
+      return 'not-a-number';
+    case 'boolean':
+      return 'not-a-boolean';
+    case 'array':
+      return {};
+    case 'object':
+      return 'not-an-object';
+    default:
+      return null;
+  }
+};
+
+/**
+ * Derives negative input cases from a tool's ADVERTISED input JSON Schema — the
+ * wire contract from `listTools`, not the route module's zod source.
+ *
+ * Generates, when the schema has top-level object structure:
+ * - one unknown-extra-key case
+ * - one missing-required-property case per required field
+ * - one wrong-JSON-type case per typed top-level property
+ *
+ * Does NOT prove deep nested validation, format constraints, or enum exhaustiveness
+ * beyond the top-level object shape the MCP SDK advertises.
+ */
+export const negativeInputsFromJsonSchema = (
+  schema: Record<string, unknown>,
+): readonly { readonly label: string; readonly input: Record<string, unknown> }[] | undefined => {
+  if (schema.type !== 'object') return undefined;
+  const properties = schema.properties;
+  if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
+    return undefined;
+  }
+  const propertyEntries = Object.entries(properties as Record<string, Record<string, unknown>>);
+  if (propertyEntries.length === 0 && !Array.isArray(schema.required)) {
+    return [{ input: { __agentBundleContractNegative: true }, label: 'unknown-extra-key' }];
+  }
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+  const negatives: { readonly label: string; readonly input: Record<string, unknown> }[] = [
+    { input: { __agentBundleContractNegative: true }, label: 'unknown-extra-key' },
+  ];
+  for (const key of required) {
+    const present = Object.fromEntries(
+      required.filter((candidate) => candidate !== key).map((candidate) => {
+        const propertySchema = (properties as Record<string, Record<string, unknown>>)[candidate];
+        const type = propertySchema?.type;
+        return [candidate, typeof type === 'string' ? defaultValueForType(type) : 'value'];
+      }),
+    );
+    negatives.push({ input: present, label: `missing-required:${key}` });
+  }
+  for (const [key, propertySchema] of propertyEntries) {
+    const type = propertySchema.type;
+    if (typeof type !== 'string') continue;
+    const base = Object.fromEntries(
+      propertyEntries.map(([propertyKey, property]) => [
+        propertyKey,
+        propertyKey === key ? wrongJsonType(type) : defaultValueForType(typeof property.type === 'string' ? property.type : 'string'),
+      ]),
+    );
+    negatives.push({ input: base, label: `wrong-type:${key}` });
+  }
+  return negatives;
+};
+
+const defaultValueForType = (type: string): unknown => {
+  switch (type) {
+    case 'string':
+      return 'value';
+    case 'number':
+    case 'integer':
+      return 1;
+    case 'boolean':
+      return true;
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    default:
+      return 'value';
+  }
+};
+
+const checkSurfaceCompleteness = (
+  descriptor: TestableRouteDescriptor,
+  surface: LiveSurface,
+): ContractCheckOutcome => {
+  switch (descriptor.kind) {
+    case 'tool': {
+      const name = routeProtocolName(descriptor);
+      return surface.tools.some((entry) => entry.name === name)
+        ? passed()
+        : failed(`tool ${JSON.stringify(name)} is missing from listTools`);
+    }
+    case 'resource': {
+      const uri = routeResourceUri(descriptor);
+      if (uri === undefined) {
+        return failed('resource route config exports no uri to compare against listResources');
+      }
+      return surface.resources.includes(uri)
+        ? passed()
+        : failed(`resource URI ${JSON.stringify(uri)} is missing from listResources`);
+    }
+    case 'prompt': {
+      const name = routeProtocolName(descriptor);
+      return surface.prompts.includes(name)
+        ? passed()
+        : failed(`prompt ${JSON.stringify(name)} is missing from listPrompts`);
+    }
+    case 'app':
+      return notApplicable('MCP Apps are not registered by the in-memory projection level.');
+    case 'cli':
+    case 'event-route':
+    case 'script':
+      return notApplicable(`route kind ${descriptor.kind} is not registered on the MCP server surface.`);
+    default: {
+      const exhaustive: never = descriptor.kind;
+      return failed(`unsupported route kind ${String(exhaustive)} for surface completeness`);
+    }
+  }
+};
+
+const runSweep = async (
+  client: Client,
+  descriptor: TestableRouteDescriptor,
+  fixture: ContractRouteFixture,
+  cache: Map<string, ToolInvocationResult>,
+): Promise<ContractCheckOutcome> => {
+  switch (descriptor.kind) {
+    case 'tool': {
+      for (const input of fixtureInputs(fixture)) {
+        const result = await callToolResult(client, routeProtocolName(descriptor), input, { cache });
+        if (result.threw) {
+          return failed(`callTool threw: ${result.error instanceof Error ? result.error.message : captured(result.error)}`);
+        }
+        if (result.structuredContent === undefined) {
+          return failed(`callTool returned no structuredContent for input ${captured(input)}`);
+        }
+        if (result.isError) {
+          return notApplicable(
+            'Invocation returned isError; sweep proves successful invocation paths only.',
+          );
+        }
+      }
+      return passed();
+    }
+    case 'resource': {
+      const uri = routeResourceUri(descriptor);
+      if (uri === undefined) {
+        return failed('resource route config exports no uri to read');
+      }
+      const read = await client.readResource({ uri }) as { contents?: unknown };
+      const contents = Array.isArray(read.contents) ? read.contents : [];
+      return contents.length === 0
+        ? failed(`readResource returned no contents for ${JSON.stringify(uri)}`)
+        : passed();
+    }
+    case 'prompt': {
+      const result = await client.getPrompt({
+        arguments: (fixture.input ?? {}) as Record<string, string>,
+        name: routeProtocolName(descriptor),
+      }) as { messages?: unknown };
+      const messages = Array.isArray(result.messages) ? result.messages : [];
+      return messages.length === 0
+        ? failed(`getPrompt returned no messages for input ${captured(fixture.input ?? {})}`)
+        : passed();
+    }
+    default:
+      return notApplicable(`route kind ${descriptor.kind} has no sweep invocation at the MCP level.`);
+  }
+};
+
+const runSerializedRoundTrip = async (
+  client: Client,
+  descriptor: TestableRouteDescriptor,
+  fixture: ContractRouteFixture,
+  module: AgentRouteModule & { readonly resultSchema: { parse: (value: unknown) => unknown } },
+  cache: Map<string, ToolInvocationResult>,
+): Promise<ContractCheckOutcome> => {
+  if (descriptor.kind !== 'tool') {
+    return notApplicable('serialized round-trip applies to tool structuredContent only.');
+  }
+  for (const input of fixtureInputs(fixture)) {
+    const result = await callToolResult(client, routeProtocolName(descriptor), input, { cache });
+    if (result.threw) {
+      return failed(`callTool threw before round-trip: ${result.error instanceof Error ? result.error.message : captured(result.error)}`);
+    }
+    if (result.structuredContent === undefined) {
+      return failed(`callTool returned no structuredContent for input ${captured(input)}`);
+    }
+    if (result.isError) {
+      return notApplicable('serialized round-trip requires a successful tool result.');
+    }
+    try {
+      module.resultSchema.parse(serializedRoundTrip(result.structuredContent));
+    } catch (error) {
+      return failed(
+        `JSON round-tripped structuredContent failed resultSchema.parse: ${error instanceof Error ? error.message : captured(error)}`,
+      );
+    }
+  }
+  return passed();
+};
+
+const runCompatProbe = async (
+  client: Client,
+  descriptor: TestableRouteDescriptor,
+  fixture: ContractRouteFixture,
+  module: AgentRouteModule & { readonly resultSchema: { parse: (value: unknown) => unknown } },
+  cache: Map<string, ToolInvocationResult>,
+): Promise<ContractCheckOutcome> => {
+  if (descriptor.kind !== 'tool') {
+    return notApplicable('result compat policy applies to tool routes only.');
+  }
+  if (fixture.resultCompat === undefined) {
+    return failed('tool route fixture must declare resultCompat (additive or closed).');
+  }
+  const input = fixtureInputs(fixture)[0] ?? {};
+  const result = await callToolResult(client, routeProtocolName(descriptor), input, { cache });
+  if (result.threw || result.structuredContent === undefined || result.isError) {
+    return notApplicable('compat probe requires a successful tool result with structuredContent.');
+  }
+  const roundTripped = serializedRoundTrip(result.structuredContent);
+  const probe = compatProbe(roundTripped, fixture.resultCompat, module.resultSchema.parse.bind(module.resultSchema));
+  if (fixture.resultCompat === 'additive') {
+    return probe.accepted
+      ? passed()
+      : failed(`declared additive policy but resultSchema rejected unknown key ${JSON.stringify(COMPAT_PROBE_KEY)}`);
+  }
+  return probe.accepted
+    ? failed(`declared closed policy but resultSchema accepted unknown key ${JSON.stringify(COMPAT_PROBE_KEY)}`)
+    : passed();
+};
+
+const runVersionSkew = (
+  descriptor: TestableRouteDescriptor,
+  fixture: ContractRouteFixture,
+  module: AgentRouteModule & { readonly resultSchema: { parse: (value: unknown) => unknown } },
+): ContractCheckOutcome => {
+  if (descriptor.kind !== 'tool') {
+    return notApplicable('version-skew fixtures apply to tool routes only.');
+  }
+  if (fixture.previousResults === undefined || fixture.previousResults.length === 0) {
+    return notApplicable('no previousResults fixtures declared.');
+  }
+  for (const [index, payload] of fixture.previousResults.entries()) {
+    try {
+      module.resultSchema.parse(payload);
+    } catch (error) {
+      return failed(
+        `previousResults[${String(index)}] failed current resultSchema.parse: ${error instanceof Error ? error.message : captured(error)}`,
+      );
+    }
+  }
+  return passed();
+};
+
+const runNegativeInputs = async (
+  client: Client,
+  descriptor: TestableRouteDescriptor,
+  surface: LiveSurface,
+): Promise<ContractCheckOutcome> => {
+  if (descriptor.kind !== 'tool') {
+    return notApplicable('negative input generation applies to tool routes only.');
+  }
+  const listing = surface.tools.find((entry) => entry.name === routeProtocolName(descriptor));
+  if (listing?.inputSchema === undefined) {
+    return notApplicable('listTools did not advertise an inputSchema for this tool.');
+  }
+  const negatives = negativeInputsFromJsonSchema(listing.inputSchema);
+  if (negatives === undefined) {
+    return notApplicable('advertised inputSchema has no top-level object structure to derive negative cases from.');
+  }
+  let anyRejected = false;
+  for (const negative of negatives) {
+    const result = await callToolResult(client, routeProtocolName(descriptor), negative.input);
+    if (result.threw || result.isError || result.structuredContent === undefined) {
+      anyRejected = true;
+      continue;
+    }
+    if (negative.label === 'unknown-extra-key') {
+      // Advertised JSON Schema declares additionalProperties: false, but plain
+      // z.object routes may strip unknown keys without failing the protocol
+      // call. Other generated negatives still prove rejection paths.
+      continue;
+    }
+    return failed(`negative input ${negative.label} produced a successful tool result: ${captured(negative.input)}`);
+  }
+  return anyRejected
+    ? passed()
+    : failed('no generated negative input caused callTool to fail or return isError');
+};
+
+const runCancellation = async (
+  client: Client,
+  descriptor: TestableRouteDescriptor,
+  fixture: ContractRouteFixture,
+  cache: Map<string, ToolInvocationResult>,
+): Promise<ContractCheckOutcome> => {
+  if (descriptor.kind !== 'tool') {
+    return notApplicable('cancellation applies to tool routes only.');
+  }
+  if (fixture.cancellation === undefined) {
+    return notApplicable('no cancellation fixture declared.');
+  }
+  const abortAfterMs = fixture.cancellation.abortAfterMs ?? 50;
+  const settleWithinMs = abortAfterMs + 2_000;
+  const controller = new AbortController();
+  const input = fixture.cancellation.input ?? { holdMs: 5000 };
+  const call = callToolResult(client, routeProtocolName(descriptor), input, {
+    signal: controller.signal,
+    timeout: settleWithinMs,
+  });
+  const timer = setTimeout(() => controller.abort(), abortAfterMs);
+  const result = await Promise.race([
+    call.then((settled) => ({ kind: 'settled' as const, settled })),
+    new Promise<{ kind: 'timeout' }>((resolve) => {
+      setTimeout(() => resolve({ kind: 'timeout' }), settleWithinMs);
+    }),
+  ]);
+  clearTimeout(timer);
+  if (result.kind === 'timeout') {
+    return failed(`callTool did not settle within ${String(settleWithinMs)}ms after abort`);
+  }
+  if (!result.settled.threw) {
+    return failed('aborted callTool settled without throwing or rejecting.');
+  }
+  const healthy = await callToolResult(client, routeProtocolName(descriptor), { holdMs: 1 }, { cache });
+  if (healthy.threw) {
+    return failed(`session did not recover: subsequent callTool threw: ${healthy.error instanceof Error ? healthy.error.message : captured(healthy.error)}`);
+  }
+  if (healthy.isError || healthy.structuredContent === undefined) {
+    return failed('session did not recover: subsequent healthy invocation failed.');
+  }
+  return passed();
+};
+
+/**
+ * Runs the contract matrix against one compiled MCP server at the
+ * `mcp-in-memory` proof level. Returns a per-route report; throws one
+ * aggregated `AgentTestError` with code `contract-violation` when any check
+ * failed (never first-failure-only).
+ */
+export const runContractMatrix = async (
+  options: ContractMatrixOptions,
+): Promise<ContractMatrixReport> => {
+  const manifest = options.manifest ?? testManifest();
+  const serverName = resolveServerName(manifest, options.server);
+  const routes = serverRoutes(manifest, serverName);
+  const appRoutes = serverAppRoutes(manifest, serverName);
+  const failures: MatrixFailure[] = [];
+  const routeReports: Record<string, ContractRouteReport> = {};
+
+  const unknownFixtureKeys = Object.keys(options.fixtures).filter(
+    (routeId) => manifest.routes[routeId] === undefined,
+  );
+  if (unknownFixtureKeys.length > 0) {
+    for (const routeId of unknownFixtureKeys.sort()) {
+      recordFailure(
+        failures,
+        routeId,
+        CHECK_COVERAGE,
+        `fixture names unknown route ${JSON.stringify(routeId)}`,
+      );
+      routeReports[routeId] = {
+        checks: {
+          [CHECK_COVERAGE]: failed(`fixture names unknown route ${JSON.stringify(routeId)}`),
+        },
+      };
+    }
+  }
+
+  await using session = await openInMemoryMcpServer(options);
+  const surface = await listLiveSurface(session.client);
+  const proofLabel = proofLevelLabel(MCP_IN_MEMORY_PROOF_LEVEL);
+  const invocationCache = new Map<string, ToolInvocationResult>();
+
+  for (const descriptor of routes) {
+    const checks: Record<string, ContractCheckOutcome> = {};
+    const fixture = options.fixtures[descriptor.id];
+
+    checks[CHECK_COVERAGE] = outcomeFromCheck(
+      failures,
+      descriptor.id,
+      CHECK_COVERAGE,
+      fixture === undefined
+        ? failed('compiled route has no fixture entry')
+        : passed(),
+    );
+
+    checks[CHECK_SURFACE] = outcomeFromCheck(
+      failures,
+      descriptor.id,
+      CHECK_SURFACE,
+      checkSurfaceCompleteness(descriptor, surface),
+    );
+
+    if (fixture === undefined) {
+      routeReports[descriptor.id] = { checks };
+      continue;
+    }
+
+    const module = descriptor.kind === 'tool'
+      ? await loadRouteModule(manifest, descriptor)
+      : undefined;
+
+    checks[CHECK_SWEEP] = outcomeFromCheck(
+      failures,
+      descriptor.id,
+      CHECK_SWEEP,
+      await runSweep(session.client, descriptor, fixture, invocationCache),
+    );
+
+    if (module !== undefined) {
+      checks[CHECK_SERIALIZED_ROUND_TRIP] = outcomeFromCheck(
+        failures,
+        descriptor.id,
+        CHECK_SERIALIZED_ROUND_TRIP,
+        await runSerializedRoundTrip(session.client, descriptor, fixture, module, invocationCache),
+      );
+      checks[CHECK_COMPAT_PROBE] = outcomeFromCheck(
+        failures,
+        descriptor.id,
+        CHECK_COMPAT_PROBE,
+        await runCompatProbe(session.client, descriptor, fixture, module, invocationCache),
+      );
+      checks[CHECK_VERSION_SKEW] = outcomeFromCheck(
+        failures,
+        descriptor.id,
+        CHECK_VERSION_SKEW,
+        runVersionSkew(descriptor, fixture, module),
+      );
+      checks[CHECK_NEGATIVE_INPUTS] = outcomeFromCheck(
+        failures,
+        descriptor.id,
+        CHECK_NEGATIVE_INPUTS,
+        await runNegativeInputs(session.client, descriptor, surface),
+      );
+      checks[CHECK_CANCELLATION] = outcomeFromCheck(
+        failures,
+        descriptor.id,
+        CHECK_CANCELLATION,
+        await runCancellation(session.client, descriptor, fixture, invocationCache),
+      );
+    } else {
+      checks[CHECK_SERIALIZED_ROUND_TRIP] = notApplicable('applies to tool routes only.');
+      checks[CHECK_COMPAT_PROBE] = notApplicable('applies to tool routes only.');
+      checks[CHECK_VERSION_SKEW] = notApplicable('applies to tool routes only.');
+      checks[CHECK_NEGATIVE_INPUTS] = notApplicable('applies to tool routes only.');
+      checks[CHECK_CANCELLATION] = notApplicable('applies to tool routes only.');
+    }
+
+    routeReports[descriptor.id] = { checks };
+  }
+
+  for (const descriptor of appRoutes) {
+    routeReports[descriptor.id] = {
+      checks: {
+        [CHECK_SURFACE]: notApplicable('MCP Apps are not registered by the in-memory projection level.'),
+      },
+    };
+  }
+
+  const report: ContractMatrixReport = Object.freeze({
+    provenance: session.provenance,
+    routes: Object.freeze(routeReports),
+  });
+
+  if (failures.length > 0) {
+    const details = failures.map((entry) =>
+      `- ${entry.routeId} / ${entry.check}: ${entry.reason} (${proofLabel})`);
+    throw new AgentTestError(
+      'contract-violation',
+      `Contract matrix reported ${String(failures.length)} violation(s) at the ${MCP_IN_MEMORY_PROOF_LEVEL} proof level.`,
+      {
+        details,
+        recovery: 'Fix the failing route, fixture, or declared resultCompat policy; re-run runContractMatrix.',
+      },
+    );
+  }
+
+  return report;
+};

--- a/packages/agent-bundle/src/test/contract.ts
+++ b/packages/agent-bundle/src/test/contract.ts
@@ -1,25 +1,33 @@
 /**
- * The generated-plugin contract matrix at the `mcp-in-memory` proof level.
+ * The generated-plugin contract matrix — framework-owned wire-contract checks
+ * at two proof boundaries today (`mcp-in-memory` and packed stdio).
  *
- * A matrix run opens one real MCP client against the real generated server
- * (same registration and projection as a built artifact) and executes a fixed
- * suite of framework-owned checks per compiled route. The project supplies
- * only fixtures — valid inputs, declared result-compat policy, version-skew
- * payloads, and optional cancellation cases — not the check logic itself.
+ * Both entry points share one implementation. Boundary differences are explicit
+ * capability flags, not forked check logic. The project supplies only fixtures
+ * — valid inputs, declared result-compat policy, version-skew payloads, and
+ * optional cancellation cases — not the check logic itself.
  *
- * What this level proves: wire surface completeness against the compiler
- * manifest, fixture coverage, successful invocation sweeps, JSON serialized
- * round-trip through the route's own `resultSchema`, declared additive/closed
- * compat behavior, previous-server payload acceptance, advertised input-schema
- * rejection, and mid-flight cancellation hygiene — all over the SDK's
- * in-memory transport with a real MCP client.
+ * **`runContractMatrix` (`mcp-in-memory`)** opens one real MCP client against
+ * the real generated server over the SDK's in-memory transport and runs the
+ * full matrix including module-backed validation: JSON serialized round-trip
+ * through each tool route's own `resultSchema`, declared additive/closed compat
+ * behavior, and previous-server payload acceptance. In-memory transport may
+ * pass structured values without serialization; the explicit
+ * `JSON.parse(JSON.stringify(...))` round-trip closes that gap. MCP Apps are
+ * not registered at this level.
  *
- * What it deliberately does NOT prove: process spawn, stdio framing, packed
- * tarball contents, host install, or browser App HTML. Those belong to
- * `packed-stdio`, `host-install`, and `browser-app` respectively. In-memory
- * transport may pass structured values without JSON serialization; the
- * explicit `JSON.parse(JSON.stringify(...))` round-trip in the serialized
- * round-trip check closes that gap.
+ * **`runPackedContractMatrix` (`packed-stdio` / `packed-deleted-source`)** runs
+ * against an already-open packed session. It proves process stdio evidence for
+ * surface completeness (including compiled MCP App resource URIs), fixture
+ * coverage, successful-path sweeps, advertised input-schema rejection, and
+ * client-side cancellation hygiene. It cannot load project route modules — source
+ * may be deleted and verified absent — so serialized-round-trip, compat-probe,
+ * and version-skew are reported `not-applicable`. The packed server validates
+ * every tool result through its bundled `resultSchema` before returning; a
+ * successful sweep invocation is that evidence.
+ *
+ * **Neither boundary proves:** host install, browser App HTML, or lifecycle
+ * replay across artifact rebuilds (stage 2+).
  */
 import type { Client } from '@modelcontextprotocol/client';
 
@@ -28,12 +36,14 @@ import {
   MCP_IN_MEMORY_PROOF_LEVEL,
   proofLevelLabel,
   type AgentBundleTestManifest,
+  type AgentTestProofLevel,
 } from './manifest.ts';
 import {
   openInMemoryMcpServer,
   type InMemoryMcpSessionOptions,
   type McpProjectionProvenance,
 } from './mcp.ts';
+import type { PackedMcpProvenance, PackedMcpSession } from './packed.ts';
 import { registeredRouteLoader, testManifest } from './registry.ts';
 import type { AgentRouteModule, TestableRouteDescriptor } from './types.ts';
 
@@ -77,10 +87,45 @@ export interface ContractRouteReport {
   readonly checks: Readonly<Record<string, ContractCheckOutcome>>;
 }
 
+export type ContractMatrixProvenance = McpProjectionProvenance | PackedMcpProvenance;
+
 export interface ContractMatrixReport {
-  readonly provenance: McpProjectionProvenance;
+  readonly provenance: ContractMatrixProvenance;
   readonly routes: Readonly<Record<string, ContractRouteReport>>;
 }
+
+export interface PackedContractMatrixOptions {
+  readonly fixtures: Readonly<Record<string, ContractRouteFixture>>;
+  readonly manifest: AgentBundleTestManifest;
+  readonly server?: string;
+  /** An already-open packed session; this entry point never opens or closes it. */
+  readonly session: PackedMcpSession;
+}
+
+interface MatrixBoundaryCapabilities {
+  readonly canLoadRouteModules: boolean;
+  readonly moduleSchemaNotApplicableReason: string;
+  readonly proofLevel: AgentTestProofLevel;
+  readonly registersAppResources: boolean;
+}
+
+const PACKED_MODULE_SCHEMA_NOT_APPLICABLE_REASON =
+  'packed sessions cannot load project route modules (source may be deleted and verified absent); loading a module would silently break deleted-source proof. The packed server validates every tool result through its bundled resultSchema before returning — a successful sweep invocation is that evidence.';
+
+const IN_MEMORY_BOUNDARY: MatrixBoundaryCapabilities = Object.freeze({
+  canLoadRouteModules: true,
+  moduleSchemaNotApplicableReason: '',
+  proofLevel: MCP_IN_MEMORY_PROOF_LEVEL,
+  registersAppResources: false,
+});
+
+const packedBoundaryFromSession = (session: PackedMcpSession): MatrixBoundaryCapabilities =>
+  Object.freeze({
+    canLoadRouteModules: false,
+    moduleSchemaNotApplicableReason: PACKED_MODULE_SCHEMA_NOT_APPLICABLE_REASON,
+    proofLevel: session.provenance.proofLevel,
+    registersAppResources: true,
+  });
 
 const COMPAT_PROBE_KEY = '__agentBundleContractProbe';
 
@@ -117,6 +162,23 @@ const routeResourceUri = (descriptor: TestableRouteDescriptor): string | undefin
   const uri = descriptor.config.uri;
   return typeof uri === 'string' ? uri : undefined;
 };
+
+const routeAppResourceUri = (
+  descriptor: TestableRouteDescriptor,
+  manifest: AgentBundleTestManifest,
+): string | undefined => {
+  const fromConfig = descriptor.config.resourceUri;
+  if (typeof fromConfig === 'string') return fromConfig;
+  const app = Object.values(manifest.apps).find((entry) => entry.id === descriptor.id);
+  return app?.resourceUri;
+};
+
+const routeWireUri = (
+  descriptor: TestableRouteDescriptor,
+  manifest: AgentBundleTestManifest,
+): string | undefined => (descriptor.kind === 'app'
+  ? routeAppResourceUri(descriptor, manifest)
+  : routeResourceUri(descriptor));
 
 const serverRoutes = (
   manifest: AgentBundleTestManifest,
@@ -171,6 +233,7 @@ const resolveServerName = (
 };
 
 const passed = (): ContractCheckOutcome => ({ status: 'passed' });
+const passedWithReason = (reason: string): ContractCheckOutcome => ({ reason, status: 'passed' });
 const failed = (reason: string): ContractCheckOutcome => ({ reason, status: 'failed' });
 const notApplicable = (reason: string): ContractCheckOutcome => ({ reason, status: 'not-applicable' });
 
@@ -337,6 +400,11 @@ const wrongJsonType = (schemaType: unknown): unknown => {
  * - one missing-required-property case per required field
  * - one wrong-JSON-type case per typed top-level property
  *
+ * **Unknown-extra-key tolerance:** when the advertised schema declares
+ * `additionalProperties: false`, plain `z.object` tool routes may still strip
+ * unknown keys without a protocol failure. The negative-inputs check records
+ * that acceptance when other generated negatives still prove rejection paths.
+ *
  * Does NOT prove deep nested validation, format constraints, or enum exhaustiveness
  * beyond the top-level object shape the MCP SDK advertises.
  */
@@ -403,6 +471,8 @@ const defaultValueForType = (type: string): unknown => {
 const checkSurfaceCompleteness = (
   descriptor: TestableRouteDescriptor,
   surface: LiveSurface,
+  manifest: AgentBundleTestManifest,
+  boundary: MatrixBoundaryCapabilities,
 ): ContractCheckOutcome => {
   switch (descriptor.kind) {
     case 'tool': {
@@ -426,8 +496,18 @@ const checkSurfaceCompleteness = (
         ? passed()
         : failed(`prompt ${JSON.stringify(name)} is missing from listPrompts`);
     }
-    case 'app':
-      return notApplicable('MCP Apps are not registered by the in-memory projection level.');
+    case 'app': {
+      if (!boundary.registersAppResources) {
+        return notApplicable('MCP Apps are not registered by the in-memory projection level.');
+      }
+      const uri = routeAppResourceUri(descriptor, manifest);
+      if (uri === undefined) {
+        return failed('app route config exports no resourceUri to compare against listResources');
+      }
+      return surface.resources.includes(uri)
+        ? passed()
+        : failed(`MCP App resource URI ${JSON.stringify(uri)} is missing from listResources`);
+    }
     case 'cli':
     case 'event-route':
     case 'script':
@@ -443,6 +523,7 @@ const runSweep = async (
   client: Client,
   descriptor: TestableRouteDescriptor,
   fixture: ContractRouteFixture,
+  manifest: AgentBundleTestManifest,
   cache: Map<string, ToolInvocationResult>,
 ): Promise<ContractCheckOutcome> => {
   switch (descriptor.kind) {
@@ -452,21 +533,22 @@ const runSweep = async (
         if (result.threw) {
           return failed(`callTool threw: ${result.error instanceof Error ? result.error.message : captured(result.error)}`);
         }
-        if (result.structuredContent === undefined) {
-          return failed(`callTool returned no structuredContent for input ${captured(input)}`);
-        }
         if (result.isError) {
           return notApplicable(
             'Invocation returned isError; sweep proves successful invocation paths only.',
           );
         }
+        if (result.structuredContent === undefined) {
+          return failed(`callTool returned no structuredContent for input ${captured(input)}`);
+        }
       }
       return passed();
     }
-    case 'resource': {
-      const uri = routeResourceUri(descriptor);
+    case 'resource':
+    case 'app': {
+      const uri = routeWireUri(descriptor, manifest);
       if (uri === undefined) {
-        return failed('resource route config exports no uri to read');
+        return failed(`${descriptor.kind} route config exports no uri to read`);
       }
       const read = await client.readResource({ uri }) as { contents?: unknown };
       const contents = Array.isArray(read.contents) ? read.contents : [];
@@ -504,11 +586,11 @@ const runSerializedRoundTrip = async (
     if (result.threw) {
       return failed(`callTool threw before round-trip: ${result.error instanceof Error ? result.error.message : captured(result.error)}`);
     }
-    if (result.structuredContent === undefined) {
-      return failed(`callTool returned no structuredContent for input ${captured(input)}`);
-    }
     if (result.isError) {
       return notApplicable('serialized round-trip requires a successful tool result.');
+    }
+    if (result.structuredContent === undefined) {
+      return failed(`callTool returned no structuredContent for input ${captured(input)}`);
     }
     try {
       module.resultSchema.parse(serializedRoundTrip(result.structuredContent));
@@ -591,6 +673,7 @@ const runNegativeInputs = async (
     return notApplicable('advertised inputSchema has no top-level object structure to derive negative cases from.');
   }
   let anyRejected = false;
+  let unknownExtraKeyAccepted = false;
   for (const negative of negatives) {
     const result = await callToolResult(client, routeProtocolName(descriptor), negative.input);
     if (result.threw || result.isError || result.structuredContent === undefined) {
@@ -598,16 +681,19 @@ const runNegativeInputs = async (
       continue;
     }
     if (negative.label === 'unknown-extra-key') {
-      // Advertised JSON Schema declares additionalProperties: false, but plain
-      // z.object routes may strip unknown keys without failing the protocol
-      // call. Other generated negatives still prove rejection paths.
+      unknownExtraKeyAccepted = true;
       continue;
     }
     return failed(`negative input ${negative.label} produced a successful tool result: ${captured(negative.input)}`);
   }
-  return anyRejected
-    ? passed()
-    : failed('no generated negative input caused callTool to fail or return isError');
+  if (!anyRejected) {
+    return failed('no generated negative input caused callTool to fail or return isError');
+  }
+  return unknownExtraKeyAccepted
+    ? passedWithReason(
+      'unknown-extra-key input was accepted (advertised additionalProperties: false, but plain z.object routes may strip unknown keys without protocol failure); other generated negatives still proved rejection paths.',
+    )
+    : passed();
 };
 
 const runCancellation = async (
@@ -644,7 +730,8 @@ const runCancellation = async (
   if (!result.settled.threw) {
     return failed('aborted callTool settled without throwing or rejecting.');
   }
-  const healthy = await callToolResult(client, routeProtocolName(descriptor), { holdMs: 1 }, { cache });
+  const recoveryInput = fixtureInputs(fixture)[0] ?? {};
+  const healthy = await callToolResult(client, routeProtocolName(descriptor), recoveryInput, { cache });
   if (healthy.threw) {
     return failed(`session did not recover: subsequent callTool threw: ${healthy.error instanceof Error ? healthy.error.message : captured(healthy.error)}`);
   }
@@ -654,23 +741,56 @@ const runCancellation = async (
   return passed();
 };
 
-/**
- * Runs the contract matrix against one compiled MCP server at the
- * `mcp-in-memory` proof level. Returns a per-route report; throws one
- * aggregated `AgentTestError` with code `contract-violation` when any check
- * failed (never first-failure-only).
- */
-export const runContractMatrix = async (
-  options: ContractMatrixOptions,
-): Promise<ContractMatrixReport> => {
-  const manifest = options.manifest ?? testManifest();
-  const serverName = resolveServerName(manifest, options.server);
-  const routes = serverRoutes(manifest, serverName);
-  const appRoutes = serverAppRoutes(manifest, serverName);
+const matrixRouteDescriptors = (
+  manifest: AgentBundleTestManifest,
+  serverName: string,
+): readonly TestableRouteDescriptor[] => [
+  ...serverRoutes(manifest, serverName),
+  ...serverAppRoutes(manifest, serverName),
+].sort((left, right) => left.id.localeCompare(right.id));
+
+const finalizeContractMatrixReport = (
+  failures: MatrixFailure[],
+  boundary: MatrixBoundaryCapabilities,
+  provenance: ContractMatrixProvenance,
+  routeReports: Record<string, ContractRouteReport>,
+): ContractMatrixReport => {
+  const report: ContractMatrixReport = Object.freeze({
+    provenance,
+    routes: Object.freeze(routeReports),
+  });
+  if (failures.length === 0) return report;
+
+  const proofLabel = proofLevelLabel(boundary.proofLevel);
+  const details = failures.map((entry) =>
+    `- ${entry.routeId} / ${entry.check}: ${entry.reason} (${proofLabel})`);
+  throw new AgentTestError(
+    'contract-violation',
+    `Contract matrix reported ${String(failures.length)} violation(s) at the ${boundary.proofLevel} proof level.`,
+    {
+      details,
+      recovery: boundary.canLoadRouteModules
+        ? 'Fix the failing route, fixture, or declared resultCompat policy; re-run runContractMatrix.'
+        : 'Fix the failing route or fixture; re-run runPackedContractMatrix.',
+    },
+  );
+};
+
+const executeContractMatrix = async (options: {
+  readonly boundary: MatrixBoundaryCapabilities;
+  readonly client: Client;
+  readonly fixtures: Readonly<Record<string, ContractRouteFixture>>;
+  readonly manifest: AgentBundleTestManifest;
+  readonly provenance: ContractMatrixProvenance;
+  readonly serverName: string;
+}): Promise<ContractMatrixReport> => {
+  const { boundary, client, fixtures, manifest, provenance, serverName } = options;
   const failures: MatrixFailure[] = [];
   const routeReports: Record<string, ContractRouteReport> = {};
+  const moduleSchemaNotApplicable = (): ContractCheckOutcome =>
+    notApplicable(boundary.moduleSchemaNotApplicableReason);
 
-  const unknownFixtureKeys = Object.keys(options.fixtures).filter(
+  const unknownFixtureKeys = Object.keys(fixtures).filter(
     (routeId) => manifest.routes[routeId] === undefined,
   );
   if (unknownFixtureKeys.length > 0) {
@@ -689,14 +809,21 @@ export const runContractMatrix = async (
     }
   }
 
-  await using session = await openInMemoryMcpServer(options);
-  const surface = await listLiveSurface(session.client);
-  const proofLabel = proofLevelLabel(MCP_IN_MEMORY_PROOF_LEVEL);
+  const surface = await listLiveSurface(client);
   const invocationCache = new Map<string, ToolInvocationResult>();
 
-  for (const descriptor of routes) {
+  for (const descriptor of matrixRouteDescriptors(manifest, serverName)) {
+    if (descriptor.kind === 'app' && !boundary.registersAppResources) {
+      routeReports[descriptor.id] = {
+        checks: {
+          [CHECK_SURFACE]: notApplicable('MCP Apps are not registered by the in-memory projection level.'),
+        },
+      };
+      continue;
+    }
+
     const checks: Record<string, ContractCheckOutcome> = {};
-    const fixture = options.fixtures[descriptor.id];
+    const fixture = fixtures[descriptor.id];
 
     checks[CHECK_COVERAGE] = outcomeFromCheck(
       failures,
@@ -711,7 +838,7 @@ export const runContractMatrix = async (
       failures,
       descriptor.id,
       CHECK_SURFACE,
-      checkSurfaceCompleteness(descriptor, surface),
+      checkSurfaceCompleteness(descriptor, surface, manifest, boundary),
     );
 
     if (fixture === undefined) {
@@ -719,47 +846,65 @@ export const runContractMatrix = async (
       continue;
     }
 
-    const module = descriptor.kind === 'tool'
-      ? await loadRouteModule(manifest, descriptor)
-      : undefined;
-
     checks[CHECK_SWEEP] = outcomeFromCheck(
       failures,
       descriptor.id,
       CHECK_SWEEP,
-      await runSweep(session.client, descriptor, fixture, invocationCache),
+      await runSweep(client, descriptor, fixture, manifest, invocationCache),
     );
 
-    if (module !== undefined) {
-      checks[CHECK_SERIALIZED_ROUND_TRIP] = outcomeFromCheck(
-        failures,
-        descriptor.id,
-        CHECK_SERIALIZED_ROUND_TRIP,
-        await runSerializedRoundTrip(session.client, descriptor, fixture, module, invocationCache),
-      );
-      checks[CHECK_COMPAT_PROBE] = outcomeFromCheck(
-        failures,
-        descriptor.id,
-        CHECK_COMPAT_PROBE,
-        await runCompatProbe(session.client, descriptor, fixture, module, invocationCache),
-      );
-      checks[CHECK_VERSION_SKEW] = outcomeFromCheck(
-        failures,
-        descriptor.id,
-        CHECK_VERSION_SKEW,
-        runVersionSkew(descriptor, fixture, module),
-      );
+    if (descriptor.kind === 'tool') {
+      if (boundary.canLoadRouteModules) {
+        const module = await loadRouteModule(manifest, descriptor);
+        checks[CHECK_SERIALIZED_ROUND_TRIP] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_SERIALIZED_ROUND_TRIP,
+          await runSerializedRoundTrip(client, descriptor, fixture, module, invocationCache),
+        );
+        checks[CHECK_COMPAT_PROBE] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_COMPAT_PROBE,
+          await runCompatProbe(client, descriptor, fixture, module, invocationCache),
+        );
+        checks[CHECK_VERSION_SKEW] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_VERSION_SKEW,
+          runVersionSkew(descriptor, fixture, module),
+        );
+      } else {
+        checks[CHECK_SERIALIZED_ROUND_TRIP] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_SERIALIZED_ROUND_TRIP,
+          moduleSchemaNotApplicable(),
+        );
+        checks[CHECK_COMPAT_PROBE] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_COMPAT_PROBE,
+          moduleSchemaNotApplicable(),
+        );
+        checks[CHECK_VERSION_SKEW] = outcomeFromCheck(
+          failures,
+          descriptor.id,
+          CHECK_VERSION_SKEW,
+          moduleSchemaNotApplicable(),
+        );
+      }
       checks[CHECK_NEGATIVE_INPUTS] = outcomeFromCheck(
         failures,
         descriptor.id,
         CHECK_NEGATIVE_INPUTS,
-        await runNegativeInputs(session.client, descriptor, surface),
+        await runNegativeInputs(client, descriptor, surface),
       );
       checks[CHECK_CANCELLATION] = outcomeFromCheck(
         failures,
         descriptor.id,
         CHECK_CANCELLATION,
-        await runCancellation(session.client, descriptor, fixture, invocationCache),
+        await runCancellation(client, descriptor, fixture, invocationCache),
       );
     } else {
       checks[CHECK_SERIALIZED_ROUND_TRIP] = notApplicable('applies to tool routes only.');
@@ -772,31 +917,45 @@ export const runContractMatrix = async (
     routeReports[descriptor.id] = { checks };
   }
 
-  for (const descriptor of appRoutes) {
-    routeReports[descriptor.id] = {
-      checks: {
-        [CHECK_SURFACE]: notApplicable('MCP Apps are not registered by the in-memory projection level.'),
-      },
-    };
-  }
+  return finalizeContractMatrixReport(failures, boundary, provenance, routeReports);
+};
 
-  const report: ContractMatrixReport = Object.freeze({
+/**
+ * Runs the contract matrix against one compiled MCP server at the
+ * `mcp-in-memory` proof level. Returns a per-route report; throws one
+ * aggregated `AgentTestError` with code `contract-violation` when any check
+ * failed (never first-failure-only).
+ */
+export const runContractMatrix = async (
+  options: ContractMatrixOptions,
+): Promise<ContractMatrixReport> => {
+  const manifest = options.manifest ?? testManifest();
+  const serverName = resolveServerName(manifest, options.server);
+  await using session = await openInMemoryMcpServer(options);
+  return await executeContractMatrix({
+    boundary: IN_MEMORY_BOUNDARY,
+    client: session.client,
+    fixtures: options.fixtures,
+    manifest,
     provenance: session.provenance,
-    routes: Object.freeze(routeReports),
+    serverName,
   });
+};
 
-  if (failures.length > 0) {
-    const details = failures.map((entry) =>
-      `- ${entry.routeId} / ${entry.check}: ${entry.reason} (${proofLabel})`);
-    throw new AgentTestError(
-      'contract-violation',
-      `Contract matrix reported ${String(failures.length)} violation(s) at the ${MCP_IN_MEMORY_PROOF_LEVEL} proof level.`,
-      {
-        details,
-        recovery: 'Fix the failing route, fixture, or declared resultCompat policy; re-run runContractMatrix.',
-      },
-    );
-  }
-
-  return report;
+/**
+ * Runs the contract matrix against an already-open packed stdio session.
+ * Never opens or closes the session; stamps the session's own proof level.
+ */
+export const runPackedContractMatrix = async (
+  options: PackedContractMatrixOptions,
+): Promise<ContractMatrixReport> => {
+  const serverName = resolveServerName(options.manifest, options.server);
+  return executeContractMatrix({
+    boundary: packedBoundaryFromSession(options.session),
+    client: options.session.client,
+    fixtures: options.fixtures,
+    manifest: options.manifest,
+    provenance: options.session.provenance,
+    serverName,
+  });
 };

--- a/packages/agent-bundle/src/test/errors.ts
+++ b/packages/agent-bundle/src/test/errors.ts
@@ -4,6 +4,7 @@ import type { RenderedRouteProvenance } from './types.ts';
 export type AgentTestErrorCode =
   | 'assertion-failed'
   | 'command-not-found'
+  | 'contract-violation'
   | 'deleted-source-unverified'
   | 'invalid-input'
   | 'invalid-route-module'

--- a/packages/agent-bundle/src/test/index.ts
+++ b/packages/agent-bundle/src/test/index.ts
@@ -11,8 +11,8 @@
  * | `route-unit` | `renderRoute`, `renderRouteEvents`, `createTargetCapabilityFixture`, `projectTargetCapabilities` | the route component and its document through the real Agent renderer; explicit target-capability projection through the real MCP projector, without transport or host proof |
  * | `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface`, `runContractMatrix` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
  * | `cli-dispatch` | `invokeCli`, `cliJson`, `cliNdjson` | a compiled plain or rendered CLI command dispatched through the routed CLI's own shell, including rendered output modes, in this process |
- * | `packed-stdio` | `openPackedMcpServer` | a built artifact's generated entry running as a real process over stdio |
- * | `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer` | the packed stdio process still runs after project source and configuration are removed and verified absent |
+ * | `packed-stdio` | `openPackedMcpServer`, `runPackedContractMatrix` | a built artifact's generated entry running as a real process over stdio |
+ * | `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer({ deletedSource })`, `runPackedContractMatrix` | the packed stdio process still runs after project source and configuration are removed and verified absent |
  * | `browser-app` | `mountBrowserApp` (`agent-bundle/test/browser`) | production-compiled MCP App HTML mounted over the product bridge in a real browser page |
  * | `host-install` | repository real-host install proof | a built bundle accepted through a real host's public install path in an isolated home, with registration observed by that host |
  *
@@ -84,14 +84,17 @@ export {
 export {
   negativeInputsFromJsonSchema,
   runContractMatrix,
+  runPackedContractMatrix,
 } from './contract.ts';
 export type {
   ContractCheckOutcome,
   ContractCheckStatus,
   ContractMatrixOptions,
+  ContractMatrixProvenance,
   ContractMatrixReport,
   ContractRouteFixture,
   ContractRouteReport,
+  PackedContractMatrixOptions,
   ResultCompatPolicy,
 } from './contract.ts';
 export type {

--- a/packages/agent-bundle/src/test/index.ts
+++ b/packages/agent-bundle/src/test/index.ts
@@ -9,7 +9,7 @@
  * | level | helper | what it proves |
  * | --- | --- | --- |
  * | `route-unit` | `renderRoute`, `renderRouteEvents`, `createTargetCapabilityFixture`, `projectTargetCapabilities` | the route component and its document through the real Agent renderer; explicit target-capability projection through the real MCP projector, without transport or host proof |
- * | `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
+ * | `mcp-in-memory` | `openInMemoryMcpServer`, `invokeMcpTool`, `readMcpResource`, `getMcpPrompt`, `listMcpSurface`, `runContractMatrix` | the real generated MCP server's protocol contract, over the SDK's in-memory transport |
  * | `cli-dispatch` | `invokeCli`, `cliJson`, `cliNdjson` | a compiled plain or rendered CLI command dispatched through the routed CLI's own shell, including rendered output modes, in this process |
  * | `packed-stdio` | `openPackedMcpServer` | a built artifact's generated entry running as a real process over stdio |
  * | `packed-deleted-source` | `removeProjectSource`, `openPackedMcpServer` | the packed stdio process still runs after project source and configuration are removed and verified absent |
@@ -81,6 +81,19 @@ export {
   openInMemoryMcpServer,
   readMcpResource,
 } from './mcp.ts';
+export {
+  negativeInputsFromJsonSchema,
+  runContractMatrix,
+} from './contract.ts';
+export type {
+  ContractCheckOutcome,
+  ContractCheckStatus,
+  ContractMatrixOptions,
+  ContractMatrixReport,
+  ContractRouteFixture,
+  ContractRouteReport,
+  ResultCompatPolicy,
+} from './contract.ts';
 export type {
   InMemoryMcpSession,
   InMemoryMcpSessionOptions,

--- a/packages/agent-bundle/tests/contract-negative-inputs.test.ts
+++ b/packages/agent-bundle/tests/contract-negative-inputs.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from '@rstest/core';
+
+import { negativeInputsFromJsonSchema } from '../src/test/contract.ts';
+
+it('derives unknown-key, missing-required, and wrong-type negatives from a top-level object schema', () => {
+  const negatives = negativeInputsFromJsonSchema({
+    additionalProperties: false,
+    properties: {
+      count: { type: 'number' },
+      enabled: { type: 'boolean' },
+      note: { type: 'string' },
+    },
+    required: ['note'],
+    type: 'object',
+  });
+
+  expect(negatives).toEqual([
+    { input: { __agentBundleContractNegative: true }, label: 'unknown-extra-key' },
+    { input: {}, label: 'missing-required:note' },
+    { input: { count: 'not-a-number', enabled: true, note: 'value' }, label: 'wrong-type:count' },
+    { input: { count: 1, enabled: 'not-a-boolean', note: 'value' }, label: 'wrong-type:enabled' },
+    { input: { count: 1, enabled: true, note: 0 }, label: 'wrong-type:note' },
+  ]);
+});
+
+it('returns undefined when the advertised schema has no top-level object structure', () => {
+  expect(negativeInputsFromJsonSchema({ type: 'string' })).toBeUndefined();
+  expect(negativeInputsFromJsonSchema({ properties: {}, type: 'array' })).toBeUndefined();
+  expect(negativeInputsFromJsonSchema({ type: 'object' })).toBeUndefined();
+});
+
+it('derives only an unknown-key negative for an object schema with no properties', () => {
+  expect(negativeInputsFromJsonSchema({
+    additionalProperties: false,
+    properties: {},
+    type: 'object',
+  })).toEqual([
+    { input: { __agentBundleContractNegative: true }, label: 'unknown-extra-key' },
+  ]);
+});

--- a/packages/agent-bundle/tests/packed-stdio-projection.test.ts
+++ b/packages/agent-bundle/tests/packed-stdio-projection.test.ts
@@ -107,7 +107,10 @@ it('serves compiled routes and durable state across packed process restarts', as
         'echo',
         'journal',
         'publish-notice',
+        'strict-report',
+        'ticket',
         'unavailable',
+        'wait',
       ]);
       const resources = await firstSession.client.listResources();
       expect(resources.resources).toEqual(expect.arrayContaining([

--- a/packages/agent-bundle/tests/packed-stdio-projection.test.ts
+++ b/packages/agent-bundle/tests/packed-stdio-projection.test.ts
@@ -7,7 +7,10 @@ import { promisify } from 'node:util';
 import { expect, it } from '@rstest/core';
 
 import { requestEventRuntime } from '../src/events/ipc.ts';
+import { compileTestManifest } from '../src/test/manifest.ts';
+import { runPackedContractMatrix } from '../src/test/contract.ts';
 import { openPackedMcpServer, removeProjectSource } from '../src/test/packed.ts';
+import { routeHarnessPackedContractFixtures } from './support/contract-matrix-fixtures.ts';
 import { cachedNpmInstallArguments, installedEnvironment, sharedPackedTarball } from './support/shared-pack.ts';
 
 const execFile = promisify(executeFile);
@@ -87,6 +90,7 @@ it('serves compiled routes and durable state across packed process restarts', as
     expect(workerSource).toContain('createSqliteStateDriver');
     expect(workerSource).toContain('AGENT_BUNDLE_PLUGIN_ROOT');
     expect(workerSource).toMatch(/new URL\(["']\.\.["'], import\.meta\.url\)/u);
+    const harnessManifest = await compileTestManifest({ root: project });
     const deletedSource = await removeProjectSource({ projectRoot: project });
 
     const firstSession = await openPackedMcpServer({
@@ -117,6 +121,35 @@ it('serves compiled routes and durable state across packed process restarts', as
         expect.objectContaining({ mimeType: 'text/markdown', uri: 'harness://notes' }),
         expect.objectContaining({ mimeType: 'text/html;profile=mcp-app', uri: 'ui://harness/panel' }),
       ]));
+
+      const matrixReport = await runPackedContractMatrix({
+        fixtures: routeHarnessPackedContractFixtures(),
+        manifest: harnessManifest,
+        server: 'harness',
+        session: firstSession,
+      });
+      expect(matrixReport.provenance.proofLevel).toBe('packed-deleted-source');
+      expect(matrixReport.routes['app:harness/panel']?.checks['surface-completeness']).toEqual({
+        status: 'passed',
+      });
+      for (const routeId of [
+        'tool:harness/echo',
+        'tool:harness/ticket',
+        'tool:harness/strict-report',
+      ] as const) {
+        expect(matrixReport.routes[routeId]?.checks['serialized-round-trip']).toEqual({
+          reason: expect.stringContaining('packed sessions cannot load project route modules'),
+          status: 'not-applicable',
+        });
+        expect(matrixReport.routes[routeId]?.checks['compat-probe']).toEqual({
+          reason: expect.stringContaining('packed sessions cannot load project route modules'),
+          status: 'not-applicable',
+        });
+        expect(matrixReport.routes[routeId]?.checks['version-skew']).toEqual({
+          reason: expect.stringContaining('packed sessions cannot load project route modules'),
+          status: 'not-applicable',
+        });
+      }
 
       await expect(firstSession.client.callTool({ arguments: { message: 'packed' }, name: 'echo' }))
         .resolves.toMatchObject({

--- a/packages/agent-bundle/tests/projection/contract-matrix.test.ts
+++ b/packages/agent-bundle/tests/projection/contract-matrix.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from '@rstest/core';
+import { createSqliteStateDriver } from '@agent-bundle/runtime/state/sqlite';
+
+import stateDefinition from '../../fixtures/route-harness/src/state.ts';
+import { AgentTestError } from '../../src/test/errors.ts';
+import { MCP_IN_MEMORY_PROOF_LEVEL, proofLevelLabel } from '../../src/test/manifest.ts';
+import {
+  runContractMatrix,
+  type ContractMatrixOptions,
+  type ContractRouteFixture,
+} from '../../src/test/contract.ts';
+
+const proofLabel = proofLevelLabel(MCP_IN_MEMORY_PROOF_LEVEL);
+
+const baseFixtures = (): Record<string, ContractRouteFixture> => ({
+  'prompt:harness/summarize': { input: { note: 'chapter one' } },
+  'resource:harness/notes': {},
+  'tool:harness/catalog': { input: { genre: 'mystery' }, resultCompat: 'additive' },
+  'tool:harness/echo': { input: { message: 'contract matrix' }, resultCompat: 'additive' },
+  'tool:harness/journal': { input: { note: 'matrix proof' }, resultCompat: 'closed' },
+  'tool:harness/publish-notice': {
+    input: { message: 'matrix notice', recipientSession: 'matrix-session' },
+    resultCompat: 'closed',
+  },
+  'tool:harness/strict-report': { input: { reportId: 'closed-1' }, resultCompat: 'closed' },
+  'tool:harness/ticket': {
+    input: { status: 'completed' },
+    inputs: [{ status: 'pending' }, { includeDiagnostics: true, status: 'running' }],
+    previousResults: [{ status: 'completed' }],
+    resultCompat: 'additive',
+  },
+  'tool:harness/unavailable': { resultCompat: 'additive' },
+  'tool:harness/wait': {
+    cancellation: { abortAfterMs: 50, input: { holdMs: 5000 } },
+    input: { holdMs: 1 },
+    resultCompat: 'additive',
+  },
+});
+
+const withStatefulMatrix = async <T>(
+  fixtures: Record<string, ContractRouteFixture>,
+  body: (options: ContractMatrixOptions) => Promise<T>,
+): Promise<T> => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-bundle-contract-matrix-'));
+  try {
+    return await body({
+      fixtures,
+      state: {
+        definition: stateDefinition,
+        driver: createSqliteStateDriver({ root }),
+      },
+    } as unknown as ContractMatrixOptions);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+};
+
+describe('the generated-plugin contract matrix', () => {
+  it('passes every check for the route-harness server at mcp-in-memory', async () => {
+    const report = await withStatefulMatrix(baseFixtures(), (options) => runContractMatrix(options));
+
+    expect(report.provenance.proofLevel).toBe('mcp-in-memory');
+    expect(report.routes['tool:harness/wait']?.checks.cancellation).toEqual({ status: 'passed' });
+    expect(report.routes['tool:harness/ticket']?.checks['version-skew']).toEqual({ status: 'passed' });
+    expect(report.routes['app:harness/panel']?.checks['surface-completeness']).toEqual({
+      reason: 'MCP Apps are not registered by the in-memory projection level.',
+      status: 'not-applicable',
+    });
+    expect(report.routes['tool:harness/unavailable']?.checks.sweep).toEqual({
+      reason: 'Invocation returned isError; sweep proves successful invocation paths only.',
+      status: 'not-applicable',
+    });
+  }, 30_000);
+
+  it('aggregates missing route coverage with the proof-level label', async () => {
+    const fixtures = { ...baseFixtures() };
+    delete fixtures['tool:harness/echo'];
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/echo');
+    expect((error as AgentTestError).message).toContain('coverage');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+
+  it('aggregates unknown fixture keys with the proof-level label', async () => {
+    const fixtures = {
+      ...baseFixtures(),
+      'tool:harness/missing-route': { input: {} },
+    };
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/missing-route');
+    expect((error as AgentTestError).message).toContain('coverage');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+
+  it('aggregates additive declared on a closed schema with the proof-level label', async () => {
+    const fixtures = {
+      ...baseFixtures(),
+      'tool:harness/strict-report': { input: {}, resultCompat: 'additive' as const },
+    };
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/strict-report');
+    expect((error as AgentTestError).message).toContain('compat-probe');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+
+  it('aggregates closed declared on an additive schema with the proof-level label', async () => {
+    const fixtures = {
+      ...baseFixtures(),
+      'tool:harness/ticket': { input: { status: 'completed' }, resultCompat: 'closed' as const },
+    };
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/ticket');
+    expect((error as AgentTestError).message).toContain('compat-probe');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+
+  it('aggregates previousResults schema violations with the proof-level label', async () => {
+    const fixtures = {
+      ...baseFixtures(),
+      'tool:harness/ticket': {
+        input: { status: 'completed' },
+        previousResults: [{ status: 'not-a-valid-status' }],
+        resultCompat: 'additive' as const,
+      },
+    };
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/ticket');
+    expect((error as AgentTestError).message).toContain('version-skew');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+
+  it('aggregates missing resultCompat on a tool with the proof-level label', async () => {
+    const fixtures = {
+      ...baseFixtures(),
+      'tool:harness/echo': { input: { message: 'no policy' } },
+    };
+
+    const error = await withStatefulMatrix(fixtures, (options) =>
+      runContractMatrix(options).catch((thrown: unknown) => thrown));
+
+    expect(error).toBeInstanceOf(AgentTestError);
+    expect((error as AgentTestError).code).toBe('contract-violation');
+    expect((error as AgentTestError).message).toContain('tool:harness/echo');
+    expect((error as AgentTestError).message).toContain('compat-probe');
+    expect((error as AgentTestError).message).toContain(proofLabel);
+  }, 30_000);
+});

--- a/packages/agent-bundle/tests/projection/contract-matrix.test.ts
+++ b/packages/agent-bundle/tests/projection/contract-matrix.test.ts
@@ -8,41 +8,13 @@ import { createSqliteStateDriver } from '@agent-bundle/runtime/state/sqlite';
 import stateDefinition from '../../fixtures/route-harness/src/state.ts';
 import { AgentTestError } from '../../src/test/errors.ts';
 import { MCP_IN_MEMORY_PROOF_LEVEL, proofLevelLabel } from '../../src/test/manifest.ts';
-import {
-  runContractMatrix,
-  type ContractMatrixOptions,
-  type ContractRouteFixture,
-} from '../../src/test/contract.ts';
+import { runContractMatrix, type ContractMatrixOptions } from '../../src/test/contract.ts';
+import { routeHarnessContractFixtures } from '../support/contract-matrix-fixtures.ts';
 
 const proofLabel = proofLevelLabel(MCP_IN_MEMORY_PROOF_LEVEL);
 
-const baseFixtures = (): Record<string, ContractRouteFixture> => ({
-  'prompt:harness/summarize': { input: { note: 'chapter one' } },
-  'resource:harness/notes': {},
-  'tool:harness/catalog': { input: { genre: 'mystery' }, resultCompat: 'additive' },
-  'tool:harness/echo': { input: { message: 'contract matrix' }, resultCompat: 'additive' },
-  'tool:harness/journal': { input: { note: 'matrix proof' }, resultCompat: 'closed' },
-  'tool:harness/publish-notice': {
-    input: { message: 'matrix notice', recipientSession: 'matrix-session' },
-    resultCompat: 'closed',
-  },
-  'tool:harness/strict-report': { input: { reportId: 'closed-1' }, resultCompat: 'closed' },
-  'tool:harness/ticket': {
-    input: { status: 'completed' },
-    inputs: [{ status: 'pending' }, { includeDiagnostics: true, status: 'running' }],
-    previousResults: [{ status: 'completed' }],
-    resultCompat: 'additive',
-  },
-  'tool:harness/unavailable': { resultCompat: 'additive' },
-  'tool:harness/wait': {
-    cancellation: { abortAfterMs: 50, input: { holdMs: 5000 } },
-    input: { holdMs: 1 },
-    resultCompat: 'additive',
-  },
-});
-
 const withStatefulMatrix = async <T>(
-  fixtures: Record<string, ContractRouteFixture>,
+  fixtures: ContractMatrixOptions['fixtures'],
   body: (options: ContractMatrixOptions) => Promise<T>,
 ): Promise<T> => {
   const root = await mkdtemp(join(tmpdir(), 'agent-bundle-contract-matrix-'));
@@ -61,7 +33,8 @@ const withStatefulMatrix = async <T>(
 
 describe('the generated-plugin contract matrix', () => {
   it('passes every check for the route-harness server at mcp-in-memory', async () => {
-    const report = await withStatefulMatrix(baseFixtures(), (options) => runContractMatrix(options));
+    const report = await withStatefulMatrix(routeHarnessContractFixtures(), (options) =>
+      runContractMatrix(options));
 
     expect(report.provenance.proofLevel).toBe('mcp-in-memory');
     expect(report.routes['tool:harness/wait']?.checks.cancellation).toEqual({ status: 'passed' });
@@ -77,7 +50,7 @@ describe('the generated-plugin contract matrix', () => {
   }, 30_000);
 
   it('aggregates missing route coverage with the proof-level label', async () => {
-    const fixtures = { ...baseFixtures() };
+    const fixtures = { ...routeHarnessContractFixtures() };
     delete fixtures['tool:harness/echo'];
 
     const error = await withStatefulMatrix(fixtures, (options) =>
@@ -92,7 +65,7 @@ describe('the generated-plugin contract matrix', () => {
 
   it('aggregates unknown fixture keys with the proof-level label', async () => {
     const fixtures = {
-      ...baseFixtures(),
+      ...routeHarnessContractFixtures(),
       'tool:harness/missing-route': { input: {} },
     };
 
@@ -108,7 +81,7 @@ describe('the generated-plugin contract matrix', () => {
 
   it('aggregates additive declared on a closed schema with the proof-level label', async () => {
     const fixtures = {
-      ...baseFixtures(),
+      ...routeHarnessContractFixtures(),
       'tool:harness/strict-report': { input: {}, resultCompat: 'additive' as const },
     };
 
@@ -124,7 +97,7 @@ describe('the generated-plugin contract matrix', () => {
 
   it('aggregates closed declared on an additive schema with the proof-level label', async () => {
     const fixtures = {
-      ...baseFixtures(),
+      ...routeHarnessContractFixtures(),
       'tool:harness/ticket': { input: { status: 'completed' }, resultCompat: 'closed' as const },
     };
 
@@ -140,7 +113,7 @@ describe('the generated-plugin contract matrix', () => {
 
   it('aggregates previousResults schema violations with the proof-level label', async () => {
     const fixtures = {
-      ...baseFixtures(),
+      ...routeHarnessContractFixtures(),
       'tool:harness/ticket': {
         input: { status: 'completed' },
         previousResults: [{ status: 'not-a-valid-status' }],
@@ -160,7 +133,7 @@ describe('the generated-plugin contract matrix', () => {
 
   it('aggregates missing resultCompat on a tool with the proof-level label', async () => {
     const fixtures = {
-      ...baseFixtures(),
+      ...routeHarnessContractFixtures(),
       'tool:harness/echo': { input: { message: 'no policy' } },
     };
 

--- a/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
+++ b/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
@@ -30,7 +30,7 @@ describe('the in-memory MCP projection level', () => {
   it('registers every compiled route kind on the real generated server', async () => {
     const surface = await listMcpSurface();
 
-    expect(surface.tools).toEqual(['catalog', 'echo', 'journal', 'publish-notice', 'unavailable']);
+    expect(surface.tools).toEqual(['catalog', 'echo', 'journal', 'publish-notice', 'strict-report', 'ticket', 'unavailable', 'wait']);
     expect(surface.prompts).toEqual(['summarize']);
     expect(surface.resources).toEqual(['harness://notes']);
     expect(surface.provenance).toMatchObject({
@@ -42,7 +42,10 @@ describe('the in-memory MCP projection level', () => {
         'tool:harness/echo',
         'tool:harness/journal',
         'tool:harness/publish-notice',
+        'tool:harness/strict-report',
+        'tool:harness/ticket',
         'tool:harness/unavailable',
+        'tool:harness/wait',
       ],
       serverName: 'harness',
     });

--- a/packages/agent-bundle/tests/support/contract-matrix-fixtures.ts
+++ b/packages/agent-bundle/tests/support/contract-matrix-fixtures.ts
@@ -1,0 +1,37 @@
+import type { ContractRouteFixture } from '../../src/test/contract.ts';
+
+/** Shared route-harness fixtures for projection-level contract matrix tests. */
+export const routeHarnessContractFixtures = (): Record<string, ContractRouteFixture> => ({
+  'prompt:harness/summarize': { input: { note: 'chapter one' } },
+  'resource:harness/notes': {},
+  'tool:harness/catalog': { input: { genre: 'mystery' }, resultCompat: 'additive' },
+  'tool:harness/echo': { input: { message: 'contract matrix' }, resultCompat: 'additive' },
+  'tool:harness/journal': { input: { note: 'matrix proof' }, resultCompat: 'closed' },
+  'tool:harness/publish-notice': {
+    input: { message: 'matrix notice', recipientSession: 'matrix-session' },
+    resultCompat: 'closed',
+  },
+  'tool:harness/strict-report': { input: { reportId: 'closed-1' }, resultCompat: 'closed' },
+  'tool:harness/ticket': {
+    input: { status: 'completed' },
+    inputs: [{ status: 'pending' }, { includeDiagnostics: true, status: 'running' }],
+    previousResults: [{ status: 'completed' }],
+    resultCompat: 'additive',
+  },
+  'tool:harness/unavailable': { resultCompat: 'additive' },
+  'tool:harness/wait': {
+    cancellation: { abortAfterMs: 50, input: { holdMs: 5000 } },
+    input: { holdMs: 1 },
+    resultCompat: 'additive',
+  },
+});
+
+/**
+ * Packed-journey fixtures: journal sweep is read-only (`{}`) so durable-state
+ * assertions in `packed-stdio-projection.test.ts` stay intact.
+ */
+export const routeHarnessPackedContractFixtures = (): Record<string, ContractRouteFixture> => ({
+  ...routeHarnessContractFixtures(),
+  'app:harness/panel': {},
+  'tool:harness/journal': { resultCompat: 'closed' },
+});

--- a/packages/agent-bundle/tests/test-harness-manifest.test.ts
+++ b/packages/agent-bundle/tests/test-harness-manifest.test.ts
@@ -74,7 +74,10 @@ describe('the compiled test manifest', () => {
       'tool:harness/echo',
       'tool:harness/journal',
       'tool:harness/publish-notice',
+      'tool:harness/strict-report',
+      'tool:harness/ticket',
       'tool:harness/unavailable',
+      'tool:harness/wait',
     ]);
     expect(manifest.diagnostics).toEqual([]);
     expect(manifest.routes['tool:harness/echo']).toEqual({


### PR DESCRIPTION
## Summary

Stage 1 of #218, per the scope split posted on #218/#133: the runtime half of conformance — checks that require a live protocol exchange, at the two boundaries whose substrate is complete. Stages 2–4 (stateful lifecycle replay, installed-host smoke with the version quadruple, Workbench dev-epoch integration) stay on the issue.

### `runContractMatrix` (`mcp-in-memory`) and `runPackedContractMatrix` (`packed-stdio` / `packed-deleted-source`), one shared implementation

Both entry points run framework-owned checks with project-supplied fixtures only; boundary differences are explicit capability flags, never forked check logic, and every failure prints the proof-level label it actually carried.

| check | mcp-in-memory | packed |
| --- | --- | --- |
| surface completeness vs compiled manifest | ✅ (Apps honestly not-applicable — not registered at this level) | ✅ incl. MCP App resource URIs |
| fixture coverage (every compiled route) | ✅ | ✅ |
| invocation sweep (tools per input, resources, prompts) | ✅ | ✅ incl. App resource reads |
| serialized round-trip: `JSON.parse(JSON.stringify(structuredContent))` through the route's own `resultSchema` | ✅ | not-applicable — packed sessions cannot load project route modules (source may be deleted and verified absent); the packed server's own bundled `resultSchema` validation is the evidence |
| declared `resultCompat` (`additive`/`closed`) probe: unknown-key injection into the serialized payload — the cargo-conductor `unrecognized_keys` drift is a hard failure under `additive`, acceptance is a hard failure under `closed` | ✅ (required for every tool route) | not-applicable (same reason) |
| version-skew `previousResults`: previous-server payloads (incl. absent new optional fields) must parse under the current schema | ✅ | not-applicable (same reason) |
| negative inputs generated from the ADVERTISED `listTools` JSON Schema (unknown key, each missing required, wrong type per property) | ✅ | ✅ |
| mid-flight cancellation: abort settles bounded, session stays usable | ✅ | ✅ |

Documented tolerance: advertised input schemas declare `additionalProperties: false`, but plain `z.object` routes may strip unknown keys without protocol failure; that acceptance is surfaced in the passed outcome's reason and never suppresses the other negative cases.

### Fixtures and journeys

- route-harness gains `ticket` (loose schema with optional `execArgv`/`diagnostics`/`tail` — the #218 acceptance shape), `strict-report` (`z.strictObject`), and `wait` (signal-aware, bounded, for deterministic cancellation).
- The packed matrix rides the repository's single packed journey (#103 cost rule): compiled manifest captured before source removal, matrix run inside the existing deleted-source session, no new pack/install/build/spawn, journal sweep read-only so the durable-restart assertions stay byte-for-byte.
- Failing matrix throws one aggregated `AgentTestError` (`contract-violation`) naming every route, check, and proof-level label — never first-failure-only.

Changeset: minor, `agent-bundle`.

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test:unit` — all passed
- [x] `pnpm test:projection` — all passed (matrix pass + 6 honest-failure meta-cases)
- [x] `pnpm test:route-unit` — all passed
- [x] packed single journey (`run-packed-tests.mjs packages/agent-bundle/tests/packed-stdio-projection.test.ts`) — passed with the packed matrix assertions
- [x] `public-api-packed.test.ts` verified failing identically on a clean `origin/main` checkout (`ERR_MODULE_NOT_FOUND: @agent-bundle/runtime` in the packed consumer) — pre-existing, not introduced here

## Tracking

- Advances #218 (stage 1); stages 2–4 remain. Scope split vs #133 posted on both issues.