### PR TITLE
test: ship a plain script in the packed one-build fixture (#102 stage 4)

### DIFF
--- a/packages/agent-bundle/tests/cli-routes-build.test.ts
+++ b/packages/agent-bundle/tests/cli-routes-build.test.ts
@@ -141,6 +141,15 @@ it('builds and runs the generated routed-CLI executable', { retry: 2, timeout: 1
       '}',
       '',
     ].join('\n')),
+    writeProjectFile(root, 'src/scripts/checksum.ts', [
+      'const checksum = async (): Promise<number> => {',
+      "  process.stdout.write('Fixture checksum: 102\\n');",
+      '  return 0;',
+      '};',
+      'export default checksum;',
+      'export { checksum as main };',
+      '',
+    ].join('\n')),
     writeProjectFile(root, 'src/scripts/summarize.tsx', [
       "import React from 'react';",
       "import { Agent } from '@agent-bundle/runtime';",
@@ -275,4 +284,13 @@ it('builds and runs the generated routed-CLI executable', { retry: 2, timeout: 1
   expect(scriptMarkdown.stdout).toBe('Summarized 2 arguments.\n');
   const scriptJson = await execFile(process.execPath, [scriptPath, 'alpha', '--json']);
   expect(JSON.parse(scriptJson.stdout)).toEqual({ arguments: 1 });
+
+  // #102 acceptance: one build ships custom, MCP-generated, plain, and rendered commands/scripts.
+  const plainScriptPath = join(root, 'artifact', 'portable', 'scripts', 'checksum.mjs');
+  await expect(stat(plainScriptPath)).resolves.toMatchObject({});
+  const plainScript = await execFile(process.execPath, [plainScriptPath]);
+  expect(plainScript.stdout).toBe('Fixture checksum: 102\n');
+  await expect(stat(join(root, 'artifact', 'portable', 'scripts', 'checksum-flight.mjs'))).rejects.toMatchObject({
+    code: 'ENOENT',
+  });
 });


### PR DESCRIPTION
Final #102 stage-4 PR: closes the last acceptance line as literally written — "One project ships custom commands, MCP-generated commands, plain scripts, and rendered scripts through one Agent Bundle build."

The packed `cli-routes-build` fixture (which after #275 already ships custom plain/rendered commands, projected MCP commands, and a rendered `.tsx` script) gains a plain `src/scripts/checksum.ts`. The packed journey now asserts the plain script ships at `artifact/portable/scripts/checksum.mjs`, executes under `process.execPath` with deterministic stdout, and has **no** sibling `-flight.mjs` worker — a plain script remains a normal executable with no renderer assumptions.

Tests only; no changeset.

## Local gates

- `pnpm build` + packed integration `cli-routes-build.test.ts` — **1/0**
- root `pnpm lint` — 0 errors, 0 warnings (939 files)