### PR TITLE
test(example): adopt routes.mcpCommands in audiobook-curator (#102 stage 4)

### DIFF
--- a/examples/audiobook-curator/README.md
+++ b/examples/audiobook-curator/README.md
@@ -57,9 +57,10 @@ the `curator` server, lifecycle entry, warm Flight worker, and MCP registrations
 there is no `src/application.ts`, operation-array registry, handwritten
 `src/mcp/curator.ts`, or per-operation server selector.
 
-The existing handwritten CLI remains a compatibility escape hatch until routed
-CLI rendering in #102 stage 3. It uses the same domain helpers but still prints
-validated JSON directly and never renders JSX.
+The routed CLI under `src/cli/` shares the generated command graph with all
+fifteen MCP tools projected as `audiobook-curator curator <tool>`. Projected
+tools accept one optional `--input '<JSON object>'`; tools explicitly annotated
+read-only run directly, while every mutation-capable tool requires `--yes`.
 
 ## Source layout
 

--- a/examples/audiobook-curator/agent-bundle.config.ts
+++ b/examples/audiobook-curator/agent-bundle.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     // status, and the `agent-bundle/meta` constant this plugin imports.
   },
   runtime: { node: '22.19.0' },
+  // #102 stage 4 adopts the in-house G7 projection for every curator tool.
+  routes: { mcpCommands: true },
   // No `scripts` or `bin` fields needed: the routed `src/cli/` commands
   // compile into the package executable (dist/bin/audiobook-curator.js) by
   // convention (#102 stages 2-3).

--- a/examples/audiobook-curator/tests/application.test.ts
+++ b/examples/audiobook-curator/tests/application.test.ts
@@ -44,13 +44,18 @@ describe('audiobook curator filesystem application', () => {
     expect(graph.servers[0]!.routes.filter((route) => route.kind === 'prompt').map((route) => route.id)).toEqual(['prompt:curator/curate']);
   });
 
-  it('derives the complete routed CLI from src/cli/ route modules and no cli config', async () => {
+  it('derives the complete routed CLI and projected MCP toolset', async () => {
     const graph = await compileRouteGraph(root, config);
     expect(graph.cli).toMatchObject({ mode: 'generated' });
-    expect(graph.cli!.commands).toHaveLength(15);
-    // Exactly one command renders through the dispatcher; the other
-    // fourteen keep the plain one-JSON-line contract byte for byte.
-    expect(graph.cli!.commands!.filter((command) => command.rendered).map((command) => command.path.join(' ')))
+    expect(graph.cli!.commands).toHaveLength(30);
+    const customCommands = graph.cli!.commands!.filter((command) => command.mcp === undefined);
+    const projectedCommands = graph.cli!.commands!.filter((command) => command.mcp !== undefined);
+    expect(customCommands).toHaveLength(15);
+    expect(projectedCommands.map((command) => command.path.join(' '))).toEqual(
+      toolNames.map((tool) => `curator ${tool}`),
+    );
+    expect(customCommands.filter((command) => command.rendered).map((command) => command.path.join(' ')))
       .toEqual(['library-audit']);
+    expect(projectedCommands.every((command) => command.rendered)).toBe(true);
   });
 });

--- a/examples/audiobook-curator/tests/cli.test.ts
+++ b/examples/audiobook-curator/tests/cli.test.ts
@@ -26,12 +26,14 @@ afterEach(async () => {
  * one-line JSON receipts.
  */
 describe('audiobook-curator routed CLI', () => {
-  it('compiles the fifteen migrated commands with the pre-migration argv surface', async () => {
+  it('compiles the migrated commands and projected MCP toolset in one graph', async () => {
     const graph = await compileRouteGraph(root, config);
     expect(graph.diagnostics).toEqual([]);
     expect(graph.cli?.mode).toBe('generated');
     const commands = graph.cli!.commands!;
-    const byName = new Map(commands.map((command) => [command.path.join(' '), command]));
+    const customCommands = commands.filter((command) => command.mcp === undefined);
+    const projectedCommands = commands.filter((command) => command.mcp !== undefined);
+    const byName = new Map(customCommands.map((command) => [command.path.join(' '), command]));
 
     expect([...byName.keys()].sort()).toEqual([
       'acoustic-identify',
@@ -50,6 +52,9 @@ describe('audiobook-curator routed CLI', () => {
       'select',
       'whisper-verify',
     ]);
+    expect(projectedCommands).toHaveLength(15);
+    expect(projectedCommands.every((command) =>
+      command.path[0] === 'curator' && command.rendered)).toBe(true);
 
     // inspect [--max-files N] <root>
     const inspect = byName.get('inspect')!;
@@ -111,7 +116,7 @@ describe('audiobook-curator routed CLI', () => {
     expect(byName.get('audible-cache')!.options.some((option) => option.option === 'cache-dir')).toBe(true);
 
     // The result exit-code policy rides exactly the commands that declared it.
-    expect(commands.filter((command) => command.exitCode === 'result').map((command) => command.path.join(' ')).sort()).toEqual([
+    expect(customCommands.filter((command) => command.exitCode === 'result').map((command) => command.path.join(' ')).sort()).toEqual([
       'acoustic-identify', 'acoustic-verify', 'audible-search', 'audit', 'inventory', 'library-audit', 'whisper-verify',
     ]);
   });

--- a/examples/audiobook-curator/tests/route-unit/cli-dispatch.test.ts
+++ b/examples/audiobook-curator/tests/route-unit/cli-dispatch.test.ts
@@ -11,6 +11,8 @@ import inspectRoute, {
 } from '../../src/cli/inspect.ts';
 import { resultSchema as inventoryResultSchema } from '../../src/cli/inventory.ts';
 import { resultSchema as libraryAuditResultSchema } from '../../src/cli/library-audit.tsx';
+import { inputSchema as convertAudiobookInputSchema } from '../../src/mcp/curator/tools/convert_audiobook.tsx';
+import { resultSchema as inspectSourcesResultSchema } from '../../src/mcp/curator/tools/inspect_sources.tsx';
 
 const directories: string[] = [];
 
@@ -191,6 +193,98 @@ describe('audiobook-curator at the CLI dispatch proof level', () => {
       expect(run.stderr).toContain('maxFiles');
       expect(run.stderr).toContain('expected number to be >=1');
       expect(run.stderr).toContain("Run 'audiobook-curator inspect --help' for usage.");
+    });
+  });
+
+  describe('projected MCP commands', () => {
+    it('runs read-only inspect_sources without --yes and emits its schema-validated JSON receipt', async () => {
+      const { library } = await temporaryLibrary();
+      const run = await invokeCli([
+        'curator',
+        'inspect_sources',
+        '--input',
+        JSON.stringify({ root: library }),
+        '--json',
+      ]);
+      const receipt = inspectSourcesResultSchema.parse(cliJson(run));
+
+      expect(run.exitCode).toBe(0);
+      expect(run.stderr).toBe('');
+      expect(run.routeId).toBe('tool:curator/inspect_sources');
+      expect(receipt).toMatchObject({
+        files: [],
+        operation: 'inspect',
+        root: library,
+        totalBytes: 0,
+      });
+      expect(run.value).toEqual(receipt);
+    });
+
+    it('fails convert_audiobook closed without --yes and reaches domain validation with it', async () => {
+      const { directory } = await temporaryLibrary();
+      const selection = join(directory, 'selection.json');
+      await writeFile(selection, JSON.stringify({ selections: [] }));
+      const input = convertAudiobookInputSchema.parse({
+        author: 'Example Author',
+        output: join(directory, 'output'),
+        selection,
+        title: 'Example Title',
+      });
+      const argv = ['curator', 'convert_audiobook', '--input', JSON.stringify(input)];
+
+      const denied = await invokeCli(argv);
+      expect(denied.exitCode).toBe(2);
+      expect(denied.stdout).toBe('');
+      expect(denied.stderr).toContain('--yes');
+      expect(denied.value).toBeUndefined();
+
+      // An empty selection reaches domain validation before any media probe or binary.
+      const allowed = await invokeCli([...argv, '--yes', '--json']);
+      expect(allowed.exitCode).toBe(1);
+      expect(allowed.stdout).toBe('');
+      expect(allowed.stderr).toContain('Selection contains no audio files.');
+      expect(allowed.stderr).not.toContain('requires --yes');
+      expect(allowed.value).toBeUndefined();
+    });
+
+    it('maps invalid JSON and tool inputSchema rejection to usage exit 2', async () => {
+      const invalidJson = await invokeCli(['curator', 'inspect_sources', '--input', '{']);
+      expect(invalidJson.exitCode).toBe(2);
+      expect(invalidJson.stdout).toBe('');
+      expect(invalidJson.stderr).toContain('valid JSON object');
+      expect(invalidJson.value).toBeUndefined();
+
+      const rejected = await invokeCli([
+        'curator',
+        'inspect_sources',
+        '--input',
+        '{"root":""}',
+      ]);
+      expect(rejected.exitCode).toBe(2);
+      expect(rejected.stdout).toBe('');
+      expect(rejected.stderr).toContain('root');
+      expect(rejected.stderr).toContain("Run 'audiobook-curator curator inspect_sources --help' for usage.");
+      expect(rejected.value).toBeUndefined();
+    });
+
+    it('merges the curator group with custom commands and explains projected provenance', async () => {
+      const [rootHelp, curatorHelp, mutationHelp] = await Promise.all([
+        invokeCli(['--help']),
+        invokeCli(['curator', '--help']),
+        invokeCli(['curator', 'convert_audiobook', '--help']),
+      ]);
+
+      expect(rootHelp.exitCode).toBe(0);
+      expect(rootHelp.stderr).toBe('');
+      expect(rootHelp.stdout).toMatch(/^ {2}curator <command>(?: |$)/mu);
+      expect(rootHelp.stdout).toMatch(/^ {2}inspect(?: |$)/mu);
+      expect(curatorHelp.exitCode).toBe(0);
+      expect(curatorHelp.stderr).toBe('');
+      expect(curatorHelp.stdout).toMatch(/^ {2}inspect_sources(?: |$)/mu);
+      expect(mutationHelp.exitCode).toBe(0);
+      expect(mutationHelp.stderr).toBe('');
+      expect(mutationHelp.stdout).toContain('MCP tool: curator:convert_audiobook');
+      expect(mutationHelp.stdout).toContain('Mutation-capable; requires --yes.');
     });
   });
 


### PR DESCRIPTION
Third #102 stage-4 PR (after #274 acceptance and #275 projection): the real audiobook-curator example adopts `routes.mcpCommands: true`, projecting all fifteen `curator` MCP tools into the same generated executable as its fifteen custom commands, and proves the projection at the `cli-dispatch` level.

## Coverage (all hermetic — empty temp libraries, no ffmpeg/ffprobe/network)

- **Read-only projection**: `curator inspect_sources` (annotations declare `readOnlyHint: true`) runs without `--yes`; `--json` receipt parses under the tool's own `resultSchema`; `routeId` is `tool:curator/inspect_sources`.
- **Mutation fail-closed, then opened**: `curator convert_audiobook` (`destructiveHint: true`) exits 2 without `--yes` with no route execution; with `--yes` the run proceeds past the gate into the tool's own domain validation ("Selection contains no audio files.", exit 1) — proving the gate is the only barrier, without requiring media binaries.
- **`--input` contract**: invalid JSON → usage exit 2; schema-invalid object → exit 2 with the command help hint.
- **Merged graph**: root help lists `curator <command>` beside the custom `inspect`; `curator --help` lists the tools; command help carries the `MCP tool: curator:convert_audiobook` provenance line and "Mutation-capable; requires --yes."
- Graph-level expectations updated: 30 commands total (15 custom + 15 projected, all projected rendered under the `curator` group), zero diagnostics.

README updated to describe the projected commands and the `--yes` policy. No changeset (unpublished example).

## Local gates

- `pnpm --filter @agent-bundle-example/audiobook-curator check` — validate, build, typecheck, **33/0** + route suite **20/0** (16 → 20)
- root `pnpm lint` — 0 errors, 0 warnings (939 files)