### PR TITLE
fix(package): keep the generated installer's artifact URL statically analyzable in packed consumers (#252)

### DIFF
--- a/.changeset/static-packed-installer-url.md
+++ b/.changeset/static-packed-installer-url.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': patch
+---
+
+Keep generated package-relative installer paths statically analyzable when plugin projects build through a packed `agent-bundle` dependency.

--- a/packages/agent-bundle/src/build/entry-shell.ts
+++ b/packages/agent-bundle/src/build/entry-shell.ts
@@ -117,10 +117,11 @@ export const generatedInstallBinEntrySource = (options: {
   readonly hosts: readonly ('claude' | 'codex' | 'cursor')[];
   readonly name: string;
 }): string => [
+  "import { fileURLToPath } from 'node:url';",
   `import { runGeneratedInstallProcess } from ${JSON.stringify(installEntryRuntimeSpecifier)};`,
   '',
   'process.exitCode = await runGeneratedInstallProcess(process.argv.slice(2), Object.freeze({',
-  `  artifactRelativeUrl: ${JSON.stringify(options.artifactRelativeUrl)},`,
+  `  artifactRoot: fileURLToPath(new URL(${JSON.stringify(options.artifactRelativeUrl)}, import.meta.url)),`,
   `  hosts: Object.freeze(${stableJson(options.hosts)}),`,
   `  name: ${JSON.stringify(options.name)},`,
   '}));',

--- a/packages/agent-bundle/src/install-entry.ts
+++ b/packages/agent-bundle/src/install-entry.ts
@@ -1,5 +1,4 @@
 import { lstat } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 
 import { stableJson } from './core/digest.ts';
 import { DiagnosticError, type Diagnostic } from './core/diagnostics.ts';
@@ -11,7 +10,7 @@ import {
 } from './install/install.ts';
 
 export interface GeneratedInstallProcessOptions {
-  readonly artifactRelativeUrl: string;
+  readonly artifactRoot: string;
   readonly hosts: readonly InstallHost[];
   readonly name: string;
 }
@@ -98,16 +97,15 @@ export const runGeneratedInstallProcess = async (
   let parsed: ParsedInstallArguments | undefined;
   try {
     parsed = parseArguments(argv, options);
-    const artifactRoot = fileURLToPath(new URL(options.artifactRelativeUrl, import.meta.url));
-    const metadata = await lstat(artifactRoot).catch(() => undefined);
+    const metadata = await lstat(options.artifactRoot).catch(() => undefined);
     if (metadata === undefined || !metadata.isDirectory()) {
       throw new Error(
-        `Package artifact root is missing at ${JSON.stringify(artifactRoot)}; ` +
+        `Package artifact root is missing at ${JSON.stringify(options.artifactRoot)}; ` +
         'the package must ship its generated artifact directory.',
       );
     }
     const result = await installBundle({
-      from: artifactRoot,
+      from: options.artifactRoot,
       host: parsed.host,
       scope: parsed.scope,
     });

--- a/packages/agent-bundle/tests/packed-consumer.test.ts
+++ b/packages/agent-bundle/tests/packed-consumer.test.ts
@@ -327,7 +327,7 @@ it('uses only an installed tarball after source deletion', async () => {
         'export default {',
         '  mcp: { servers: { greeter: {} } },',
         "  plugin: { name: 'framework-build-fixture', version: '1.0.0' },",
-        "  targets: ['portable'],",
+        "  targets: ['claude', 'codex', 'portable'],",
         '};',
         '',
       ].join('\n')),
@@ -371,7 +371,9 @@ it('uses only an installed tarball after source deletion', async () => {
     await runInstalled(frameworkCli, frameworkRoot, ['build', '--root', frameworkRoot, '--output', frameworkArtifact]);
 
     const packedBin = join(frameworkRoot, 'dist', 'bin', 'framework-build-fixture.js');
+    const packedInstallerBin = join(frameworkRoot, 'dist', 'bin', 'framework-build-fixture-install.js');
     expect((await stat(packedBin)).mode & 0o111).not.toBe(0);
+    expect((await stat(packedInstallerBin)).mode & 0o111).not.toBe(0);
     expect((await readFile(packedBin, 'utf8')).startsWith('#!/usr/bin/env node\n')).toBe(true);
     await expect(execFile(packedBin, ['alpha'], { cwd: frameworkRoot, env: installedEnvironment() }))
       .resolves.toMatchObject({ stdout: 'packed bin ran:alpha\n' });


### PR DESCRIPTION
## Summary

Follow-up fix to #281, caught while wiring #252's release lane: in a packed consumer (a plugin project whose `node_modules` carries `agent-bundle` installed from the real tarball), any `agent-bundle build` with a package build plus install-capable targets failed with `AB5000: Bundler stats selected a module without an authored source path.`

- Root cause: the shared `install-entry` runtime called `new URL(options.artifactRelativeUrl, import.meta.url)` with a non-literal first argument. Rspack turns that into a directory ContextModule (`…/agent-bundle/dist|sync`) with no `nameForCondition`, and the provenance collector correctly fail-closes on it. Every #281/#283 gate missed this because their fixtures resolve the runtime shell from the workspace tree; the failure only reproduces when the shell is bundled out of an installed `node_modules/agent-bundle/dist`, which the release-lane scaffolder matrix (cli-tool journey) does.
- Fix: the generated wrapper — which owns the baked string-literal relative URL — now resolves `fileURLToPath(new URL('<literal>', import.meta.url))` itself and hands the absolute artifact root to `runGeneratedInstallProcess`. Statically analyzable for the bundler, identical package-relative behavior, and no weakening of the provenance collector's fail-closed posture.
- Regression coverage rides the existing packed-consumer deleted-source journey: the consumer fixture now builds with `claude`/`codex` targets through the installed framework and asserts the emitted executable `dist/bin/<name>-install.js` (fails with the exact AB5000 before this fix).

## Test plan

- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` — green
- [x] `pnpm test:packed packages/agent-bundle/tests/packed-consumer.test.ts` — 1 passed (failed with AB5000 pre-fix)
- [x] `pnpm exec rstest … prepack.test.ts installer-entry.test.ts package-build.test.ts` — 24 passed
- [x] `pnpm test:packed:release …/scaffold-packed-matrix.e2e.test.ts` — 2 passed (cli-tool journey's `npm run build` was the original failure)
- [x] Minimal hand repro (empty project + tarball-installed agent-bundle + claude target) builds clean and emits the installer bin