### PR TITLE
fix(diagnostics): keep routing codes unique

### DIFF
--- a/.changeset/fresh-routing-diagnostics.md
+++ b/.changeset/fresh-routing-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': patch
+---
+
+Assign unique AB48xx codes to event vocabulary and target diagnostics while preserving the documented routed CLI meanings.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -195,7 +195,7 @@ simply not been built yet is a validation **warning** that only
 | `AB4749` | error (build) | A payload directory overlaps the artifact `--output` root. |
 | `AB4750` | info | A payload is older than the newest project source file and may be stale; rerun the project's own build if so. |
 
-## Route graph, state, and provider conventions (`AB4800`–`AB4822`, `AB4940`–`AB4942`)
+## Route graph, state, and provider conventions (`AB4800`–`AB4825`, `AB4940`–`AB4942`)
 
 The route-graph compiler discovers conventional route modules
 (`src/mcp/<server>/{tools,resources,prompts,apps}/*`, `src/events/*/*`,
@@ -321,6 +321,9 @@ schema constants), unions, nested objects, transforms, coercions — raises
 | `AB4820` | error | A generated project selects `external` state lifetime; v1 generated mounting supports only `request`, `process`, and `workspace-durable` because external drivers require embedder wiring. |
 | `AB4821` | error | A project state definition uses the reserved notice-ledger id `@agent-bundle/runtime/agent-notice-ledger/v1`; generated runtimes own that id for the co-mounted notice store. |
 | `AB4822` | error | A `routes.mcpCommands.include` or `.exclude` pattern matches no eligible tool, or `include: []` explicitly selects none. Correct the pattern using an available `<server>:<tool>` identity listed by the diagnostic. |
+| `AB4823` | error | An event route declares an event outside the v1 event vocabulary. |
+| `AB4824` | error | An event route selects an unknown target or requires an event capability that the selected target does not support. |
+| `AB4825` | error | An event route's `config.targets` is not a nonempty array of nonempty target names. |
 | `AB4940` | error | A conventional provider module has no default export or its default export is not a function. Default-export a factory receiving `{ invocation, signal }`. |
 | `AB4941` | error | Two provider filenames derive the same camel-cased provider key. Rename one file so every provider key is unique. |
 | `AB4942` | error | A provider filename derives the reserved `processLifetime` key. Rename the file so its camel-cased key does not collide with the framework-owned provider. |

--- a/packages/agent-bundle/src/config/validate.ts
+++ b/packages/agent-bundle/src/config/validate.ts
@@ -1137,7 +1137,7 @@ const validateEventRoutes = (
         declaredTargets.some((target) => typeof target !== 'string' || target.trim().length === 0))
     ) {
       diagnostics.push(sourceDiagnostic(
-        'AB4815',
+        'AB4825',
         `Event route ${route.provenance.relativePath} config.targets must be a nonempty array of target names.`,
         route.source,
       ));
@@ -1149,7 +1149,7 @@ const validateEventRoutes = (
     for (const target of targets) {
       if (!registry.has(target)) {
         diagnostics.push({
-          code: 'AB4814',
+          code: 'AB4824',
           message: `Event route ${route.provenance.relativePath} selects unknown target ${JSON.stringify(target)}.`,
           severity: 'error',
           sourcePath: route.source,
@@ -1162,7 +1162,7 @@ const validateEventRoutes = (
       if (capability === undefined) {
         if (registry.supports(target, capabilityName)) continue;
         diagnostics.push({
-          code: 'AB4814',
+          code: 'AB4824',
           message: `Event route ${route.provenance.relativePath} requires ${capabilityName}, unavailable on ${target}.`,
           severity: 'error',
           sourcePath: route.source,
@@ -1177,7 +1177,7 @@ const validateEventRoutes = (
         case 'unavailable':
         case 'prohibited':
           diagnostics.push({
-            code: 'AB4814',
+            code: 'AB4824',
             message: `Event route ${route.provenance.relativePath} requires ${capabilityName}, ${capability.state} on ${target}: ${capability.reason}`,
             severity: 'error',
             sourcePath: route.source,

--- a/packages/agent-bundle/src/routes/graph.ts
+++ b/packages/agent-bundle/src/routes/graph.ts
@@ -464,7 +464,7 @@ export const compileRouteGraph = async (
       !canonicalAgentEvents.includes(module.event!)
     ) {
       diagnostics.push(routeError(
-        'AB4813',
+        'AB4823',
         `Event route ${relativePath} declares ${JSON.stringify(module.event)}, which is outside the #97 v1 event vocabulary.`,
         `Use one of: ${canonicalAgentEvents.join(', ')}.`,
         source,

--- a/packages/agent-bundle/tests/route-graph.test.ts
+++ b/packages/agent-bundle/tests/route-graph.test.ts
@@ -792,7 +792,7 @@ it('discovers only the seven v1 event families and validates their component con
     'tool/before',
     'workspace/open',
   ]);
-  expect(graph.diagnostics.map(({ code }) => code)).toEqual(['AB4813', 'AB4810']);
+  expect(graph.diagnostics.map(({ code }) => code)).toEqual(['AB4823', 'AB4810']);
   expect(graph.diagnostics[0]?.sourcePath).toBe(join(root, 'src/events/prompt/submit.tsx'));
   expect(graph.diagnostics[1]?.sourcePath).toBe(join(root, 'src/events/tool/before.tsx'));
 });
@@ -816,11 +816,11 @@ it('fails unavailable event routes before packaging for every selected target', 
   const unrestricted = await inspect({ root: unrestrictedRoot });
   expect(unrestricted.state).toBe('invalid');
   expect(unrestricted.diagnostics).toContainEqual(expect.objectContaining({
-    code: 'AB4814',
+    code: 'AB4824',
     target: 'claude',
   }));
   expect(unrestricted.diagnostics).toContainEqual(expect.objectContaining({
-    code: 'AB4814',
+    code: 'AB4824',
     target: 'cursor',
   }));
 
@@ -837,8 +837,34 @@ it('fails unavailable event routes before packaging for every selected target', 
   const restricted = await inspect({ root: restrictedRoot });
   expect(restricted.state).toBe('invalid');
   expect(restricted.diagnostics).toContainEqual(expect.objectContaining({
-    code: 'AB4814',
+    code: 'AB4824',
     target: 'cursor',
+  }));
+});
+
+it('rejects malformed event route targets with AB4825', async () => {
+  const root = await createRoot();
+  await writeTree(root, {
+    'agent-bundle.config.ts': [
+      'export default {',
+      "  plugin: { name: 'event-targets-fixture', version: '1.0.0' },",
+      "  targets: ['cursor'],",
+      '};',
+      '',
+    ].join('\n'),
+    'package.json': '{"type":"module"}\n',
+    'src/events/session/start.tsx': [
+      "export const config = { targets: [] };",
+      'export default async function SessionStart() { return undefined; }',
+      '',
+    ].join('\n'),
+  });
+
+  const result = await inspect({ root });
+  expect(result.state).toBe('invalid');
+  expect(result.diagnostics).toContainEqual(expect.objectContaining({
+    code: 'AB4825',
+    sourcePath: join(root, 'src/events/session/start.tsx'),
   }));
 });
 


### PR DESCRIPTION
## Summary
- preserve documented AB4813–AB4815 routed CLI meanings
- assign AB4823–AB4825 to event vocabulary, capability, and target-shape diagnostics
- document the new codes, add regression coverage, and include a patch changeset

## Test plan
- [x] `pnpm exec rstest run packages/agent-bundle/tests/route-graph.test.ts packages/agent-bundle/tests/cli-routes.test.ts --config rstest.unit.config.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`