### PR TITLE
feat(runtime): thread transport-observed identity into generated MCP tool scopes (#223)

### DIFF
--- a/.changeset/warm-clients-observe.md
+++ b/.changeset/warm-clients-observe.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': minor
+---
+
+Generated MCP tool, resource, and prompt request scopes now observe native client, session, and authenticated actor identity alongside a derived process workspace, then forward those axes into the Flight worker while preserving typed unavailability when a transport omits them.

--- a/docs/entry-conventions.md
+++ b/docs/entry-conventions.md
@@ -139,8 +139,13 @@ Conventional route components receive only their surface props, such as
 invocation plus `host`, `session`, `actor`, and `workspace` identity axes.
 Each identity axis is `Observed`: transports publish an `available` value and
 source when they know it, or `unavailable` with a typed reason when they do
-not. Generated event scopes currently mount no actor principal, so event
-routes observe actor as unavailable rather than receiving a fabricated value.
+not. Generated MCP request scopes observe the negotiated client identity as a
+native host, derive workspace from the server process working directory, and
+use native transport session and HTTP authentication data when supplied. Bare
+stdio supplies neither a session id nor HTTP actor authentication, so those
+axes remain honestly unavailable. Generated event scopes currently mount no
+actor principal, so event routes observe actor as unavailable rather than
+receiving a fabricated value.
 
 Handlers authored with `defineOperation` receive the same handle as optional
 `context.request` in the second `execute` argument:

--- a/packages/agent-bundle/src/mcp-server-runtime.ts
+++ b/packages/agent-bundle/src/mcp-server-runtime.ts
@@ -33,10 +33,12 @@ import { canonicalAgentEvents, type CanonicalAgentEvent } from './routes/public.
 import type {
   AgentActorIdentity,
   AgentDocument,
+  AgentHostIdentity,
   AgentProgressReporter,
   AgentRenderDispatch,
   AgentRenderDispatcher,
   AgentSessionIdentity,
+  AgentWorkspaceIdentity,
   McpProgressNotificationParams,
   McpProgressToken,
   Observed,
@@ -94,17 +96,26 @@ export interface RenderedGeneratedRoute {
 
 interface GeneratedRouteIdentity {
   readonly actor?: Observed<AgentActorIdentity>;
+  readonly host?: Observed<AgentHostIdentity>;
   readonly session?: Observed<AgentSessionIdentity>;
+  readonly workspace: Observed<AgentWorkspaceIdentity>;
 }
 
 /** Identity the server derives from the transport's own request context. */
-const requestIdentity = (context: GeneratedRouteRequestContext): GeneratedRouteIdentity => ({
+const requestIdentity = (
+  context: GeneratedRouteRequestContext,
+  clientName: string | undefined,
+): GeneratedRouteIdentity => ({
   ...(context.http?.authInfo?.clientId === undefined
     ? {}
     : { actor: available({ id: context.http.authInfo.clientId }, 'native') }),
+  ...(typeof clientName === 'string' && clientName.trim() !== ''
+    ? { host: available({ name: clientName }, 'native') }
+    : {}),
   ...(typeof context.sessionId === 'string' && context.sessionId.trim() !== ''
     ? { session: available({ sessionId: context.sessionId }, 'native') }
     : {}),
+  workspace: available({ root: process.cwd() }, 'derived'),
 });
 
 /**
@@ -135,6 +146,8 @@ const projectorOptions = (context: GeneratedRouteRequestContext): {
  * Renders one route inside a request scope, projects its render-event stream
  * into an MCP result, and validates the document value against the route's
  * own `resultSchema` — exactly what the generated server does per request.
+ * The host scope establishes the full transport-observed identity and the
+ * warm host's `agent()` probe forwards it into the Flight worker.
  */
 export const renderGeneratedRoute = async (
   dispatcher: AgentRenderDispatcher,
@@ -142,8 +155,9 @@ export const renderGeneratedRoute = async (
   route: GeneratedRouteRecord,
   input: unknown,
   context: GeneratedRouteRequestContext,
+  identity?: { readonly clientName?: string },
 ): Promise<RenderedGeneratedRoute> => runAgentRequest({
-  ...requestIdentity(context),
+  ...requestIdentity(context, identity?.clientName),
   invocation: { artifactEpoch, kind: 'tool', operationId: route.id, surface: route.name },
   signal: context.mcpReq.signal,
 }, async () => {
@@ -183,7 +197,15 @@ export const registerGeneratedRoutes = (
           inputSchema: route.module.inputSchema,
           outputSchema: route.module.resultSchema,
         } as never, (async (input: unknown, context: GeneratedRouteRequestContext) => {
-          const rendered = await renderGeneratedRoute(dispatcher, artifactEpoch, route, input, context);
+          const clientName = server.server.getClientVersion()?.name;
+          const rendered = await renderGeneratedRoute(
+            dispatcher,
+            artifactEpoch,
+            route,
+            input,
+            context,
+            { clientName },
+          );
           return attachMcpStructuredContent(rendered.toolResult, rendered.result);
         }) as never);
         break;
@@ -196,8 +218,17 @@ export const registerGeneratedRoutes = (
           route.name,
           uri,
           selectedConfig(route.config, ['_meta', 'description', 'icons', 'mimeType', 'title']) as never,
-          (async (resourceUri: URL, context: GeneratedRouteRequestContext) =>
-            (await renderGeneratedRoute(dispatcher, artifactEpoch, route, { uri: resourceUri.href }, context)).result) as never,
+          (async (resourceUri: URL, context: GeneratedRouteRequestContext) => {
+            const clientName = server.server.getClientVersion()?.name;
+            return (await renderGeneratedRoute(
+              dispatcher,
+              artifactEpoch,
+              route,
+              { uri: resourceUri.href },
+              context,
+              { clientName },
+            )).result;
+          }) as never,
         );
         break;
       }
@@ -205,8 +236,17 @@ export const registerGeneratedRoutes = (
         server.registerPrompt(route.name, {
           ...selectedConfig(route.config, ['_meta', 'description', 'icons', 'title']),
           argsSchema: route.module.inputSchema,
-        } as never, (async (input: unknown, context: GeneratedRouteRequestContext) =>
-          (await renderGeneratedRoute(dispatcher, artifactEpoch, route, input, context)).result) as never);
+        } as never, (async (input: unknown, context: GeneratedRouteRequestContext) => {
+          const clientName = server.server.getClientVersion()?.name;
+          return (await renderGeneratedRoute(
+            dispatcher,
+            artifactEpoch,
+            route,
+            input,
+            context,
+            { clientName },
+          )).result;
+        }) as never);
         break;
       default: {
         const unreachable: never = route.kind;

--- a/packages/agent-bundle/src/test/mcp.ts
+++ b/packages/agent-bundle/src/test/mcp.ts
@@ -148,6 +148,7 @@ interface ServerRuntime {
 }
 
 interface Renderer {
+  readonly agent: typeof import('@agent-bundle/runtime').agent;
   readonly createElement: typeof import('react').createElement;
   readonly createGeneratedRuntimeState: typeof createGeneratedRuntimeState;
   readonly createWarmFlightHost: typeof import('@agent-bundle/runtime').createWarmFlightHost;
@@ -185,6 +186,7 @@ const loadDependencies = async (): Promise<ServerRuntime & Renderer & Sdk> => {
     return {
       Client: client.Client,
       InMemoryTransport: client.InMemoryTransport,
+      agent: runtime.agent,
       createElement: react.createElement,
       createGeneratedRuntimeState: mount.createGeneratedRuntimeState,
       createGeneratedRouteMcpServer: serverRuntime.createGeneratedRouteMcpServer,
@@ -306,6 +308,7 @@ export const openInMemoryMcpServer = async <
     artifactEpoch,
     host: {
       execute: async (request): Promise<ReadableStream<Uint8Array>> => {
+        const transport = await dependencies.agent();
         // The generated server dispatches every MCP route kind as a tool
         // invocation, so the operation id is the compiled route id.
         const props = request.invocation.props as { readonly input?: unknown; readonly operationId?: string };
@@ -318,6 +321,12 @@ export const openInMemoryMcpServer = async <
         const bindings = await runtimeState?.requestBindings({ signal: request.signal });
         try {
           return streamOf(await dependencies.runAgentRequest({
+            // Mirror the Flight worker boundary while allowing the documented
+            // harness context seam to override forwarded transport identity.
+            actor: transport.actor,
+            host: transport.host,
+            session: transport.session,
+            workspace: transport.workspace,
             ...context,
             invocation: {
               kind: 'tool' as const,

--- a/packages/agent-bundle/tests/generated-route-server.test.ts
+++ b/packages/agent-bundle/tests/generated-route-server.test.ts
@@ -169,9 +169,17 @@ it('lists and calls a generated filesystem tool through final-only Flight', { re
     });
     expect(inspected.structuredContent).toMatchObject({
       actor: { reason: 'not-provided', state: 'unavailable' },
-      host: { reason: 'not-provided', state: 'unavailable' },
+      host: {
+        source: 'native',
+        state: 'available',
+        value: { name: 'generated-route-test' },
+      },
       session: { reason: 'not-provided', state: 'unavailable' },
-      workspace: { reason: 'not-provided', state: 'unavailable' },
+      workspace: {
+        source: 'derived',
+        state: 'available',
+        value: { root: process.cwd() },
+      },
     });
     const resources = await client.listResources();
     expect(resources).toMatchObject({ resources: [

--- a/packages/agent-bundle/tests/packed-stdio-projection.test.ts
+++ b/packages/agent-bundle/tests/packed-stdio-projection.test.ts
@@ -111,6 +111,7 @@ it('serves compiled routes and durable state across packed process restarts', as
         'context',
         'echo',
         'journal',
+        'mutation-probe',
         'publish-notice',
         'strict-report',
         'ticket',

--- a/packages/agent-bundle/tests/packed-stdio-projection.test.ts
+++ b/packages/agent-bundle/tests/packed-stdio-projection.test.ts
@@ -108,6 +108,7 @@ it('serves compiled routes and durable state across packed process restarts', as
       const tools = await firstSession.client.listTools();
       expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
         'catalog',
+        'context',
         'echo',
         'journal',
         'publish-notice',
@@ -155,6 +156,23 @@ it('serves compiled routes and durable state across packed process restarts', as
         .resolves.toMatchObject({
           content: [{ text: '# Echo\n\npacked', type: 'text' }, { text: expect.stringContaining('workspace:'), type: 'text' }],
           structuredContent: { message: 'packed', operationId: 'tool:harness/echo' },
+        });
+      await expect(firstSession.client.callTool({ arguments: {}, name: 'context' }))
+        .resolves.toMatchObject({
+          structuredContent: {
+            actor: { reason: 'not-provided', state: 'unavailable' },
+            host: {
+              source: 'native',
+              state: 'available',
+              value: { name: 'agent-bundle-packed-proof' },
+            },
+            session: { reason: 'not-provided', state: 'unavailable' },
+            workspace: {
+              source: 'derived',
+              state: 'available',
+              value: { root: project },
+            },
+          },
         });
       await expect(firstSession.client.callTool({ arguments: { genre: 'mystery' }, name: 'catalog' }))
         .resolves.toMatchObject({

--- a/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
+++ b/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
@@ -72,14 +72,24 @@ describe('the in-memory MCP projection level', () => {
     expect(invocation.provenance.proofLevel).toBe('mcp-in-memory');
   });
 
-  it('reports the identity axes the in-memory projection actually installs', async () => {
-    const invocation = await invokeMcpTool('context');
+  it('reports transport identity without accepting lookalike input fields', async () => {
+    const invocation = await invokeMcpTool('context', {
+      input: { host: 'spoofed-host', session: 'spoofed-session' },
+    });
 
     expect(invocation.structuredContent).toEqual({
       actor: { reason: 'not-provided', state: 'unavailable' },
-      host: { reason: 'not-provided', state: 'unavailable' },
+      host: {
+        source: 'native',
+        state: 'available',
+        value: { name: 'agent-bundle-in-memory-projection' },
+      },
       session: { reason: 'not-provided', state: 'unavailable' },
-      workspace: { reason: 'not-provided', state: 'unavailable' },
+      workspace: {
+        source: 'derived',
+        state: 'available',
+        value: { root: process.cwd() },
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

Delivers the remaining #223 transport slice for the generated MCP server: tool, resource, and prompt request scopes now observe the transport-known identity axes and forward them into the Flight worker, so compiled bundles' handlers read `(await agent()).host/.session/.actor/.workspace` instead of typed-unavailable axes the transport actually knew. Mirrors the rsc-runtime wiring PR #273 landed:

- **host** from the negotiated MCP client identity (`server.server.getClientVersion()?.name`, source `native`), resolved per request after the initialize handshake;
- **session** from the transport's native `sessionId` where one exists (unchanged wiring — bare stdio supplies none, so it stays honestly `unavailable('not-provided')`);
- **actor** from `http.authInfo.clientId` where present (unchanged — stdio has no authInfo, honestly unavailable);
- **workspace** derived from the server process cwd (`available({ root: process.cwd() }, 'derived')`), the established CLI derivation.

No Flight-worker changes: `createFlightWorkerHost` already probes `agent()` and forwards all four axes; the generated worker template already re-installs them. The gap was purely the host-scope installation. The in-memory projection level (`agent-bundle/test`) now mirrors the worker boundary — its in-process stand-in forwards the host-scope axes into the render scope with the documented harness context seam still winning — so `mcp-in-memory` stays faithful to the artifact.

**Observed axes per transport after this change**

| Transport | host | session | actor | workspace |
|---|---|---|---|---|
| packed stdio (generated artifact) | available/native (client name) | unavailable/not-provided | unavailable/not-provided | available/derived (spawn cwd) |
| generated stdio (integration fixture) | available/native | unavailable/not-provided | unavailable/not-provided | available/derived |
| mcp-in-memory projection | available/native | unavailable/not-provided | unavailable/not-provided | available/derived |
| generated event scopes | native (unchanged) | native (unchanged) | unavailable (stays #233/#269 follow-up) | native (unchanged) |

**Assertions flipped from honest absence to the positive contract** at all three proof levels (generated-server integration `inspect`, `mcp-in-memory` `tool:harness/context` — now also proving lookalike `host`/`session` input fields cannot alter observed axes — and a new packed-journey context assertion inside the existing first session, no new spawns). Honest-absence assertions stay for the axes stdio genuinely lacks.

**Also repairs two stale packed `listTools` expectations**: #273 added `tool:harness/context` and #275 added `tool:harness/mutation-probe` to the shared route-harness fixture without updating the packed journey's strict list (the packed pool is not a per-PR gate, so main drifted red there).

Event scopes' actor mounting and Workbench provenance stay out per the recorded #269/#233 and Workbench deferrals on #223.

Changeset: minor for `agent-bundle`.

## Gates (local, on the rebased branch at f06a91c68)

- `pnpm build` + `pnpm typecheck` — pass
- `pnpm lint` — 0 errors / 0 warnings (939 files)
- `pnpm test:unit` — 2454 passed / 0 failed (one pool-level flake observed and re-run green twice; isolated file runs green with and without this diff)
- `pnpm test:route-unit` — 18/18
- `pnpm test:projection` — 57/57 (includes #275's new cli-dispatch-mcp suite)
- generated-route-server integration (scoped, prebuilt) — 9/9
- packed journey (scoped `run-packed-tests.mjs`) — every assertion through both packed sessions passes including the new context axes proof; the suite then fails at the pre-existing `requestEventRuntime` IPC step, reproduced byte-identical on unchanged origin/main (A/B with only the stale listTools repair applied), unrelated to this change.

Refs #223, #273, #233, #269.