### PR TITLE
feat(workbench): user-initiated live MCP probing with consent + redaction (#105 stage 5)

### DIFF
--- a/.changeset/consented-mcp-probes.md
+++ b/.changeset/consented-mcp-probes.md
@@ -1,0 +1,9 @@
+---
+"agent-bundle": patch
+---
+
+Add user-initiated, read-only live MCP probing to the Workbench Hosts page
+with per-probe consent, redacted launch details, honest neutral down states,
+and ephemeral results. Discovery now enumerates installed-bundle MCP servers,
+and the authenticated `POST /api/discovery/probes` route reports probe outcomes
+with diagnostics AB8219 through AB8223.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -30,6 +30,7 @@ gate a build, a validation, or a dev rebuild.
 | `AB7xxx` | Project preparation and development rebuilds. |
 | `AB7300`–`AB7316` | Read-only install Doctor: host probes, installed inventory, bundle comparison and registration proof, runtime endpoint health, and durable-state inventory. |
 | `AB8215`–`AB8218` | Workbench read-only host discovery route. |
+| `AB8219`–`AB8223` | Workbench live MCP probe route (user-initiated, read-only initialize + tools/list): `AB8219` invalid path, `AB8220` invalid request/method, `AB8221` probe target not found, `AB8222` response over the 16 MiB budget, `AB8223` probe unavailable. |
 | `AB8xxx` | Development server configuration. |
 | `AB9xxx` | Eval selection, harnesses, and persisted runs. |
 

--- a/docs/effect-conventions.md
+++ b/docs/effect-conventions.md
@@ -186,7 +186,8 @@ Exact-pin `effect` + `@effect/atom-react` (synchronized with the repo's effect
 pin, currently `4.0.0-rc.112`) are allowed there, but only in dedicated
 browser-state modules (`src/runtime/agent-document-atoms.ts`,
 `src/routes/route-editor-atoms.ts`, and `src/discovery/discovery-atoms.ts`).
-Atoms live in `effect/unstable/reactivity`; React bindings come from
+The discovery module owns report loading plus ephemeral live-probe consent
+and result state. Atoms live in `effect/unstable/reactivity`; React bindings come from
 `@effect/atom-react`.
 
 - No `Atom` or `AsyncResult` types in DTOs, public exports, or examples —

--- a/packages/agent-bundle/src/contracts/discovery.ts
+++ b/packages/agent-bundle/src/contracts/discovery.ts
@@ -53,9 +53,15 @@ export interface DiscoveryFinding {
   readonly version?: string;
 }
 
+export interface DiscoveryMcpServer {
+  readonly name: string;
+  readonly transport: 'stdio' | 'streamable-http';
+}
+
 export interface DiscoveryBundleFinding extends DiscoveryFinding {
   readonly bundleRoot?: string;
   readonly marketplace?: string;
+  readonly mcpServers?: readonly DiscoveryMcpServer[];
 }
 
 export interface DiscoveryProbe {

--- a/packages/agent-bundle/src/contracts/mcp-probe.ts
+++ b/packages/agent-bundle/src/contracts/mcp-probe.ts
@@ -1,0 +1,53 @@
+export type McpProbeHost = 'claude' | 'codex' | 'cursor';
+export type McpProbeStatus = 'ok' | 'timed-out' | 'unreachable';
+export type McpProbeFailureKind = 'connect' | 'handshake' | 'protocol';
+
+export interface McpProbeLaunchStdio {
+  readonly args: readonly string[];
+  readonly command: string;
+  readonly cwd?: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly kind: 'stdio';
+}
+
+export interface McpProbeLaunchRemote {
+  readonly kind: 'streamable-http';
+  readonly url: string;
+}
+
+export type McpProbeLaunch = McpProbeLaunchStdio | McpProbeLaunchRemote;
+
+export interface McpProbeTool {
+  readonly description?: string;
+  readonly name: string;
+  readonly title?: string;
+}
+
+export interface McpProbeSnapshot {
+  readonly capabilities: Readonly<Record<string, boolean>>;
+  readonly instructions?: string;
+  readonly protocolVersion: string;
+  readonly serverInfo: Readonly<{
+    readonly name: string;
+    readonly title?: string;
+    readonly version: string;
+  }>;
+  readonly tools: readonly McpProbeTool[];
+  readonly toolsTruncated: boolean;
+}
+
+export interface McpProbeFailure {
+  readonly detail: string;
+  readonly kind: McpProbeFailureKind;
+}
+
+export interface McpProbeReport {
+  readonly durationMs: number;
+  readonly failure?: McpProbeFailure;
+  readonly generatedAt: string;
+  readonly host: McpProbeHost;
+  readonly launch: McpProbeLaunch;
+  readonly serverName: string;
+  readonly snapshot?: McpProbeSnapshot;
+  readonly status: McpProbeStatus;
+}

--- a/packages/agent-bundle/src/dev/foreground-server.ts
+++ b/packages/agent-bundle/src/dev/foreground-server.ts
@@ -15,6 +15,7 @@ import { InspectorRoutes, type InspectorRouteService } from './inspector-routes.
 import { HookPlaygroundRoutes, type HookPlaygroundRouteService } from './playground/hook-playground-routes.ts';
 import { HostDiscoveryRoutes, type HostDiscoveryRouteService } from './playground/host-discovery-routes.ts';
 import { LifecycleReplayRoutes, type LifecycleReplayRouteService } from './playground/lifecycle-replay-routes.ts';
+import { McpProbeRoutes, type McpProbeRouteService } from './playground/mcp-probe-routes.ts';
 import { McpAppRoutes, type McpAppRoutePreviewService } from './mcp-apps/mcp-app-routes.ts';
 import { McpSessionRoutes } from './mcp-session/mcp-session-routes.ts';
 import type { McpSessionService } from './mcp-session/mcp-session-service.ts';
@@ -135,6 +136,8 @@ export interface ForegroundServerOptions {
   readonly hookPlayground?: HookPlaygroundRouteService;
   /** Read-only host probes, install inventory, bundle drift, and runtime endpoint health. */
   readonly hostDiscovery?: HostDiscoveryRouteService;
+  /** User-initiated read-only initialize and tools/list probing over trusted artifact servers. */
+  readonly mcpProbe?: McpProbeRouteService;
   /** Read-only semantic lifecycle replay over the latest valid prepared graph. */
   readonly lifecycleReplay?: LifecycleReplayRouteService;
   /** Opt-in standalone MCP Inspector child; never auto-started. */
@@ -444,6 +447,7 @@ export class ForegroundServer {
   readonly #lifecycleReplayRoutes: LifecycleReplayRoutes;
   readonly #mcpAppPreviews: McpAppRoutePreviewService | undefined;
   readonly #mcpAppRoutes: McpAppRoutes;
+  readonly #mcpProbeRoutes: McpProbeRoutes;
   readonly #runtimeMcpRoutes: RuntimeMcpRoutes;
   readonly #mcpSessionRoutes: McpSessionRoutes;
   readonly #runtimeRoutes: RuntimeRoutes;
@@ -524,6 +528,10 @@ export class ForegroundServer {
     this.#hostDiscoveryRoutes = new HostDiscoveryRoutes({
       authorize: (request) => this.#assertMutationSession(request),
       ...(options.hostDiscovery === undefined ? {} : { service: options.hostDiscovery }),
+    });
+    this.#mcpProbeRoutes = new McpProbeRoutes({
+      authorize: (request) => this.#assertMutationSession(request),
+      ...(options.mcpProbe === undefined ? {} : { service: options.mcpProbe }),
     });
     this.#lifecycleReplayRoutes = new LifecycleReplayRoutes({
       authorize: (request) => this.#assertMutationSession(request),
@@ -681,6 +689,7 @@ export class ForegroundServer {
     // abort callbacks may synchronously re-enter foreground shutdown, and
     // must observe the already-published close outcome.
     const releaseHookPlayground = this.#hookPlaygroundRoutes.close();
+    this.#mcpProbeRoutes.close();
     this.#hostDiscoveryRoutes.close();
     // App tombstone publication below deliberately yields once before joining
     // resource drains. Observe this promise now so a fast drain failure cannot
@@ -774,6 +783,7 @@ export class ForegroundServer {
     if (await this.#runtimeMcpRoutes.handle(request, response)) return;
     if (await this.#runtimeRoutes.handle(request, response)) return;
     if (await this.#hookPlaygroundRoutes.handle(request, response)) return;
+    if (await this.#mcpProbeRoutes.handle(request, response)) return;
     if (await this.#hostDiscoveryRoutes.handle(request, response)) return;
     if (await this.#lifecycleReplayRoutes.handle(request, response)) return;
     if (await this.#playgroundRoutes.handle(request, response)) return;

--- a/packages/agent-bundle/src/dev/playground/host-discovery-routes.ts
+++ b/packages/agent-bundle/src/dev/playground/host-discovery-routes.ts
@@ -28,6 +28,9 @@ const responseJson = (response: ServerResponse, body: unknown): void =>
 const matchesDiscoveryRoute = (requestTarget: string | undefined): boolean => {
   const pathname = rawPathname(requestTarget);
   if (pathname === '/api/discovery') return true;
+  if (pathname === '/api/discovery/probes' || pathname.startsWith('/api/discovery/probes/')) {
+    return false;
+  }
   if (pathname.startsWith('/api/discovery/')) {
     throw requestError(diagnostic('AB8215', 'Host discovery route path is not valid.', 400));
   }

--- a/packages/agent-bundle/src/dev/playground/host-discovery-service.ts
+++ b/packages/agent-bundle/src/dev/playground/host-discovery-service.ts
@@ -1,3 +1,7 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { createDefaultRegistry, type TargetRegistry } from '../../adapters/registry.ts';
 import type {
   DiscoveryBundleFinding,
   DiscoveryDiagnostic,
@@ -6,9 +10,11 @@ import type {
   DiscoveryEndpointReport,
   DiscoveryFinding,
   DiscoveryHostReport,
+  DiscoveryMcpServer,
   DiscoveryProbe,
   HostDiscoveryReport,
 } from '../../contracts/discovery.ts';
+import { parseJsonWithoutDuplicateKeys } from '../../core/strict-json.ts';
 import {
   runDoctor,
   type DoctorDurableStateReport,
@@ -20,6 +26,10 @@ import {
   type DoctorOptions,
   type DoctorReport,
 } from '../../install/doctor.ts';
+import {
+  readTargetMcpServers,
+  type ModernMcpServerEntry,
+} from '../../services/mcp-runtime.ts';
 import type { HostDiscoveryRouteService } from './host-discovery-routes.ts';
 
 export interface HostDiscoveryServiceOptions {
@@ -30,6 +40,7 @@ export interface HostDiscoveryServiceOptions {
     readonly bundleSource: string;
     readonly manifestDigest?: string;
   }> | undefined;
+  readonly registry?: TargetRegistry;
 }
 
 const discoveryDiagnostic = (
@@ -81,10 +92,12 @@ const findingFields = (value: DoctorFinding): DiscoveryFinding => Object.freeze(
 
 const bundleFinding = (
   value: NonNullable<DoctorHostReport['bundle']>,
+  mcpServers: readonly DiscoveryMcpServer[] | undefined,
 ): DiscoveryBundleFinding => Object.freeze({
   ...findingFields(value),
   ...(value.bundleRoot === undefined ? {} : { bundleRoot: value.bundleRoot }),
   ...(value.marketplace === undefined ? {} : { marketplace: value.marketplace }),
+  ...(mcpServers === undefined ? {} : { mcpServers }),
 });
 
 const discoveryProbe = (value: DoctorHostProbe): DiscoveryProbe => Object.freeze({
@@ -93,8 +106,38 @@ const discoveryProbe = (value: DoctorHostProbe): DiscoveryProbe => Object.freeze
   ...(value.version === undefined ? {} : { version: value.version }),
 });
 
-const hostReport = (value: DoctorHostReport): DiscoveryHostReport => Object.freeze({
-  ...(value.bundle === undefined ? {} : { bundle: bundleFinding(value.bundle) }),
+const discoveryMcpServer = (value: ModernMcpServerEntry): DiscoveryMcpServer => Object.freeze({
+  name: value.name,
+  transport: value.server.kind,
+});
+
+const enumerateMcpServers = async (
+  value: DoctorHostReport,
+  registry: TargetRegistry,
+): Promise<readonly DiscoveryMcpServer[] | undefined> => {
+  const bundleRoot = value.bundle?.bundleRoot;
+  if (bundleRoot === undefined) return undefined;
+  try {
+    const runtime = registry.mcpRuntime(value.host);
+    if (runtime === undefined) return undefined;
+    const document = parseJsonWithoutDuplicateKeys(
+      await readFile(join(bundleRoot, runtime.manifestPath), 'utf8'),
+    );
+    const result = readTargetMcpServers(runtime, document);
+    if (result.status === 'invalid') return undefined;
+    return Object.freeze(result.servers.map(discoveryMcpServer));
+  } catch {
+    return undefined;
+  }
+};
+
+const hostReport = async (
+  value: DoctorHostReport,
+  registry: TargetRegistry,
+): Promise<DiscoveryHostReport> => Object.freeze({
+  ...(value.bundle === undefined
+    ? {}
+    : { bundle: bundleFinding(value.bundle, await enumerateMcpServers(value, registry)) }),
   diagnostics: Object.freeze(value.diagnostics.map(discoveryDiagnostic)),
   host: value.host,
   inventory: Object.freeze({
@@ -121,6 +164,7 @@ export class HostDiscoveryService implements HostDiscoveryRouteService {
   readonly #doctorOptions: DoctorOptions;
   readonly #now: () => Date;
   readonly #prepared: NonNullable<HostDiscoveryServiceOptions['prepared']>;
+  readonly #registry: TargetRegistry;
   #inFlight: Promise<HostDiscoveryReport> | undefined;
 
   constructor(options: HostDiscoveryServiceOptions = {}) {
@@ -128,6 +172,7 @@ export class HostDiscoveryService implements HostDiscoveryRouteService {
     this.#doctorOptions = options.doctorOptions ?? Object.freeze({});
     this.#now = options.now ?? (() => new Date());
     this.#prepared = options.prepared ?? (() => undefined);
+    this.#registry = options.registry ?? createDefaultRegistry();
   }
 
   discover(): Promise<HostDiscoveryReport> {
@@ -149,7 +194,9 @@ export class HostDiscoveryService implements HostDiscoveryRouteService {
       ...this.#doctorOptions,
       ...(bundleSource ? { from: bundleSource } : {}),
     });
-    const hosts: readonly DiscoveryHostReport[] = Object.freeze(report.hosts.map(hostReport));
+    const hosts: readonly DiscoveryHostReport[] = Object.freeze(
+      await Promise.all(report.hosts.map((value) => hostReport(value, this.#registry))),
+    );
     const endpoints: DiscoveryEndpointReport = endpointReport(report.endpoints);
     const diagnostics: readonly DiscoveryDiagnostic[] = Object.freeze(
       report.diagnostics.map(discoveryDiagnostic),

--- a/packages/agent-bundle/src/dev/playground/mcp-probe-routes.ts
+++ b/packages/agent-bundle/src/dev/playground/mcp-probe-routes.ts
@@ -1,0 +1,117 @@
+import { Buffer } from 'node:buffer';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { McpProbeHost, McpProbeReport } from '../../contracts/mcp-probe.ts';
+import {
+  diagnostic,
+  hasOnly,
+  isRequestDiagnostic,
+  nonemptyString,
+  rawPathname,
+  readJsonBody,
+  requestError,
+  responseDiagnostic,
+  responseJson as writeJsonResponse,
+} from '../http.ts';
+import { McpProbeTargetNotFoundError } from './mcp-probe-service.ts';
+
+export const mcpProbeResponseLimit = 16 * 1024 * 1024;
+
+export interface McpProbeRouteService {
+  probe(options: {
+    readonly host: McpProbeHost;
+    readonly serverName: string;
+  }): Promise<McpProbeReport>;
+}
+
+export interface McpProbeRoutesOptions {
+  readonly authorize: (request: IncomingMessage) => void;
+  readonly responseByteLimit?: number;
+  readonly service?: McpProbeRouteService;
+}
+
+const responseJson = (response: ServerResponse, body: unknown): void =>
+  writeJsonResponse(response, body, { destroyIfEnded: true });
+
+const matchesProbeRoute = (requestTarget: string | undefined): boolean => {
+  const pathname = rawPathname(requestTarget);
+  if (pathname === '/api/discovery/probes') return true;
+  if (pathname.startsWith('/api/discovery/probes/')) {
+    throw requestError(diagnostic('AB8219', 'MCP probe route path is not valid.', 400));
+  }
+  return false;
+};
+
+const noQuery = (requestTarget: string | undefined): void => {
+  if (new URL(requestTarget ?? '/', 'http://localhost').searchParams.size > 0) {
+    throw requestError(diagnostic('AB8220', 'MCP probe request is not valid.', 400));
+  }
+};
+
+const invalidRequest = (): never => {
+  throw requestError(diagnostic('AB8220', 'MCP probe request is not valid.', 400));
+};
+
+const isHost = (value: unknown): value is McpProbeHost =>
+  value === 'claude' || value === 'codex' || value === 'cursor';
+
+const probeRequest = async (
+  request: IncomingMessage,
+): Promise<{ readonly host: McpProbeHost; readonly serverName: string }> => {
+  const body = await readJsonBody(request, { invalidShape: invalidRequest });
+  if (!hasOnly(body, ['host', 'serverName']) || Object.keys(body).length !== 2) {
+    return invalidRequest();
+  }
+  const host = body.host;
+  const serverName = body.serverName;
+  if (!isHost(host) || !nonemptyString(serverName) || serverName.length > 256) {
+    return invalidRequest();
+  }
+  return Object.freeze({ host, serverName });
+};
+
+export class McpProbeRoutes {
+  readonly #authorize: (request: IncomingMessage) => void;
+  readonly #responseByteLimit: number;
+  readonly #service: McpProbeRouteService | undefined;
+  #closed = false;
+
+  constructor(options: McpProbeRoutesOptions) {
+    this.#authorize = options.authorize;
+    this.#responseByteLimit = options.responseByteLimit ?? mcpProbeResponseLimit;
+    this.#service = options.service;
+  }
+
+  close(): void {
+    this.#closed = true;
+  }
+
+  async handle(request: IncomingMessage, response: ServerResponse): Promise<boolean> {
+    if (!matchesProbeRoute(request.url)) return false;
+    this.#authorize(request);
+    if (this.#closed || this.#service === undefined) {
+      throw requestError(diagnostic('AB8223', 'MCP probing is not available.', 503));
+    }
+    const method = request.method ?? 'GET';
+    if (method !== 'POST') {
+      responseDiagnostic(response, diagnostic('AB8220', 'MCP probe request is not valid.', 405));
+      return true;
+    }
+    noQuery(request.url);
+    let report: McpProbeReport;
+    try {
+      report = await this.#service.probe(await probeRequest(request));
+    } catch (error) {
+      if (isRequestDiagnostic(error)) throw error;
+      if (error instanceof McpProbeTargetNotFoundError) {
+        throw requestError(diagnostic('AB8221', error.message, 404));
+      }
+      throw requestError(diagnostic('AB8220', 'MCP probe could not be completed.', 502));
+    }
+    if (Buffer.byteLength(JSON.stringify(report), 'utf8') > this.#responseByteLimit) {
+      throw requestError(diagnostic('AB8222', 'MCP probe exceeds the 16 MiB response limit.', 413));
+    }
+    responseJson(response, report);
+    return true;
+  }
+}

--- a/packages/agent-bundle/src/dev/playground/mcp-probe-service.ts
+++ b/packages/agent-bundle/src/dev/playground/mcp-probe-service.ts
@@ -1,0 +1,541 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type Implementation,
+  type ServerCapabilities,
+  type Tool,
+  type Transport,
+} from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { performance } from 'node:perf_hooks';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { createDefaultRegistry, type TargetRegistry } from '../../adapters/registry.ts';
+import type {
+  McpProbeFailure,
+  McpProbeFailureKind,
+  McpProbeHost,
+  McpProbeLaunch,
+  McpProbeReport,
+  McpProbeSnapshot,
+  McpProbeTool,
+} from '../../contracts/mcp-probe.ts';
+import { redactCredentialText } from '../../core/credentials.ts';
+import { parseJsonWithoutDuplicateKeys } from '../../core/strict-json.ts';
+import { resolveBundleRoot } from '../../install/doctor.ts';
+import {
+  readTargetMcpServer,
+  type TargetMcpRuntimeContract,
+} from '../../services/mcp-runtime.ts';
+import {
+  mcpSessionInspectorConfig,
+  resolveMcpSessionLaunch,
+  type ResolvedMcpSessionLaunch,
+} from '../mcp-session/mcp-session-launch.ts';
+import type { McpSessionInspectorConfig } from '../mcp-session/mcp-session-protocol.ts';
+import type { RemoteTransportOptions, StdioOptions } from '../mcp-session/mcp-session-types.ts';
+
+export const mcpProbeTimeoutMs = 10_000;
+export const mcpProbeToolLimit = 200;
+export const mcpProbeInstructionTextLimit = 2_048;
+export const mcpProbeToolTextLimit = 2_048;
+export const mcpProbeFailureTextLimit = 2_048;
+
+const mcpProbeCapabilityLimit = 32;
+const mcpProbeNameTextLimit = 256;
+const safeCapabilityName = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/u;
+const connectionErrorCodes = new Set([
+  'EACCES',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENOENT',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+]);
+
+export type McpProbeTransport = Transport;
+
+export interface McpProbeClient {
+  close(): Promise<void>;
+  connect(transport: Transport): Promise<void>;
+  getInstructions(): string | undefined;
+  getNegotiatedProtocolVersion(): string | undefined;
+  getServerCapabilities(): ServerCapabilities | undefined;
+  getServerVersion(): Implementation | undefined;
+  listTools(): Promise<{ readonly tools: readonly Tool[] }>;
+}
+
+export interface McpProbeServiceOptions {
+  readonly clock?: () => number;
+  readonly createClient?: () => McpProbeClient;
+  readonly createPluginData?: () => Promise<string>;
+  readonly createStdioTransport?: (options: StdioOptions) => McpProbeTransport;
+  readonly createStreamableHttpTransport?: (
+    url: URL,
+    options: RemoteTransportOptions,
+  ) => McpProbeTransport;
+  readonly now?: () => Date;
+  readonly prepared: () => Readonly<{ readonly bundleSource: string }> | undefined;
+  readonly projectRoot: string;
+  readonly registry?: TargetRegistry;
+  readonly timeoutMs?: number;
+}
+
+export class McpProbeTargetNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'McpProbeTargetNotFoundError';
+  }
+}
+
+class McpProbeTimeoutError extends Error {
+  readonly kind: McpProbeFailureKind;
+
+  constructor(kind: McpProbeFailureKind) {
+    super('The MCP probe exceeded its total time budget.');
+    this.name = 'McpProbeTimeoutError';
+    this.kind = kind;
+  }
+}
+
+class McpProbeProtocolError extends Error {
+  readonly kind: McpProbeFailureKind;
+
+  constructor(kind: McpProbeFailureKind, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'McpProbeProtocolError';
+    this.kind = kind;
+  }
+}
+
+const truncate = (value: string, maximum: number): string =>
+  value.length <= maximum ? value : `${value.slice(0, maximum - 1)}…`;
+
+const escapeExpression = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+
+const bundlePathPattern = (bundleRoot: string): RegExp => {
+  const normalized = resolve(bundleRoot).replaceAll('\\', '/').replace(/\/+$/u, '');
+  const root = escapeExpression(normalized).replaceAll('/', '[\\\\/]');
+  const suffix = String.raw`(?:[\\/][^\s,;{}()[\]<>"'\x00-\x1F\x7F]*)*`;
+  return new RegExp(String.raw`(?:file:\/\/)?${root}${suffix}`, 'gu');
+};
+
+const hasAbsolutePath = (value: string): boolean =>
+  /(?:file:|(?:^|[\s"'([{])\/[^\s,;{}()[\]<>"']+|(?:^|[\s"'([{])[A-Za-z]:[\\/]|\\\\)/u.test(value);
+
+/**
+ * Probe text follows the Dev Log browser-wire precedent without coupling this
+ * read-only service to log retention: credential text is removed first,
+ * bundle paths become a label, and every other absolute path fails closed.
+ */
+const redactProbeText = (value: string, bundleRoot: string, maximum: number): string => {
+  const redacted = redactCredentialText(value).replace(
+    bundlePathPattern(bundleRoot),
+    (match) => {
+      const normalized = match.replace(/^file:\/\//u, '').replaceAll('\\', '/');
+      const root = resolve(bundleRoot).replaceAll('\\', '/').replace(/\/+$/u, '');
+      return `<bundle>${normalized.slice(root.length)}`;
+    },
+  );
+  return truncate(hasAbsolutePath(redacted) ? '[REDACTED]' : redacted, maximum);
+};
+
+const inspectorLaunch = (value: McpSessionInspectorConfig['launch']): McpProbeLaunch => {
+  switch (value.kind) {
+    case 'stdio':
+      return Object.freeze({
+        args: Object.freeze([...value.args]),
+        command: value.command,
+        ...(value.cwd === undefined ? {} : { cwd: value.cwd }),
+        env: Object.freeze({ ...value.env }),
+        kind: value.kind,
+      });
+    case 'streamable-http':
+      return Object.freeze({ kind: value.kind, url: value.url });
+    default: {
+      const exhaustive: never = value;
+      throw new TypeError(`Unknown MCP probe launch ${String(exhaustive)}.`);
+    }
+  }
+};
+
+const capabilitySnapshot = (
+  value: ServerCapabilities | undefined,
+): Readonly<Record<string, boolean>> => {
+  const capabilities: Record<string, boolean> = {};
+  if (value === undefined) return Object.freeze(capabilities);
+  for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+    if (
+      Object.keys(capabilities).length >= mcpProbeCapabilityLimit ||
+      !safeCapabilityName.test(key) ||
+      !value[key as keyof ServerCapabilities]
+    ) continue;
+    capabilities[key] = true;
+  }
+  return Object.freeze(capabilities);
+};
+
+const probeTool = (value: Tool, bundleRoot: string): McpProbeTool => Object.freeze({
+  ...(typeof value.description === 'string'
+    ? { description: redactProbeText(value.description, bundleRoot, mcpProbeToolTextLimit) }
+    : {}),
+  name: redactProbeText(value.name, bundleRoot, mcpProbeNameTextLimit),
+  ...(typeof value.title === 'string'
+    ? { title: redactProbeText(value.title, bundleRoot, mcpProbeToolTextLimit) }
+    : {}),
+});
+
+const serverInfoSnapshot = (
+  value: Implementation,
+  bundleRoot: string,
+): McpProbeSnapshot['serverInfo'] => Object.freeze({
+  name: redactProbeText(value.name, bundleRoot, mcpProbeNameTextLimit),
+  ...(typeof value.title === 'string'
+    ? { title: redactProbeText(value.title, bundleRoot, mcpProbeToolTextLimit) }
+    : {}),
+  version: redactProbeText(value.version, bundleRoot, mcpProbeNameTextLimit),
+});
+
+const errorDetail = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const connectFailureKind = (error: unknown): McpProbeFailureKind => {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code !== undefined && connectionErrorCodes.has(code)) return 'connect';
+  return /(?:connect|connection|spawn|exited?|socket)/iu.test(errorDetail(error))
+    ? 'connect'
+    : 'handshake';
+};
+
+const failureSnapshot = (
+  error: unknown,
+  bundleRoot: string,
+  fallbackKind: McpProbeFailureKind,
+): McpProbeFailure => Object.freeze({
+  detail: redactProbeText(errorDetail(error), bundleRoot, mcpProbeFailureTextLimit),
+  kind: error instanceof McpProbeTimeoutError || error instanceof McpProbeProtocolError
+    ? error.kind
+    : fallbackKind,
+});
+
+const positiveTimeout = (value: number): number => {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError('MCP probe timeout must be a positive safe integer.');
+  }
+  return value;
+};
+
+export class McpProbeService {
+  readonly #clock: () => number;
+  readonly #createClient: () => McpProbeClient;
+  readonly #createPluginData: () => Promise<string>;
+  readonly #createStdioTransport: NonNullable<McpProbeServiceOptions['createStdioTransport']>;
+  readonly #createStreamableHttpTransport: NonNullable<McpProbeServiceOptions['createStreamableHttpTransport']>;
+  readonly #inFlight = new Map<string, Promise<McpProbeReport>>();
+  readonly #now: () => Date;
+  readonly #prepared: McpProbeServiceOptions['prepared'];
+  readonly #projectRoot: string;
+  readonly #registry: TargetRegistry;
+  readonly #timeoutMs: number;
+
+  constructor(options: McpProbeServiceOptions) {
+    this.#clock = options.clock ?? (() => performance.now());
+    this.#createClient = options.createClient ??
+      (() => new Client(
+        { name: 'agent-bundle', version: '0.1.0' },
+        { capabilities: {} },
+      ));
+    this.#createPluginData = options.createPluginData ??
+      (() => mkdtemp(resolve(tmpdir(), 'agent-bundle-mcp-probe-')));
+    this.#createStdioTransport = options.createStdioTransport ??
+      ((stdioOptions) => new StdioClientTransport(stdioOptions));
+    this.#createStreamableHttpTransport = options.createStreamableHttpTransport ??
+      ((url, transportOptions) => new StreamableHTTPClientTransport(url, {
+        requestInit: transportOptions.headers === undefined
+          ? undefined
+          : { headers: transportOptions.headers },
+      }));
+    this.#now = options.now ?? (() => new Date());
+    this.#prepared = options.prepared;
+    this.#projectRoot = resolve(options.projectRoot);
+    this.#registry = options.registry ?? createDefaultRegistry();
+    this.#timeoutMs = positiveTimeout(options.timeoutMs ?? mcpProbeTimeoutMs);
+  }
+
+  probe(options: {
+    readonly host: McpProbeHost;
+    readonly serverName: string;
+  }): Promise<McpProbeReport> {
+    const key = `${options.host}:${options.serverName}`;
+    const inFlight = this.#inFlight.get(key);
+    if (inFlight !== undefined) return inFlight;
+    const probe = this.#run(options);
+    this.#inFlight.set(key, probe);
+    const settle = (): void => {
+      if (this.#inFlight.get(key) === probe) this.#inFlight.delete(key);
+    };
+    void probe.then(settle, settle);
+    return probe;
+  }
+
+  async #run(options: {
+    readonly host: McpProbeHost;
+    readonly serverName: string;
+  }): Promise<McpProbeReport> {
+    const startedAt = this.#clock();
+    const generatedAt = this.#now().toISOString();
+    const prepared = this.#prepared();
+    if (prepared === undefined) {
+      throw new McpProbeTargetNotFoundError('No prepared bundle is available for MCP probing.');
+    }
+    let bundleRoot: string;
+    try {
+      bundleRoot = await resolveBundleRoot(prepared.bundleSource, options.host);
+    } catch {
+      throw new McpProbeTargetNotFoundError(
+        `No prepared ${options.host} bundle is available for MCP probing.`,
+      );
+    }
+    const runtime = this.#runtime(options.host);
+    const server = await this.#server(bundleRoot, options.host, runtime, options.serverName);
+    const pluginData = await this.#createPluginData();
+    try {
+      const launch = resolveMcpSessionLaunch({
+        pluginData,
+        resolved: {
+          runtime,
+          server,
+          target: options.host,
+          targetRoot: bundleRoot,
+        },
+        workspaceRoot: this.#projectRoot,
+      });
+      const projectedLaunch = inspectorLaunch(
+        mcpSessionInspectorConfig(launch, bundleRoot).launch,
+      );
+      return await this.#execute({
+        bundleRoot,
+        generatedAt,
+        host: options.host,
+        launch,
+        projectedLaunch,
+        serverName: options.serverName,
+        startedAt,
+      });
+    } finally {
+      await rm(pluginData, { force: true, recursive: true });
+    }
+  }
+
+  #runtime(host: McpProbeHost): TargetMcpRuntimeContract {
+    let runtime: TargetMcpRuntimeContract | undefined;
+    try {
+      runtime = this.#registry.mcpRuntime(host);
+    } catch {
+      runtime = undefined;
+    }
+    if (runtime === undefined) {
+      throw new McpProbeTargetNotFoundError(
+        `Host ${JSON.stringify(host)} has no MCP runtime available for probing.`,
+      );
+    }
+    return runtime;
+  }
+
+  async #server(
+    bundleRoot: string,
+    host: McpProbeHost,
+    runtime: TargetMcpRuntimeContract,
+    serverName: string,
+  ) {
+    const document = parseJsonWithoutDuplicateKeys(
+      await readFile(resolve(bundleRoot, runtime.manifestPath), 'utf8'),
+    );
+    const result = readTargetMcpServer(runtime, document, serverName);
+    if (result.status === 'missing') {
+      throw new McpProbeTargetNotFoundError(
+        `MCP server ${JSON.stringify(serverName)} was not found for ${host}.`,
+      );
+    }
+    if (result.status === 'invalid') {
+      throw new Error(`The ${host} MCP manifest is invalid.`);
+    }
+    return result.server;
+  }
+
+  async #execute(options: {
+    readonly bundleRoot: string;
+    readonly generatedAt: string;
+    readonly host: McpProbeHost;
+    readonly launch: ResolvedMcpSessionLaunch;
+    readonly projectedLaunch: McpProbeLaunch;
+    readonly serverName: string;
+    readonly startedAt: number;
+  }): Promise<McpProbeReport> {
+    const client = this.#createClient();
+    const transport = this.#transport(options.launch);
+    let report: McpProbeReport;
+    try {
+      try {
+        await this.#withinBudget(
+          client.connect(transport),
+          options.startedAt,
+          'connect',
+          () => transport.close(),
+        );
+      } catch (error) {
+        const failure = failureSnapshot(
+          error,
+          options.bundleRoot,
+          connectFailureKind(error),
+        );
+        report = this.#failureReport(options, failure, error instanceof McpProbeTimeoutError);
+        return report;
+      }
+
+      const protocolVersion = client.getNegotiatedProtocolVersion();
+      const serverInfo = client.getServerVersion();
+      if (protocolVersion === undefined || protocolVersion.length === 0 || serverInfo === undefined) {
+        const error = new McpProbeProtocolError(
+          'handshake',
+          'The MCP initialize response omitted required server metadata.',
+        );
+        return this.#failureReport(
+          options,
+          failureSnapshot(error, options.bundleRoot, 'handshake'),
+          false,
+        );
+      }
+
+      let listed: { readonly tools: readonly Tool[] };
+      try {
+        listed = await this.#withinBudget(
+          client.listTools(),
+          options.startedAt,
+          'protocol',
+          () => transport.close(),
+        );
+      } catch (error) {
+        const protocolError = error instanceof McpProbeTimeoutError
+          ? error
+          : new McpProbeProtocolError('protocol', errorDetail(error), { cause: error });
+        return this.#failureReport(
+          options,
+          failureSnapshot(protocolError, options.bundleRoot, 'protocol'),
+          protocolError instanceof McpProbeTimeoutError,
+        );
+      }
+      const tools = Object.freeze(
+        listed.tools.slice(0, mcpProbeToolLimit).map((tool) => probeTool(tool, options.bundleRoot)),
+      );
+      const instructions = client.getInstructions();
+      const snapshot: McpProbeSnapshot = Object.freeze({
+        capabilities: capabilitySnapshot(client.getServerCapabilities()),
+        ...(instructions === undefined
+          ? {}
+          : {
+              instructions: redactProbeText(
+                instructions,
+                options.bundleRoot,
+                mcpProbeInstructionTextLimit,
+              ),
+            }),
+        protocolVersion: redactProbeText(
+          protocolVersion,
+          options.bundleRoot,
+          mcpProbeNameTextLimit,
+        ),
+        serverInfo: serverInfoSnapshot(serverInfo, options.bundleRoot),
+        tools,
+        toolsTruncated: listed.tools.length > mcpProbeToolLimit,
+      });
+      report = Object.freeze({
+        durationMs: Math.max(0, Math.round(this.#clock() - options.startedAt)),
+        generatedAt: options.generatedAt,
+        host: options.host,
+        launch: options.projectedLaunch,
+        serverName: options.serverName,
+        snapshot,
+        status: 'ok',
+      });
+      return report;
+    } finally {
+      await Promise.allSettled([client.close(), transport.close()]);
+    }
+  }
+
+  #failureReport(
+    options: {
+      readonly generatedAt: string;
+      readonly host: McpProbeHost;
+      readonly projectedLaunch: McpProbeLaunch;
+      readonly serverName: string;
+      readonly startedAt: number;
+    },
+    failure: McpProbeFailure,
+    timedOut: boolean,
+  ): McpProbeReport {
+    return Object.freeze({
+      durationMs: Math.max(0, Math.round(this.#clock() - options.startedAt)),
+      failure,
+      generatedAt: options.generatedAt,
+      host: options.host,
+      launch: options.projectedLaunch,
+      serverName: options.serverName,
+      status: timedOut ? 'timed-out' : 'unreachable',
+    });
+  }
+
+  #transport(launch: ResolvedMcpSessionLaunch): McpProbeTransport {
+    switch (launch.kind) {
+      case 'stdio':
+        return this.#createStdioTransport({
+          args: [...launch.args],
+          command: launch.command,
+          ...(launch.cwd === undefined ? {} : { cwd: launch.cwd }),
+          env: { ...launch.env },
+          stderr: 'pipe',
+        });
+      case 'streamable-http':
+        return this.#createStreamableHttpTransport(
+          launch.url,
+          launch.headers === undefined ? {} : { headers: { ...launch.headers } },
+        );
+      default: {
+        const exhaustive: never = launch;
+        throw new TypeError(`Unknown MCP probe transport ${String(exhaustive)}.`);
+      }
+    }
+  }
+
+  async #withinBudget<T>(
+    operation: Promise<T>,
+    startedAt: number,
+    kind: McpProbeFailureKind,
+    onTimeout: () => Promise<void>,
+  ): Promise<T> {
+    const remaining = Math.max(0, this.#timeoutMs - (this.#clock() - startedAt));
+    if (remaining === 0) {
+      await onTimeout().catch(() => undefined);
+      throw new McpProbeTimeoutError(kind);
+    }
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        void onTimeout().catch(() => undefined);
+        reject(new McpProbeTimeoutError(kind));
+      }, remaining);
+      timer.unref();
+    });
+    try {
+      return await Promise.race([operation, timedOut]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+}

--- a/packages/agent-bundle/src/dev/workbench-server.ts
+++ b/packages/agent-bundle/src/dev/workbench-server.ts
@@ -19,6 +19,10 @@ import {
 } from './playground/host-discovery-service.ts';
 import { LifecycleReplayService } from './playground/lifecycle-replay-service.ts';
 import {
+  McpProbeService,
+  type McpProbeServiceOptions,
+} from './playground/mcp-probe-service.ts';
+import {
   startForegroundServer,
   type ForegroundCoordinator,
   type ForegroundServerOptions,
@@ -119,6 +123,17 @@ interface DevServerTesting {
   readonly createSandboxProxy?: (options: CreateMcpAppSandboxProxyOptions) => Promise<McpAppSandboxProxy>;
   /** Overrides only Doctor execution and time; prepared build identity always comes from this dev server. */
   readonly hostDiscoveryOptions?: Pick<HostDiscoveryServiceOptions, 'doctor' | 'doctorOptions' | 'now'>;
+  readonly mcpProbeOptions?: Pick<
+    McpProbeServiceOptions,
+    | 'clock'
+    | 'createClient'
+    | 'createPluginData'
+    | 'createStdioTransport'
+    | 'createStreamableHttpTransport'
+    | 'now'
+    | 'registry'
+    | 'timeoutMs'
+  >;
   readonly openRuntimeClientSurface?: (
     endpoint: DevRuntimeClientSurfaceEndpoint,
     listener: Parameters<typeof RuntimeClientSurfaceProxy.open>[1],
@@ -696,18 +711,26 @@ export const startDevServer = async (options: StartDevServerOptions): Promise<De
     traceSink: createMcpDevLogTraceSink(logs),
   });
   const hookPlayground = new HookPlaygroundService({ epochStore, logger: logs, registry });
+  const preparedBundle = () => {
+    const prepared = latestValidPreparedProject;
+    if (prepared?.model === undefined) return undefined;
+    return Object.freeze({
+      bundleSource: join(root, prepared.artifactDistPath),
+      ...(prepared.source.revision === undefined
+        ? {}
+        : { manifestDigest: prepared.source.revision }),
+    });
+  };
   const hostDiscovery = new HostDiscoveryService({
     ...options.testing?.hostDiscoveryOptions,
-    prepared: () => {
-      const prepared = latestValidPreparedProject;
-      if (prepared?.model === undefined) return undefined;
-      return Object.freeze({
-        bundleSource: join(root, prepared.artifactDistPath),
-        ...(prepared.source.revision === undefined
-          ? {}
-          : { manifestDigest: prepared.source.revision }),
-      });
-    },
+    prepared: preparedBundle,
+    registry,
+  });
+  const mcpProbe = new McpProbeService({
+    prepared: preparedBundle,
+    projectRoot: root,
+    registry,
+    ...options.testing?.mcpProbeOptions,
   });
   const lifecycleReplay = new LifecycleReplayService({
     logger: logs,
@@ -799,6 +822,7 @@ export const startDevServer = async (options: StartDevServerOptions): Promise<De
     lifecycleReplay,
     logs,
     mcpAppPreviews: appPreviews,
+    mcpProbe,
     mcpSessions,
     playground,
     port: options.port,

--- a/packages/agent-bundle/src/install/doctor.ts
+++ b/packages/agent-bundle/src/install/doctor.ts
@@ -219,7 +219,7 @@ const readString = (
   return value;
 };
 
-const resolveBundleRoot = async (from: string, host: DoctorHost): Promise<string> => {
+export const resolveBundleRoot = async (from: string, host: DoctorHost): Promise<string> => {
   const root = resolve(from);
   const manifest = manifestPath(host);
   if (await exists(join(root, manifest))) return root;

--- a/packages/agent-bundle/tests/host-discovery-routes.test.ts
+++ b/packages/agent-bundle/tests/host-discovery-routes.test.ts
@@ -84,6 +84,22 @@ it('returns false for paths outside the discovery route', async () => {
   expect(authorized).toBe(false);
 });
 
+it('leaves the live MCP probe route for its dedicated handler', async () => {
+  let authorized = false;
+  const routes = new HostDiscoveryRoutes({
+    authorize: () => {
+      authorized = true;
+    },
+    service: new RecordingService(),
+  });
+
+  await expect(routes.handle(
+    { url: '/api/discovery/probes' } as IncomingMessage,
+    {} as ServerResponse,
+  )).resolves.toBe(false);
+  expect(authorized).toBe(false);
+});
+
 it('rejects discovery subpaths', async () => {
   const started = await startRoutes(new RecordingService());
   try {

--- a/packages/agent-bundle/tests/host-discovery-service.test.ts
+++ b/packages/agent-bundle/tests/host-discovery-service.test.ts
@@ -1,5 +1,10 @@
+import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { expect, it } from '@rstest/core';
 
+import type { TargetRegistry } from '../src/adapters/registry.ts';
 import type { HostDiscoveryReport } from '../src/contracts/discovery.ts';
 import { HostDiscoveryService } from '../src/dev/playground/host-discovery-service.ts';
 import type {
@@ -143,4 +148,80 @@ it('shares only an in-flight scan and starts a fresh scan after settlement', asy
   const freshReport = await service.discover();
   expect(calls).toBe(2);
   expect(freshReport).not.toBe(firstReport);
+});
+
+it('enumerates sorted modern MCP servers from a valid bundle manifest', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-bundle-discovery-mcp-'));
+  try {
+    await writeFile(join(root, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        zeta: { headers: {}, type: 'http', url: 'https://example.com/mcp' },
+        alpha: { args: [], command: 'node', type: 'stdio' },
+      },
+    }));
+    const service = new HostDiscoveryService({
+      doctor: async () => Object.freeze({
+        ...doctorReport,
+        hosts: Object.freeze([
+          Object.freeze({
+            ...doctorReport.hosts[0]!,
+            bundle: Object.freeze({ ...doctorReport.hosts[0]!.bundle!, bundleRoot: root }),
+          }),
+        ]),
+      }),
+    });
+
+    const report = await service.discover();
+
+    expect(report.hosts[0]?.bundle?.mcpServers).toEqual([
+      { name: 'alpha', transport: 'stdio' },
+      { name: 'zeta', transport: 'streamable-http' },
+    ]);
+    expect(Object.isFrozen(report.hosts[0]?.bundle?.mcpServers)).toBe(true);
+    expect(Object.isFrozen(report.hosts[0]?.bundle?.mcpServers?.[0])).toBe(true);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('distinguishes empty MCP manifests from manifests that could not be enumerated', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-bundle-discovery-mcp-empty-'));
+  try {
+    const service = new HostDiscoveryService({
+      doctor: async () => Object.freeze({
+        ...doctorReport,
+        hosts: Object.freeze([
+          Object.freeze({
+            ...doctorReport.hosts[0]!,
+            bundle: Object.freeze({ ...doctorReport.hosts[0]!.bundle!, bundleRoot: root }),
+          }),
+        ]),
+      }),
+    });
+
+    await writeFile(join(root, '.mcp.json'), '{"mcpServers":{}}');
+    expect((await service.discover()).hosts[0]?.bundle?.mcpServers).toEqual([]);
+
+    await writeFile(join(root, '.mcp.json'), '{"mcpServers":{"broken":');
+    expect((await service.discover()).hosts[0]?.bundle).not.toHaveProperty('mcpServers');
+
+    await unlink(join(root, '.mcp.json'));
+    expect((await service.discover()).hosts[0]?.bundle).not.toHaveProperty('mcpServers');
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('leaves MCP server enumeration absent when the host has no MCP runtime', async () => {
+  const registry = {
+    mcpRuntime: () => undefined,
+  } as unknown as TargetRegistry;
+  const service = new HostDiscoveryService({
+    doctor: async () => doctorReport,
+    registry,
+  });
+
+  const report = await service.discover();
+
+  expect(report.hosts[0]?.bundle).not.toHaveProperty('mcpServers');
 });

--- a/packages/agent-bundle/tests/mcp-probe-dev-server.test.ts
+++ b/packages/agent-bundle/tests/mcp-probe-dev-server.test.ts
@@ -1,0 +1,106 @@
+import { access, cp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { expect, it } from '@rstest/core';
+
+import { build } from '../src/api.ts';
+import type { McpProbeReport } from '../src/contracts/mcp-probe.ts';
+import { createWorkbenchAssetSource } from '../src/dev/workbench-assets.ts';
+import { startDevServer } from '../src/dev/workbench-server.ts';
+import { createProjectFixture } from './helpers/project-fixture.ts';
+import { agentBundleNodeModules } from './helpers/workspace-paths.ts';
+
+it('runs an authenticated initialize and tools/list probe against a real built stdio server', { timeout: 30_000 }, async () => {
+  const project = await createProjectFixture({
+    config: [
+      'export default {',
+      '  mcp: {',
+      '    servers: {',
+      "      timeline: { entry: { prebuilt: './prebuilt/runtime/mcp/stdio.js' }, transport: 'stdio' },",
+      '    },',
+      '  },',
+      "  payload: { runtime: './prebuilt/runtime' },",
+      "  plugin: { name: 'mcp-probe-dev-server', version: '1.0.0' },",
+      "  targets: ['claude'],",
+      '};',
+      '',
+    ].join('\n'),
+    files: { 'package.json': '{"type":"module"}\n' },
+    prefix: 'agent-bundle-mcp-probe-dev-server-',
+  });
+  const assetsRoot = join(project.root, 'workbench');
+  const exampleRuntime = join(
+    import.meta.dirname,
+    '..',
+    '..',
+    '..',
+    'examples',
+    'rsc-agent-runtime',
+    'dist',
+    'runtime',
+  );
+  let server: Awaited<ReturnType<typeof startDevServer>> | undefined;
+  await Promise.all([
+    mkdir(assetsRoot, { recursive: true }),
+    mkdir(join(project.root, 'dist'), { recursive: true }),
+    mkdir(join(project.root, 'prebuilt'), { recursive: true }),
+  ]);
+  await Promise.all([
+    cp(exampleRuntime, join(project.root, 'prebuilt', 'runtime'), { recursive: true }),
+    symlink(agentBundleNodeModules, join(project.root, 'node_modules'), 'dir'),
+    writeFile(join(assetsRoot, 'index.html'), '<!doctype html><title>MCP probe</title>'),
+  ]);
+  try {
+    const built = await build({ output: join(project.root, 'dist'), root: project.root });
+    expect(built.diagnostics.filter((entry) => entry.severity === 'error')).toEqual([]);
+    server = await startDevServer({
+      assets: createWorkbenchAssetSource({ root: assetsRoot }),
+      open: false,
+      port: 0,
+      root: project.root,
+    });
+    await access(join(project.root, 'dist', 'claude', '.mcp.json'));
+
+    const unauthenticated = await fetch(`${server.url}/api/discovery/probes`, {
+      body: JSON.stringify({ host: 'claude', serverName: 'timeline' }),
+      headers: {
+        'content-type': 'application/json',
+        origin: server.url,
+      },
+      method: 'POST',
+    });
+    expect(unauthenticated.status).toBe(403);
+
+    const bootstrap = await fetch(`${server.url}/api/project/session`, {
+      headers: { 'sec-fetch-site': 'same-origin' },
+    });
+    const { token } = await bootstrap.json() as { readonly token: string };
+    const response = await fetch(`${server.url}/api/discovery/probes`, {
+      body: JSON.stringify({ host: 'claude', serverName: 'timeline' }),
+      headers: {
+        'content-type': 'application/json',
+        origin: server.url,
+        'x-agent-bundle-session': token,
+      },
+      method: 'POST',
+    });
+    expect(response.status).toBe(200);
+    const report = await response.json() as McpProbeReport;
+
+    expect(report.status).toBe('ok');
+    expect(report.host).toBe('claude');
+    expect(report.serverName).toBe('timeline');
+    expect(report.snapshot?.protocolVersion).not.toBe('');
+    expect(report.snapshot?.tools.length).toBeGreaterThan(0);
+    expect(report.launch).toMatchObject({
+      command: 'node',
+      kind: 'stdio',
+    });
+    if (report.launch.kind !== 'stdio') throw new Error('Expected a stdio probe launch.');
+    expect(Object.keys(report.launch.env).every((key) =>
+      ['FORCE_COLOR', 'LANG', 'LC_ALL', 'NO_COLOR', 'TZ'].includes(key))).toBe(true);
+  } finally {
+    await server?.close().catch(() => undefined);
+    await rm(project.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 50 });
+  }
+});

--- a/packages/agent-bundle/tests/mcp-probe-routes.test.ts
+++ b/packages/agent-bundle/tests/mcp-probe-routes.test.ts
@@ -1,0 +1,274 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { expect, it } from '@rstest/core';
+
+import type { McpProbeReport } from '../src/contracts/mcp-probe.ts';
+import {
+  McpProbeRoutes,
+  type McpProbeRouteService,
+} from '../src/dev/playground/mcp-probe-routes.ts';
+import { McpProbeTargetNotFoundError } from '../src/dev/playground/mcp-probe-service.ts';
+import {
+  authorize,
+  originHeaders,
+  routeError,
+  startRoutes as startRouteServer,
+} from './support/route-harness.ts';
+
+const unreachableReport = Object.freeze({
+  durationMs: 12,
+  failure: Object.freeze({ detail: 'connect ECONNREFUSED', kind: 'connect' }),
+  generatedAt: '2026-09-02T07:00:00.000Z',
+  host: 'claude',
+  launch: Object.freeze({
+    args: Object.freeze(['mcp/timeline.js']),
+    command: 'node',
+    env: Object.freeze({}),
+    kind: 'stdio',
+  }),
+  serverName: 'timeline',
+  status: 'unreachable',
+}) satisfies McpProbeReport;
+
+class RecordingService implements McpProbeRouteService {
+  calls: { readonly host: 'claude' | 'codex' | 'cursor'; readonly serverName: string }[] = [];
+  result: McpProbeReport = unreachableReport;
+
+  async probe(options: {
+    readonly host: 'claude' | 'codex' | 'cursor';
+    readonly serverName: string;
+  }): Promise<McpProbeReport> {
+    this.calls.push(options);
+    return this.result;
+  }
+}
+
+const startRoutes = async (
+  service?: McpProbeRouteService,
+  responseByteLimit?: number,
+) => startRouteServer(new McpProbeRoutes({
+  authorize,
+  ...(responseByteLimit === undefined ? {} : { responseByteLimit }),
+  ...(service === undefined ? {} : { service }),
+}), { closeMode: 'awaited' });
+
+const post = (
+  url: string,
+  body: unknown,
+  headers: Readonly<Record<string, string>> = originHeaders(),
+) => fetch(url, {
+  body: JSON.stringify(body),
+  headers: { ...headers, 'content-type': 'application/json' },
+  method: 'POST',
+});
+
+it('authorizes before probing', async () => {
+  let probed = false;
+  const started = await startRouteServer(new McpProbeRoutes({
+    authorize: () => {
+      throw routeError('AB8004', 'A valid same-session token is required.', 403);
+    },
+    service: {
+      probe: async () => {
+        probed = true;
+        return unreachableReport;
+      },
+    },
+  }), { closeMode: 'awaited' });
+  try {
+    const response = await post(`${started.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'timeline',
+    }, {});
+    expect(response.status).toBe(403);
+    expect(probed).toBe(false);
+  } finally {
+    await started.close();
+  }
+});
+
+it('returns false for the host discovery root', async () => {
+  let authorized = false;
+  const routes = new McpProbeRoutes({
+    authorize: () => {
+      authorized = true;
+    },
+    service: new RecordingService(),
+  });
+
+  await expect(routes.handle(
+    { url: '/api/discovery' } as IncomingMessage,
+    {} as ServerResponse,
+  )).resolves.toBe(false);
+  expect(authorized).toBe(false);
+});
+
+it('rejects longer probe paths with AB8219', async () => {
+  const started = await startRoutes(new RecordingService());
+  try {
+    const response = await post(`${started.url}/api/discovery/probes/extra`, {});
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8219',
+        message: 'MCP probe route path is not valid.',
+      },
+    });
+  } finally {
+    await started.close();
+  }
+});
+
+it('rejects methods and query parameters with AB8220', async () => {
+  const started = await startRoutes(new RecordingService());
+  try {
+    const getResponse = await fetch(`${started.url}/api/discovery/probes`, {
+      headers: originHeaders(),
+    });
+    expect(getResponse.status).toBe(405);
+    await expect(getResponse.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8220',
+        message: 'MCP probe request is not valid.',
+      },
+    });
+
+    const queryResponse = await post(
+      `${started.url}/api/discovery/probes?refresh=true`,
+      { host: 'claude', serverName: 'timeline' },
+    );
+    expect(queryResponse.status).toBe(400);
+    await expect(queryResponse.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8220',
+        message: 'MCP probe request is not valid.',
+      },
+    });
+  } finally {
+    await started.close();
+  }
+});
+
+it('rejects request shapes outside the host and server-name selector', async () => {
+  const started = await startRoutes(new RecordingService());
+  try {
+    for (const body of [
+      { extra: true, host: 'claude', serverName: 'timeline' },
+      { host: 'portable', serverName: 'timeline' },
+      { host: 'claude', serverName: '' },
+      { host: 'claude', serverName: 'x'.repeat(257) },
+      { host: 'claude' },
+    ]) {
+      const response = await post(`${started.url}/api/discovery/probes`, body);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        diagnostic: {
+          code: 'AB8220',
+          message: 'MCP probe request is not valid.',
+        },
+      });
+    }
+  } finally {
+    await started.close();
+  }
+});
+
+it('maps typed target misses to AB8221', async () => {
+  const started = await startRoutes({
+    probe: async () => {
+      throw new McpProbeTargetNotFoundError('MCP server "missing" was not found for claude.');
+    },
+  });
+  try {
+    const response = await post(`${started.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'missing',
+    });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8221',
+        message: 'MCP server "missing" was not found for claude.',
+      },
+    });
+  } finally {
+    await started.close();
+  }
+});
+
+it('serves honest unreachable reports as HTTP 200', async () => {
+  const service = new RecordingService();
+  const started = await startRoutes(service);
+  try {
+    const response = await post(`${started.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'timeline',
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(unreachableReport);
+    expect(service.calls).toEqual([{ host: 'claude', serverName: 'timeline' }]);
+  } finally {
+    await started.close();
+  }
+});
+
+it('rejects probe reports over the named response budget', async () => {
+  const started = await startRoutes(new RecordingService(), 32);
+  try {
+    const response = await post(`${started.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'timeline',
+    });
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8222',
+        message: 'MCP probe exceeds the 16 MiB response limit.',
+      },
+    });
+  } finally {
+    await started.close();
+  }
+});
+
+it('reports the probe unavailable when no service was provided or routes closed', async () => {
+  const absent = await startRoutes();
+  try {
+    const response = await post(`${absent.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'timeline',
+    });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8223',
+        message: 'MCP probing is not available.',
+      },
+    });
+  } finally {
+    await absent.close();
+  }
+});
+
+it('maps unexpected probe failures to a bounded AB8220 response', async () => {
+  const started = await startRoutes({
+    probe: async () => {
+      throw new Error('unexpected internal detail');
+    },
+  });
+  try {
+    const response = await post(`${started.url}/api/discovery/probes`, {
+      host: 'claude',
+      serverName: 'timeline',
+    });
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      diagnostic: {
+        code: 'AB8220',
+        message: 'MCP probe could not be completed.',
+      },
+    });
+  } finally {
+    await started.close();
+  }
+});

--- a/packages/agent-bundle/tests/mcp-probe-service.test.ts
+++ b/packages/agent-bundle/tests/mcp-probe-service.test.ts
@@ -1,0 +1,274 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, it } from '@rstest/core';
+
+import type { TargetRegistry } from '../src/adapters/registry.ts';
+import {
+  McpProbeService,
+  McpProbeTargetNotFoundError,
+  mcpProbeInstructionTextLimit,
+  mcpProbeToolLimit,
+  type McpProbeClient,
+  type McpProbeServiceOptions,
+  type McpProbeTransport,
+} from '../src/dev/playground/mcp-probe-service.ts';
+
+const createBundle = async (
+  servers: Readonly<Record<string, unknown>> = {
+    timeline: {
+      args: ['${CLAUDE_PLUGIN_ROOT}/mcp/timeline.js', '--token=super-secret-value'],
+      command: 'node',
+      env: { LANG: 'en_US.UTF-8', SECRET_TOKEN: 'super-secret-value' },
+      type: 'stdio',
+    },
+  },
+): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-bundle-mcp-probe-'));
+  await mkdir(join(root, '.claude-plugin'), { recursive: true });
+  await writeFile(join(root, '.claude-plugin', 'plugin.json'), '{"name":"probe","version":"1.0.0"}');
+  await writeFile(join(root, '.mcp.json'), JSON.stringify({ mcpServers: servers }));
+  return root;
+};
+
+const transport = (
+  close: () => Promise<void> = async () => undefined,
+): McpProbeTransport => ({
+  close,
+  send: async () => undefined,
+  start: async () => undefined,
+});
+
+const client = (
+  overrides: Partial<McpProbeClient> = {},
+): McpProbeClient => ({
+  close: async () => undefined,
+  connect: async () => undefined,
+  getInstructions: () => 'Use token=abc12345678901234567 at /home/private/config.json',
+  getNegotiatedProtocolVersion: () => '2025-11-25',
+  getServerCapabilities: () => ({
+    experimental: {},
+    prompts: {},
+    resources: {},
+    tools: {},
+  }),
+  getServerVersion: () => ({
+    name: 'timeline',
+    title: 'Timeline Server',
+    version: '1.2.3',
+  }),
+  listTools: async () => ({
+    tools: Array.from({ length: mcpProbeToolLimit + 1 }, (_, index) => ({
+      description: index === 0
+        ? 'Reads token=abc12345678901234567 from /home/private/config.json'
+        : `Tool ${index}`,
+      inputSchema: { type: 'object' as const },
+      name: `tool-${index}`,
+      title: `Tool ${index}`,
+    })),
+  }),
+  ...overrides,
+});
+
+const serviceFor = (
+  bundleRoot: string,
+  overrides: Partial<McpProbeServiceOptions> = {},
+): McpProbeService => new McpProbeService({
+  createClient: () => client(),
+  createStdioTransport: () => transport(),
+  createStreamableHttpTransport: () => transport(),
+  now: () => new Date('2026-09-02T07:00:00.000Z'),
+  prepared: () => Object.freeze({ bundleSource: bundleRoot }),
+  projectRoot: '/workspace/project',
+  ...overrides,
+});
+
+it('maps a bounded, frozen successful probe snapshot and redacted launch', async () => {
+  const root = await createBundle();
+  try {
+    const report = await serviceFor(root).probe({ host: 'claude', serverName: 'timeline' });
+
+    expect(report.status).toBe('ok');
+    expect(report.generatedAt).toBe('2026-09-02T07:00:00.000Z');
+    expect(report.launch).toEqual({
+      args: [join(root, 'mcp', 'timeline.js'), '[REDACTED]'],
+      command: 'node',
+      cwd: root,
+      env: { LANG: 'en_US.UTF-8' },
+      kind: 'stdio',
+    });
+    expect(report.snapshot).toMatchObject({
+      capabilities: {
+        experimental: true,
+        prompts: true,
+        resources: true,
+        tools: true,
+      },
+      protocolVersion: '2025-11-25',
+      serverInfo: {
+        name: 'timeline',
+        title: 'Timeline Server',
+        version: '1.2.3',
+      },
+      toolsTruncated: true,
+    });
+    expect(report.snapshot?.instructions).toBe('[REDACTED]');
+    expect(report.snapshot?.tools).toHaveLength(mcpProbeToolLimit);
+    expect(report.snapshot?.tools[0]?.description).toBe('[REDACTED]');
+    expect(JSON.stringify(report)).not.toContain('super-secret-value');
+    expect(JSON.stringify(report)).not.toContain('abc12345678901234567');
+    expect(JSON.stringify(report)).not.toContain('/home/private');
+    expect(Object.isFrozen(report)).toBe(true);
+    expect(Object.isFrozen(report.snapshot)).toBe(true);
+    expect(Object.isFrozen(report.snapshot?.tools)).toBe(true);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('truncates server instructions to the named text budget', async () => {
+  const root = await createBundle();
+  try {
+    const service = serviceFor(root, {
+      createClient: () => client({
+        getInstructions: () => 'x'.repeat(mcpProbeInstructionTextLimit + 100),
+        listTools: async () => ({ tools: [] }),
+      }),
+    });
+
+    const report = await service.probe({ host: 'claude', serverName: 'timeline' });
+
+    const instructions = report.snapshot?.instructions;
+    expect(instructions).toHaveLength(mcpProbeInstructionTextLimit);
+    expect(instructions?.endsWith('…')).toBe(true);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('reports connect rejection as an honest unreachable probe result', async () => {
+  const root = await createBundle();
+  try {
+    const service = serviceFor(root, {
+      createClient: () => client({
+        connect: async () => {
+          const error = new Error('connect ECONNREFUSED /home/private/server.sock') as NodeJS.ErrnoException;
+          error.code = 'ECONNREFUSED';
+          throw error;
+        },
+      }),
+    });
+
+    const report = await service.probe({ host: 'claude', serverName: 'timeline' });
+
+    expect(report).toMatchObject({
+      failure: { detail: '[REDACTED]', kind: 'connect' },
+      status: 'unreachable',
+    });
+    expect(report).not.toHaveProperty('snapshot');
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('times out within the total budget and destroys the transport', async () => {
+  const root = await createBundle();
+  let transportCloses = 0;
+  try {
+    const service = serviceFor(root, {
+      createClient: () => client({ connect: () => new Promise(() => undefined) }),
+      createStdioTransport: () => transport(async () => {
+        transportCloses += 1;
+      }),
+      timeoutMs: 10,
+    });
+
+    const report = await service.probe({ host: 'claude', serverName: 'timeline' });
+
+    expect(report.status).toBe('timed-out');
+    expect(report.failure?.kind).toBe('connect');
+    expect(transportCloses).toBeGreaterThan(0);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('coalesces only identical in-flight probes and clears them after settlement', async () => {
+  const root = await createBundle();
+  const connectStarted = Promise.withResolvers<void>();
+  const connected = Promise.withResolvers<void>();
+  let clients = 0;
+  try {
+    const service = serviceFor(root, {
+      createClient: () => {
+        clients += 1;
+        return client({
+          connect: () => {
+            connectStarted.resolve();
+            return connected.promise;
+          },
+          listTools: async () => ({ tools: [] }),
+        });
+      },
+    });
+    const first = service.probe({ host: 'claude', serverName: 'timeline' });
+    const concurrent = service.probe({ host: 'claude', serverName: 'timeline' });
+    expect(first).toBe(concurrent);
+    await connectStarted.promise;
+    expect(clients).toBe(1);
+
+    connected.resolve();
+    const [firstReport, concurrentReport] = await Promise.all([first, concurrent]);
+    expect(firstReport).toBe(concurrentReport);
+
+    await service.probe({ host: 'claude', serverName: 'timeline' });
+    expect(clients).toBe(2);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('throws typed not-found errors for unavailable trusted probe targets', async () => {
+  const root = await createBundle();
+  try {
+    await expect(new McpProbeService({
+      prepared: () => undefined,
+      projectRoot: '/workspace/project',
+    }).probe({ host: 'claude', serverName: 'timeline' })).rejects.toBeInstanceOf(McpProbeTargetNotFoundError);
+
+    await expect(serviceFor(root).probe({
+      host: 'claude',
+      serverName: 'missing',
+    })).rejects.toBeInstanceOf(McpProbeTargetNotFoundError);
+
+    const registry = { mcpRuntime: () => undefined } as unknown as TargetRegistry;
+    await expect(serviceFor(root, { registry }).probe({
+      host: 'claude',
+      serverName: 'timeline',
+    })).rejects.toBeInstanceOf(McpProbeTargetNotFoundError);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('removes the fresh plugin data directory after every probe', async () => {
+  const root = await createBundle();
+  let pluginData: string | undefined;
+  try {
+    const service = serviceFor(root, {
+      createPluginData: async () => {
+        pluginData = await mkdtemp(join(tmpdir(), 'agent-bundle-mcp-probe-data-'));
+        await writeFile(join(pluginData, 'proof.txt'), 'present');
+        return pluginData;
+      },
+    });
+
+    await service.probe({ host: 'claude', serverName: 'timeline' });
+
+    await expect(readFile(join(pluginData!, 'proof.txt'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  } finally {
+    if (pluginData !== undefined) await rm(pluginData, { force: true, recursive: true });
+    await rm(root, { force: true, recursive: true });
+  }
+});

--- a/packages/workbench/src/discovery/discovery-atoms.ts
+++ b/packages/workbench/src/discovery/discovery-atoms.ts
@@ -3,11 +3,37 @@ import { Effect } from 'effect';
 import { Atom } from 'effect/unstable/reactivity';
 import { useCallback, useEffect, useState } from 'react';
 
-import type { HostDiscoveryReport } from './discovery-client.ts';
+import type {
+  HostDiscoveryReport,
+  McpProbeHost,
+  McpProbeReport,
+} from './discovery-client.ts';
 
 export type DiscoveryLoader = (signal?: AbortSignal) => Promise<HostDiscoveryReport>;
+export type DiscoveryProbeLoader = (
+  request: Readonly<{ readonly host: McpProbeHost; readonly serverName: string }>,
+  signal?: AbortSignal,
+) => Promise<McpProbeReport>;
+
+export type DiscoveryProbeState =
+  | Readonly<{ readonly state: 'consent-pending' }>
+  | Readonly<{ readonly state: 'probing' }>
+  | Readonly<{ readonly report: McpProbeReport; readonly state: 'settled' }>
+  | Readonly<{ readonly code: string; readonly message: string; readonly state: 'failed' }>
+  | undefined;
 
 export const discoveryLoaderAtom = Atom.make<DiscoveryLoader | undefined>(undefined);
+export const discoveryProbeLoaderAtom = Atom.make<DiscoveryProbeLoader | undefined>(undefined);
+
+export const discoveryProbeKey = (
+  refreshKey: number,
+  host: McpProbeHost,
+  serverName: string,
+): string => `${String(refreshKey)}\u0000${host}\u0000${serverName}`;
+
+export const discoveryProbeStateAtom = Atom.family(
+  (key: string) => Atom.make<DiscoveryProbeState>(undefined),
+);
 
 export const discoveryReportAtom = Atom.family((refreshKey: number) => Atom.make((get) => {
   const loader = get.once(discoveryLoaderAtom);
@@ -28,6 +54,19 @@ export const useDiscoveryLoader = (loader: DiscoveryLoader | undefined): boolean
     setCurrent((latest: DiscoveryLoader | undefined) => latest === loader ? latest : loader);
     return () => {
       setCurrent((latest: DiscoveryLoader | undefined) => latest === loader ? undefined : latest);
+    };
+  }, [loader, setCurrent]);
+  return loader === undefined || current !== undefined;
+};
+
+export const useDiscoveryProbeLoader = (
+  loader: DiscoveryProbeLoader | undefined,
+): boolean => {
+  const [current, setCurrent] = useAtom(discoveryProbeLoaderAtom);
+  useEffect(() => {
+    setCurrent((latest: DiscoveryProbeLoader | undefined) => latest === loader ? latest : loader);
+    return () => {
+      setCurrent((latest: DiscoveryProbeLoader | undefined) => latest === loader ? undefined : latest);
     };
   }, [loader, setCurrent]);
   return loader === undefined || current !== undefined;

--- a/packages/workbench/src/discovery/discovery-client.ts
+++ b/packages/workbench/src/discovery/discovery-client.ts
@@ -15,6 +15,18 @@ import type {
   DiscoveryProbeStatus,
   HostDiscoveryReport,
 } from '../../../agent-bundle/src/contracts/discovery.ts';
+import type {
+  McpProbeFailure,
+  McpProbeFailureKind,
+  McpProbeHost,
+  McpProbeLaunch,
+  McpProbeLaunchRemote,
+  McpProbeLaunchStdio,
+  McpProbeReport,
+  McpProbeSnapshot,
+  McpProbeStatus,
+  McpProbeTool,
+} from '../../../agent-bundle/src/contracts/mcp-probe.ts';
 import { deeplyFrozenHookValue } from '../hooks/hook-client.ts';
 import type { ForegroundRequestAuthority } from '../mcp/mcp-route-client.ts';
 
@@ -32,6 +44,16 @@ export type {
   DiscoveryProbe,
   DiscoveryProbeStatus,
   HostDiscoveryReport,
+  McpProbeFailure,
+  McpProbeFailureKind,
+  McpProbeHost,
+  McpProbeLaunch,
+  McpProbeLaunchRemote,
+  McpProbeLaunchStdio,
+  McpProbeReport,
+  McpProbeSnapshot,
+  McpProbeStatus,
+  McpProbeTool,
 };
 
 export interface DiscoveryClientOptions {
@@ -52,6 +74,9 @@ export class DiscoveryClientError extends Error {
 
 const invalidResponse = (): DiscoveryClientError =>
   new DiscoveryClientError('AB8234', 'Host discovery route returned an invalid response.');
+
+const invalidProbeResponse = (): DiscoveryClientError =>
+  new DiscoveryClientError('AB8235', 'MCP probe route returned an invalid response.');
 
 const textSchema = z.string();
 const diagnosticSchema = z.strictObject({
@@ -107,6 +132,10 @@ const bundleFindingSchema = z.strictObject({
   ...findingShape,
   bundleRoot: textSchema.optional(),
   marketplace: textSchema.optional(),
+  mcpServers: z.array(z.strictObject({
+    name: textSchema,
+    transport: z.enum(['stdio', 'streamable-http']),
+  })).optional(),
 });
 const probeSchema = z.strictObject({
   evidence: z.literal('directory').optional(),
@@ -154,11 +183,68 @@ const errorResponseSchema = z.strictObject({
   }),
 });
 
-const frozenInput = (value: unknown): unknown => {
+const mcpProbeLaunchSchema = z.union([
+  z.strictObject({
+    args: z.array(textSchema),
+    command: textSchema,
+    cwd: textSchema.optional(),
+    env: z.record(textSchema, textSchema),
+    kind: z.literal('stdio'),
+  }),
+  z.strictObject({
+    kind: z.literal('streamable-http'),
+    url: textSchema,
+  }),
+]);
+const mcpProbeToolSchema = z.strictObject({
+  description: textSchema.optional(),
+  name: textSchema,
+  title: textSchema.optional(),
+});
+const mcpProbeSnapshotSchema = z.strictObject({
+  capabilities: z.record(textSchema, z.boolean()),
+  instructions: textSchema.optional(),
+  protocolVersion: textSchema,
+  serverInfo: z.strictObject({
+    name: textSchema,
+    title: textSchema.optional(),
+    version: textSchema,
+  }),
+  tools: z.array(mcpProbeToolSchema),
+  toolsTruncated: z.boolean(),
+});
+const mcpProbeFailureSchema = z.strictObject({
+  detail: textSchema,
+  kind: z.enum(['connect', 'handshake', 'protocol']),
+});
+const mcpProbeReportShape = {
+  durationMs: z.number(),
+  generatedAt: textSchema,
+  host: z.enum(['claude', 'codex', 'cursor']),
+  launch: mcpProbeLaunchSchema,
+  serverName: textSchema,
+} as const;
+const mcpProbeReportSchema = z.union([
+  z.strictObject({
+    ...mcpProbeReportShape,
+    snapshot: mcpProbeSnapshotSchema,
+    status: z.literal('ok'),
+  }),
+  z.strictObject({
+    ...mcpProbeReportShape,
+    failure: mcpProbeFailureSchema,
+    status: z.enum(['timed-out', 'unreachable']),
+  }),
+]);
+
+const frozenInput = (
+  value: unknown,
+  invalid: () => DiscoveryClientError = invalidResponse,
+): unknown => {
   try {
     return deeplyFrozenHookValue(value);
   } catch {
-    throw invalidResponse();
+    throw invalid();
   }
 };
 
@@ -168,23 +254,47 @@ const decode = (value: unknown): HostDiscoveryReport => {
   return frozenInput(parsed.data) as HostDiscoveryReport;
 };
 
-const failureFor = (value: unknown, status: number): DiscoveryClientError => {
+const decodeProbe = (value: unknown): McpProbeReport => {
+  const parsed = mcpProbeReportSchema.safeParse(frozenInput(value, invalidProbeResponse));
+  if (!parsed.success) throw invalidProbeResponse();
+  return frozenInput(parsed.data, invalidProbeResponse) as McpProbeReport;
+};
+
+const diagnosticFailureFor = (
+  value: unknown,
+  status: number,
+  fallbackCode: string,
+  fallbackMessage: string,
+  invalid: () => DiscoveryClientError,
+): DiscoveryClientError => {
   let parsed: z.infer<typeof errorResponseSchema> | undefined;
   try {
-    const result = errorResponseSchema.safeParse(frozenInput(value));
+    const result = errorResponseSchema.safeParse(frozenInput(value, invalid));
     if (result.success) parsed = result.data;
   } catch {
     // Invalid failure bodies fall through to the status-only diagnostic.
   }
   if (parsed === undefined) {
-    return new DiscoveryClientError(
-      'AB8234',
-      `Host discovery request failed with HTTP ${String(status)}.`,
-      status,
-    );
+    return new DiscoveryClientError(fallbackCode, fallbackMessage, status);
   }
   return new DiscoveryClientError(parsed.diagnostic.code, parsed.diagnostic.message, status);
 };
+
+const failureFor = (value: unknown, status: number): DiscoveryClientError => diagnosticFailureFor(
+  value,
+  status,
+  'AB8234',
+  `Host discovery request failed with HTTP ${String(status)}.`,
+  invalidResponse,
+);
+
+const probeFailureFor = (value: unknown, status: number): DiscoveryClientError => diagnosticFailureFor(
+  value,
+  status,
+  'AB8235',
+  `MCP probe request failed with HTTP ${String(status)}.`,
+  invalidProbeResponse,
+);
 
 /** Strict browser client for read-only local host discovery. */
 export class DiscoveryClient {
@@ -202,5 +312,20 @@ export class DiscoveryClient {
     const body: unknown = await response.json().catch(() => undefined);
     if (!response.ok) throw failureFor(body, response.status);
     return decode(body);
+  }
+
+  async probe(
+    request: Readonly<{ readonly host: McpProbeHost; readonly serverName: string }>,
+    signal?: AbortSignal,
+  ): Promise<McpProbeReport> {
+    const response = await this.#foreground.protectedRequest('/api/discovery/probes', {
+      body: JSON.stringify(request),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+      ...(signal === undefined ? {} : { signal }),
+    });
+    const body: unknown = await response.json().catch(() => undefined);
+    if (!response.ok) throw probeFailureFor(body, response.status);
+    return decodeProbe(body);
   }
 }

--- a/packages/workbench/src/discovery/discovery-model.ts
+++ b/packages/workbench/src/discovery/discovery-model.ts
@@ -9,9 +9,11 @@ import type {
   DiscoveryInventoryStatus,
   DiscoveryProbe,
   HostDiscoveryReport,
+  McpProbeReport,
+  McpProbeStatus,
 } from './discovery-client.ts';
 
-export type DiscoveryPresentationTone = 'error' | 'info' | 'neutral' | 'warning';
+export type DiscoveryPresentationTone = 'error' | 'info' | 'neutral' | 'positive' | 'warning';
 
 export interface DiscoveryPresentation {
   readonly label: string;
@@ -58,6 +60,12 @@ export interface HostDiscoveryView {
   readonly report: HostDiscoveryReport;
 }
 
+export interface McpProbeView {
+  readonly capabilityNames: readonly string[];
+  readonly presentation: DiscoveryPresentation;
+  readonly report: McpProbeReport;
+}
+
 const presentation = (
   label: string,
   tone: DiscoveryPresentationTone,
@@ -77,6 +85,29 @@ export const probePresentationFor = (probe: DiscoveryProbe): DiscoveryPresentati
     }
   }
 };
+
+export const mcpProbePresentationFor = (status: McpProbeStatus): DiscoveryPresentation => {
+  switch (status) {
+    case 'ok':
+      return presentation('Connected', 'positive');
+    case 'timed-out':
+      return presentation('Timed out', 'neutral');
+    case 'unreachable':
+      return presentation('Unreachable', 'neutral');
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+};
+
+export const mcpProbeViewFor = (report: McpProbeReport): McpProbeView => Object.freeze({
+  capabilityNames: Object.freeze(
+    report.status === 'ok' ? Object.keys(report.snapshot?.capabilities ?? {}) : [],
+  ),
+  presentation: mcpProbePresentationFor(report.status),
+  report,
+});
 
 export const inventoryPresentationFor = (
   host: DiscoveryHost,

--- a/packages/workbench/src/discovery/discovery-page.css
+++ b/packages/workbench/src/discovery/discovery-page.css
@@ -26,6 +26,7 @@
 .discovery-badge { border: 1px solid currentColor; border-radius: 999px; display: inline-block; flex: 0 0 auto; font-size: 10px; font-weight: 800; letter-spacing: .04em; max-width: 100%; padding: 4px 8px; text-align: center; text-transform: uppercase; }
 .discovery-badge--neutral { background: #f1f4f7; color: #475569; }
 .discovery-badge--info { background: #eef5ff; color: #0759c7; }
+.discovery-badge--positive { background: #ecf8f0; color: #18733b; }
 .discovery-badge--warning { background: #fff8df; color: #8a6200; }
 .discovery-badge--error { background: #fff0f0; color: #b31b23; }
 .discovery-facts { display: grid; margin: 0; }
@@ -66,3 +67,47 @@
 .discovery-diagnostic > div span { font-size: 10px; font-weight: 800; text-transform: uppercase; }
 .discovery-diagnostic p { color: #374151; font-size: 12px; margin: 6px 0 0; }
 .discovery-diagnostic small { color: #687386; display: block; font-size: 10px; margin-top: 6px; }
+.discovery-mcp-servers { border-top: 1px solid #d9dee7; margin-top: 14px; padding-top: 13px; }
+.discovery-mcp-servers > .discovery-section-heading > span { color: #687386; font-size: 10px; font-weight: 700; }
+.discovery-mcp-servers > ul { display: grid; gap: 10px; list-style: none; margin: 0; padding: 0; }
+.discovery-mcp-servers > ul > li { background: #f7f9fc; border: 1px solid #d4dce7; padding: 10px; }
+.discovery-mcp-server-heading { align-items: center; display: flex; justify-content: space-between; }
+.discovery-mcp-server-heading > div { align-items: center; display: flex; flex-wrap: wrap; gap: 7px; min-width: 0; }
+.discovery-mcp-server-heading strong { color: #24364e; font-size: 12px; overflow-wrap: anywhere; }
+.discovery-mcp-probe-button, .discovery-mcp-consent button { border: 1px solid #8794a6; border-radius: 4px; cursor: pointer; font-size: 11px; font-weight: 750; min-height: 31px; padding: 0 11px; }
+.discovery-mcp-probe-button { background: #fff; color: #23466f; margin-top: 9px; }
+.discovery-mcp-probe-button:hover, .discovery-mcp-consent button:first-child:hover { background: #edf2f7; }
+.discovery-mcp-consent { background: #fffbea; border: 1px solid #ddc977; border-left: 3px solid #a87500; margin-top: 9px; padding: 10px; }
+.discovery-mcp-consent h4, .discovery-mcp-consent p { margin: 0; }
+.discovery-mcp-consent h4 { color: #654d00; font-size: 12px; }
+.discovery-mcp-consent p { color: #514b32; font-size: 11px; line-height: 1.5; margin-top: 6px; }
+.discovery-mcp-consent > div { display: flex; gap: 7px; margin-top: 9px; }
+.discovery-mcp-consent button { background: #fff; color: #334155; }
+.discovery-mcp-consent button:last-child { background: #0b5bd3; border-color: #06459e; color: #fff; }
+.discovery-mcp-consent button:last-child:hover { background: #084eb9; }
+.discovery-mcp-consent button:disabled { cursor: wait; opacity: .55; }
+.discovery-mcp-probing { background: #eef5ff; border-left: 3px solid #0b5bd3; color: #23466f; font-size: 11px; margin: 9px 0 0; padding: 9px; }
+.discovery-mcp-result { background: #fff; border: 1px solid #b8d8c3; border-left: 3px solid #2d8650; margin-top: 9px; padding: 10px; }
+.discovery-mcp-result--down { background: #f8fafc; border-color: #cbd4e0; border-left-color: #64748b; }
+.discovery-mcp-result-heading { align-items: center; display: flex; gap: 8px; justify-content: space-between; }
+.discovery-mcp-result-heading h4, .discovery-mcp-result h5, .discovery-mcp-launch h5 { color: #334155; font-size: 10px; font-weight: 800; letter-spacing: .05em; margin: 0; text-transform: uppercase; }
+.discovery-mcp-result > p { color: #4b5563; font-size: 11px; line-height: 1.45; margin: 8px 0 0; }
+.discovery-mcp-server-facts { border-bottom: 1px solid #d9dee7; border-top: 1px solid #d9dee7; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 10px; }
+.discovery-mcp-server-facts > div:nth-child(3) { border-left: 0; border-top: 1px solid #d9dee7; }
+.discovery-mcp-server-facts > div:nth-child(4) { border-top: 1px solid #d9dee7; }
+.discovery-mcp-capabilities, .discovery-mcp-instructions, .discovery-mcp-tools, .discovery-mcp-launch { margin-top: 11px; }
+.discovery-mcp-capabilities > div { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.discovery-mcp-instructions p { color: #4b5563; display: -webkit-box; font-size: 11px; line-height: 1.45; margin: 6px 0 0; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 4; }
+.discovery-mcp-tools-table { margin-top: 6px; }
+.discovery-mcp-tools-table th:nth-child(1), .discovery-mcp-tools-table td:nth-child(1) { width: 30%; }
+.discovery-mcp-tools-table th:nth-child(2), .discovery-mcp-tools-table td:nth-child(2) { width: 25%; }
+.discovery-mcp-tools-table th:nth-child(3), .discovery-mcp-tools-table td:nth-child(3) { width: 45%; }
+.discovery-mcp-launch { border-top: 1px solid #d9dee7; padding-top: 10px; }
+.discovery-mcp-launch > code { display: block; font: 10px/1.5 "SFMono-Regular", Consolas, "Liberation Mono", monospace; margin-top: 6px; overflow-wrap: anywhere; }
+.discovery-mcp-launch p { color: #687386; font-size: 10px; margin: 6px 0 0; }
+.discovery-mcp-launch ul { list-style: none; margin: 6px 0 0; padding: 0; }
+.discovery-mcp-launch li { font-size: 10px; overflow-wrap: anywhere; }
+.discovery-mcp-probe-metadata { border-top: 1px solid #d9dee7; grid-template-columns: 1fr 2fr; margin-top: 10px; }
+.discovery-mcp-request-error { background: #fff5f5; border-left: 3px solid #c01d26; color: #78242a; margin-top: 9px; padding: 9px; }
+.discovery-mcp-request-error h4, .discovery-mcp-request-error p { font-size: 11px; margin: 0; }
+.discovery-mcp-request-error p { line-height: 1.45; margin-top: 5px; }

--- a/packages/workbench/src/discovery/discovery-page.tsx
+++ b/packages/workbench/src/discovery/discovery-page.tsx
@@ -1,11 +1,16 @@
-import { useAtomValue } from '@effect/atom-react';
+import { useAtom, useAtomValue } from '@effect/atom-react';
 import { AsyncResult } from 'effect/unstable/reactivity';
-import React, { useMemo, type ReactNode } from 'react';
+import React, { useEffect, useMemo, useRef, type ReactNode } from 'react';
 
 import {
   discoveryReportAtom,
+  discoveryProbeKey,
+  discoveryProbeLoaderAtom,
+  discoveryProbeStateAtom,
   type DiscoveryLoader,
+  type DiscoveryProbeLoader,
   useDiscoveryLoader,
+  useDiscoveryProbeLoader,
   useDiscoveryRefresh,
 } from './discovery-atoms.ts';
 import {
@@ -13,11 +18,14 @@ import {
   type DiscoveryDiagnostic,
   type DiscoveryFinding,
   type DiscoveryHost,
+  type McpProbeLaunch,
+  type McpProbeReport,
   type HostDiscoveryReport,
 } from './discovery-client.ts';
 import {
   hostDiscoveryViewFor,
   isStaleReport,
+  mcpProbeViewFor,
   type DiscoveryBundleView,
   type DiscoveryFindingView,
   type DiscoveryHostView,
@@ -25,7 +33,7 @@ import {
 } from './discovery-model.ts';
 import './discovery-page.css';
 
-export type DiscoveryClientSurface = Pick<DiscoveryClient, 'discover'>;
+export type DiscoveryClientSurface = Pick<DiscoveryClient, 'discover' | 'probe'>;
 
 export interface DiscoveryPageProps {
   readonly client: DiscoveryClientSurface;
@@ -57,6 +65,19 @@ const errorDetails = (reason: unknown): Readonly<{ readonly code: string; readon
   return Object.freeze({
     code: 'AB8234',
     message: 'Host discovery request could not be completed.',
+  });
+};
+
+const probeErrorDetails = (
+  reason: unknown,
+): Readonly<{ readonly code: string; readonly message: string }> => {
+  if (reason instanceof Error) {
+    const code = 'code' in reason && typeof reason.code === 'string' ? reason.code : 'AB8235';
+    return Object.freeze({ code, message: reason.message });
+  }
+  return Object.freeze({
+    code: 'AB8235',
+    message: 'MCP probe request could not be completed.',
   });
 };
 
@@ -105,8 +126,260 @@ const DurableState = ({ finding }: Readonly<{
   </ul>}
 </div>;
 
-const BundleCheck = ({ bundle }: Readonly<{
+const launchSummary = (launch: McpProbeLaunch): ReactNode => {
+  switch (launch.kind) {
+    case 'stdio': {
+      const environment = Object.entries(launch.env);
+      return <>
+        <code>{[launch.command, ...launch.args].join(' ')}</code>
+        {launch.cwd === undefined ? undefined : <p>Working directory: <code>{launch.cwd}</code></p>}
+        {environment.length === 0
+          ? <p>No environment entries.</p>
+          : <ul aria-label="Redacted launch environment">
+              {environment.map(([name, value]) => <li key={name}><code>{name}={value}</code></li>)}
+            </ul>}
+      </>;
+    }
+    case 'streamable-http':
+      return <code>{launch.url}</code>;
+    default: {
+      const exhaustive: never = launch;
+      return exhaustive;
+    }
+  }
+};
+
+const McpProbeResult = ({ report }: Readonly<{ readonly report: McpProbeReport }>) => {
+  const view = mcpProbeViewFor(report);
+  const metadata = <dl className="discovery-facts discovery-mcp-probe-metadata">
+    <div><dt>Duration</dt><dd>{String(report.durationMs)} ms</dd></div>
+    <div><dt>Generated at</dt><dd>{report.generatedAt}</dd></div>
+  </dl>;
+  const launch = <section className="discovery-mcp-launch" aria-label="Redacted launch summary">
+    <h5>Redacted launch summary</h5>
+    {launchSummary(report.launch)}
+  </section>;
+
+  switch (report.status) {
+    case 'ok': {
+      const snapshot = report.snapshot;
+      if (snapshot === undefined) return undefined;
+      return <div className="discovery-mcp-result">
+        <div className="discovery-mcp-result-heading">
+          <h4>Live probe result</h4>
+          <StatusBadge presentation={view.presentation} />
+        </div>
+        <dl className="discovery-facts discovery-mcp-server-facts">
+          <div><dt>Protocol</dt><dd>{snapshot.protocolVersion}</dd></div>
+          <div><dt>Server name</dt><dd>{snapshot.serverInfo.name}</dd></div>
+          <div><dt>Title</dt><dd>{valueOrDash(snapshot.serverInfo.title)}</dd></div>
+          <div><dt>Version</dt><dd>{snapshot.serverInfo.version}</dd></div>
+        </dl>
+        {view.capabilityNames.length === 0 ? undefined : <div className="discovery-mcp-capabilities">
+          <h5>Capabilities</h5>
+          <div>{view.capabilityNames.map((capability) =>
+            <span className="discovery-badge discovery-badge--neutral" key={capability}>{capability}</span>)}</div>
+        </div>}
+        {snapshot.instructions === undefined ? undefined : <section className="discovery-mcp-instructions">
+          <h5>Instructions</h5>
+          <p>{snapshot.instructions}</p>
+        </section>}
+        <section className="discovery-mcp-tools" aria-label={`${report.serverName} tools`}>
+          <h5>Read-only tool catalog</h5>
+          {snapshot.tools.length === 0
+            ? <p className="discovery-empty">No tools were reported.</p>
+            : <table className="discovery-table discovery-mcp-tools-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Title</th>
+                    <th scope="col">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshot.tools.map((tool) => <tr key={tool.name}>
+                    <td><code>{tool.name}</code></td>
+                    <td>{valueOrDash(tool.title)}</td>
+                    <td>{valueOrDash(tool.description)}</td>
+                  </tr>)}
+                </tbody>
+              </table>}
+          {snapshot.toolsTruncated
+            ? <p className="discovery-honest-state">The tool catalog was truncated by the probe response limit.</p>
+            : undefined}
+        </section>
+        {launch}
+        {metadata}
+      </div>;
+    }
+    case 'timed-out':
+    case 'unreachable':
+      return <div className="discovery-mcp-result discovery-mcp-result--down">
+        <div className="discovery-mcp-result-heading">
+          <h4>Live probe result</h4>
+          <StatusBadge presentation={view.presentation} />
+        </div>
+        {report.failure === undefined ? undefined : <>
+          <p><strong>{report.failure.kind}</strong></p>
+          <p>{report.failure.detail}</p>
+        </>}
+        {launch}
+        {metadata}
+      </div>;
+    default: {
+      const exhaustive: never = report.status;
+      return exhaustive;
+    }
+  }
+};
+
+const McpServerProbe = ({ host, refreshKey, serverName }: Readonly<{
+  readonly host: DiscoveryHost;
+  readonly refreshKey: number;
+  readonly serverName: string;
+}>) => {
+  const [state, setState] = useAtom(
+    discoveryProbeStateAtom(discoveryProbeKey(refreshKey, host, serverName)),
+  );
+  const probe = useAtomValue(discoveryProbeLoaderAtom);
+  const activeRequest = useRef<AbortController | undefined>(undefined);
+
+  useEffect(() => () => {
+    activeRequest.current?.abort();
+    activeRequest.current = undefined;
+  }, []);
+
+  const confirm = (): void => {
+    if (probe === undefined || activeRequest.current !== undefined) return;
+    const request = new AbortController();
+    activeRequest.current = request;
+    setState(Object.freeze({ state: 'probing' }));
+    void probe(Object.freeze({ host, serverName }), request.signal).then(
+      (report) => {
+        if (activeRequest.current !== request) return;
+        activeRequest.current = undefined;
+        setState(Object.freeze({ report, state: 'settled' }));
+      },
+      (reason: unknown) => {
+        if (activeRequest.current !== request) return;
+        activeRequest.current = undefined;
+        if (reason instanceof Error && reason.name === 'AbortError') return;
+        const error = probeErrorDetails(reason);
+        setState(Object.freeze({ ...error, state: 'failed' }));
+      },
+    );
+  };
+
+  if (state === undefined) {
+    return <button
+      aria-label={`Probe ${serverName}`}
+      className="discovery-mcp-probe-button"
+      onClick={() => setState(Object.freeze({ state: 'consent-pending' }))}
+      type="button"
+    >
+      Probe
+    </button>;
+  }
+  switch (state.state) {
+    case 'consent-pending':
+      return <div className="discovery-mcp-consent">
+        <h4>Consent required</h4>
+        <p>
+          This read-only live probe performs an MCP initialize handshake and tools/list against
+          the installed bundle&apos;s <strong>{serverName}</strong> server. It starts the server
+          process or connects to its endpoint on this machine. Nothing is stored, and this
+          surface cannot call tools.
+        </p>
+        <div>
+          <button onClick={() => setState(undefined)} type="button">Cancel</button>
+          <button disabled={probe === undefined} onClick={confirm} type="button">Run live probe</button>
+        </div>
+      </div>;
+    case 'probing':
+      return <p className="discovery-mcp-probing" role="status">Probing {serverName}…</p>;
+    case 'settled':
+      return <>
+        <McpProbeResult report={state.report} />
+        <button
+          aria-label={`Probe ${serverName} again`}
+          className="discovery-mcp-probe-button"
+          onClick={() => setState(Object.freeze({ state: 'consent-pending' }))}
+          type="button"
+        >
+          Probe again
+        </button>
+      </>;
+    case 'failed':
+      return <>
+        <div className="discovery-mcp-request-error" role="alert">
+          <h4>Live probe unavailable</h4>
+          <p><strong>{state.code}</strong> {state.message}</p>
+        </div>
+        <button
+          aria-label={`Probe ${serverName} again`}
+          className="discovery-mcp-probe-button"
+          onClick={() => setState(Object.freeze({ state: 'consent-pending' }))}
+          type="button"
+        >
+          Try again
+        </button>
+      </>;
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+const transportLabelFor = (
+  transport: 'stdio' | 'streamable-http',
+): string => {
+  switch (transport) {
+    case 'stdio':
+      return 'stdio';
+    case 'streamable-http':
+      return 'streamable HTTP';
+    default: {
+      const exhaustive: never = transport;
+      return exhaustive;
+    }
+  }
+};
+
+const McpServers = ({ bundle, host, refreshKey }: Readonly<{
   readonly bundle: DiscoveryBundleView;
+  readonly host: DiscoveryHost;
+  readonly refreshKey: number;
+}>) => {
+  const servers = bundle.finding?.mcpServers;
+  if (servers === undefined) return undefined;
+  return <section className="discovery-mcp-servers" aria-label={`${hostLabelFor(host)} MCP servers`}>
+    <div className="discovery-section-heading">
+      <h3>MCP servers</h3>
+      <span>{String(servers.length)} declared</span>
+    </div>
+    {servers.length === 0
+      ? <p className="discovery-empty">No MCP servers are declared by this bundle.</p>
+      : <ul>
+          {servers.map((server) => <li key={server.name}>
+            <div className="discovery-mcp-server-heading">
+              <div>
+                <strong>{server.name}</strong>
+                <span className="discovery-badge discovery-badge--neutral">
+                  {transportLabelFor(server.transport)}
+                </span>
+              </div>
+            </div>
+            <McpServerProbe host={host} refreshKey={refreshKey} serverName={server.name} />
+          </li>)}
+        </ul>}
+  </section>;
+};
+
+const BundleCheck = ({ bundle, host, refreshKey }: Readonly<{
+  readonly bundle: DiscoveryBundleView;
+  readonly host: DiscoveryHost;
+  readonly refreshKey: number;
 }>) => <section className="discovery-bundle" aria-label="Bundle check">
   <div className="discovery-section-heading">
     <h3>Bundle check</h3>
@@ -119,10 +392,12 @@ const BundleCheck = ({ bundle }: Readonly<{
       <div><dt>Version</dt><dd>{valueOrDash(bundle.finding.version)}</dd></div>
     </dl>
     <DurableState finding={bundle.finding} />
+    <McpServers bundle={bundle} host={host} refreshKey={refreshKey} />
   </>}
 </section>;
 
-const HostCard = ({ view }: Readonly<{
+const HostCard = ({ refreshKey, view }: Readonly<{
+  readonly refreshKey: number;
   readonly view: DiscoveryHostView;
 }>) => <section aria-label={view.label} className="discovery-host-card" role="group">
   <header>
@@ -147,7 +422,7 @@ const HostCard = ({ view }: Readonly<{
         : <FindingTable findings={view.inventory.findings} />
       : <p className="discovery-honest-state">{view.inventory.presentation.label}</p>}
   </section>
-  <BundleCheck bundle={view.bundle} />
+  <BundleCheck bundle={view.bundle} host={view.host} refreshKey={refreshKey} />
 </section>;
 
 const EndpointFindings = ({ findings }: Readonly<{
@@ -189,9 +464,10 @@ const Diagnostics = ({ diagnostics }: Readonly<{
       </ol>}
 </section>;
 
-const DiscoveryReport = ({ manifestDigest, onRefresh, report }: Readonly<{
+const DiscoveryReport = ({ manifestDigest, onRefresh, refreshKey, report }: Readonly<{
   readonly manifestDigest: string | undefined;
   readonly onRefresh: () => void;
+  readonly refreshKey: number;
   readonly report: HostDiscoveryReport;
 }>) => {
   const view = hostDiscoveryViewFor(report);
@@ -218,7 +494,7 @@ const DiscoveryReport = ({ manifestDigest, onRefresh, report }: Readonly<{
       <StatusBadge presentation={view.build} />
     </section>
     <div className="discovery-host-grid">
-      {view.hosts.map((host) => <HostCard key={host.host} view={host} />)}
+      {view.hosts.map((host) => <HostCard key={host.host} refreshKey={refreshKey} view={host} />)}
     </div>
     <section aria-label="Runtime endpoints" className="discovery-endpoints">
       <div className="discovery-title-row">
@@ -259,6 +535,7 @@ const DiscoveryResult = ({ manifestDigest, onRefresh, refreshKey }: Readonly<{
     onSuccess: ({ value }) => <DiscoveryReport
       manifestDigest={manifestDigest}
       onRefresh={onRefresh}
+      refreshKey={refreshKey}
       report={value}
     />,
     onWaiting: () => <p className="discovery-loading" role="status">Loading host discovery</p>,
@@ -268,7 +545,12 @@ const DiscoveryResult = ({ manifestDigest, onRefresh, refreshKey }: Readonly<{
 /** Read-only browser view of local hosts, installed bundles, drift, and runtime endpoints. */
 export const DiscoveryPage = ({ client, manifestDigest }: DiscoveryPageProps) => {
   const loader = useMemo<DiscoveryLoader>(() => (signal) => client.discover(signal), [client]);
+  const probeLoader = useMemo<DiscoveryProbeLoader>(
+    () => (request, signal) => client.probe(request, signal),
+    [client],
+  );
   const loaderReady = useDiscoveryLoader(loader);
+  const probeLoaderReady = useDiscoveryProbeLoader(probeLoader);
   const [refreshKey, refresh] = useDiscoveryRefresh();
 
   return <section aria-label="Host discovery" className="discovery-content" role="region">
@@ -279,7 +561,7 @@ export const DiscoveryPage = ({ client, manifestDigest }: DiscoveryPageProps) =>
         <p>Read-only discovery of local agent hosts, installed bundles, drift against the current build, and runtime endpoints.</p>
       </div>
     </div>
-    {loaderReady
+    {loaderReady && probeLoaderReady
       ? <DiscoveryResult manifestDigest={manifestDigest} onRefresh={refresh} refreshKey={refreshKey} />
       : <p className="discovery-loading" role="status">Loading host discovery</p>}
   </section>;

--- a/packages/workbench/tests/discovery-atoms-disposal.test.ts
+++ b/packages/workbench/tests/discovery-atoms-disposal.test.ts
@@ -11,10 +11,12 @@ import { createWorkbenchConfig } from '../rsbuild.config.ts';
 declare global {
   interface Window {
     __discoveryAtoms: {
-      mount(mode: 'never' | 'resolving'): void;
+      mount(mode: 'never' | 'probe-never' | 'resolving'): void;
       readonly stats: {
         neverAborted: number;
         neverCalls: number;
+        probeAborted: number;
+        probeCalls: number;
         resolvingCalls: number;
         unmounts: number;
       };
@@ -68,11 +70,44 @@ const fixtureSource = (root: string): string => `
       summary: { live: 0, staleLocks: 0, staleSockets: 0 },
     },
     generatedAt: '2026-09-01T12:00:00.000Z',
-    hosts: [],
+    hosts: [{
+      bundle: {
+        bundleRoot: '/workspace/dist',
+        mcpServers: [{ name: 'timeline', transport: 'stdio' }],
+        name: 'agent-bundle',
+        state: 'installed',
+      },
+      diagnostics: [],
+      host: 'claude',
+      inventory: { findings: [], status: 'known' },
+      probe: { status: 'available', version: '1.2.3' },
+    }],
     manifestDigest: 'manifest-current',
     summary: { errors: 0, infos: 0, warnings: 0 },
   } as const;
-  const stats = { neverAborted: 0, neverCalls: 0, resolvingCalls: 0, unmounts: 0 };
+  const probeReport = {
+    durationMs: 12,
+    generatedAt: '2026-09-01T12:00:01.000Z',
+    host: 'claude',
+    launch: { args: ['dist/timeline.js'], command: 'node', env: {}, kind: 'stdio' },
+    serverName: 'timeline',
+    snapshot: {
+      capabilities: { tools: true },
+      protocolVersion: '2025-06-18',
+      serverInfo: { name: 'timeline-server', version: '1.0.0' },
+      tools: [{ description: 'Lists entries.', name: 'timeline_list', title: 'List timeline' }],
+      toolsTruncated: false,
+    },
+    status: 'ok',
+  } as const;
+  const stats = {
+    neverAborted: 0,
+    neverCalls: 0,
+    probeAborted: 0,
+    probeCalls: 0,
+    resolvingCalls: 0,
+    unmounts: 0,
+  };
   const neverClient = {
     discover: (signal?: AbortSignal) => {
       stats.neverCalls += 1;
@@ -80,21 +115,43 @@ const fixtureSource = (root: string): string => `
         signal?.addEventListener('abort', () => { stats.neverAborted += 1; }, { once: true });
       });
     },
+    probe: async () => probeReport,
   };
   const resolvingClient = {
     discover: async () => {
       stats.resolvingCalls += 1;
       return report;
     },
+    probe: async () => {
+      stats.probeCalls += 1;
+      return probeReport;
+    },
+  };
+  const probeNeverClient = {
+    discover: async () => {
+      stats.resolvingCalls += 1;
+      return report;
+    },
+    probe: (_request: unknown, signal?: AbortSignal) => {
+      stats.probeCalls += 1;
+      return new Promise<never>(() => {
+        signal?.addEventListener('abort', () => { stats.probeAborted += 1; }, { once: true });
+      });
+    },
   };
 
   const Fixture = () => {
-    const [state, setState] = useState<{ mounted: boolean; mode: 'never' | 'resolving' }>({
+    const [state, setState] = useState<{
+      mounted: boolean;
+      mode: 'never' | 'probe-never' | 'resolving';
+    }>({
       mode: 'never',
       mounted: false,
     });
     window.__discoveryAtoms = {
-      mount: (mode: 'never' | 'resolving') => { setState({ mode, mounted: true }); },
+      mount: (mode: 'never' | 'probe-never' | 'resolving') => {
+        setState({ mode, mounted: true });
+      },
       stats,
       unmount: () => {
         stats.unmounts += 1;
@@ -103,7 +160,11 @@ const fixtureSource = (root: string): string => `
     };
     return state.mounted
       ? <DiscoveryPage
-          client={state.mode === 'never' ? neverClient : resolvingClient}
+          client={state.mode === 'never'
+            ? neverClient
+            : state.mode === 'probe-never'
+              ? probeNeverClient
+              : resolvingClient}
           manifestDigest="manifest-current"
         />
       : <p>Discovery unmounted</p>;
@@ -163,6 +224,32 @@ describe('Discovery atoms', () => {
       const callsBeforeRerun = await page.evaluate(() => window.__discoveryAtoms.stats.resolvingCalls);
       await page.getByRole('button', { name: 'Re-run discovery' }).first().click();
       await expect.poll(() => page.evaluate(() => window.__discoveryAtoms.stats.resolvingCalls)).toBe(callsBeforeRerun + 1);
+
+      expect(await page.evaluate(() => window.__discoveryAtoms.stats.probeCalls)).toBe(0);
+      await page.getByRole('button', { name: 'Probe timeline' }).click();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+      expect(await page.evaluate(() => window.__discoveryAtoms.stats.probeCalls)).toBe(0);
+      await page.getByRole('button', { name: 'Probe timeline' }).click();
+      await page.getByRole('button', { name: 'Run live probe' }).click();
+      await page.getByText('Connected', { exact: true }).waitFor({ timeout: 5_000 });
+      expect(await page.evaluate(() => window.__discoveryAtoms.stats.probeCalls)).toBe(1);
+
+      await page.evaluate(() => window.__discoveryAtoms.unmount());
+      await page.getByText('Discovery unmounted', { exact: true }).waitFor({ timeout: 5_000 });
+      await page.evaluate(() => window.__discoveryAtoms.mount('resolving'));
+      await page.getByRole('button', { name: 'Probe timeline' }).waitFor({ timeout: 5_000 });
+      await expect.poll(() => page.getByText('Connected', { exact: true }).count()).toBe(0);
+
+      await page.evaluate(() => window.__discoveryAtoms.unmount());
+      await page.evaluate(() => window.__discoveryAtoms.mount('probe-never'));
+      await page.getByRole('button', { name: 'Probe timeline' }).click();
+      await page.getByRole('button', { name: 'Run live probe' }).click();
+      await expect.poll(() => page.evaluate(() => window.__discoveryAtoms.stats.probeCalls)).toBe(2);
+      await page.evaluate(() => window.__discoveryAtoms.unmount());
+      await expect.poll(() => page.evaluate(() => window.__discoveryAtoms.stats.probeAborted)).toBe(1);
+      await page.evaluate(() => window.__discoveryAtoms.mount('resolving'));
+      await page.getByRole('button', { name: 'Probe timeline' }).waitFor({ timeout: 5_000 });
+      await expect.poll(() => page.getByText('Connected', { exact: true }).count()).toBe(0);
       expect(errors).toEqual([]);
     } finally {
       await browser.close();

--- a/packages/workbench/tests/discovery-client.test.ts
+++ b/packages/workbench/tests/discovery-client.test.ts
@@ -7,6 +7,8 @@ import {
 import type { ForegroundRequestAuthority } from '../src/mcp/mcp-route-client.ts';
 
 interface RecordedRequest {
+  readonly body?: BodyInit | null;
+  readonly contentType?: string;
   readonly method: string;
   readonly signal?: AbortSignal;
   readonly url: string;
@@ -77,6 +79,10 @@ const fullReport = {
       bundleRoot: '/home/user/.codex/plugins/agent-bundle',
       durableState,
       marketplace: 'local',
+      mcpServers: [{
+        name: 'timeline',
+        transport: 'stdio' as const,
+      }],
       name: 'agent-bundle',
       state: 'drifted' as const,
       version: '1.2.2',
@@ -107,6 +113,10 @@ const authority = (
 ): ForegroundRequestAuthority => ({
   protectedRequest: async (path, init = {}) => {
     calls.push({
+      ...(init.body === null || init.body === undefined ? {} : { body: init.body }),
+      ...(new Headers(init.headers).get('content-type') === null
+        ? {}
+        : { contentType: new Headers(init.headers).get('content-type')! }),
       method: init.method ?? 'GET',
       ...(init.signal === null || init.signal === undefined ? {} : { signal: init.signal }),
       url: String(path),
@@ -127,6 +137,11 @@ it('decodes and deeply freezes a full discovery report through the foreground au
   expect(Object.isFrozen(result)).toBe(true);
   expect(Object.isFrozen(result.hosts)).toBe(true);
   expect(Object.isFrozen(result.hosts[1]!.bundle!.durableState!.findings)).toBe(true);
+  expect(result.hosts[1]!.bundle!.mcpServers).toEqual([{
+    name: 'timeline',
+    transport: 'stdio',
+  }]);
+  expect(result.hosts[0]!.bundle?.mcpServers).toBeUndefined();
 });
 
 it('rejects unknown keys at every discovery response boundary', async () => {
@@ -144,6 +159,16 @@ it('rejects unknown keys at every discovery response boundary', async () => {
     { ...fullReport, hosts: [{ ...firstHost, probe: { ...firstHost.probe, extra: true } }] },
     { ...fullReport, hosts: [{ ...firstHost, inventory: { ...firstHost.inventory, extra: true } }] },
     { ...fullReport, hosts: [{ ...firstHost, bundle: { ...firstHost.bundle!, extra: true } }] },
+    {
+      ...fullReport,
+      hosts: [{
+        ...firstHost,
+        bundle: {
+          ...firstHost.bundle!,
+          mcpServers: [{ name: 'timeline', transport: 'stdio', extra: true }],
+        },
+      }],
+    },
     {
       ...fullReport,
       hosts: [{
@@ -198,6 +223,16 @@ it('rejects every out-of-range discovery enum value', async () => {
         ...firstHost,
         bundle: {
           ...firstHost.bundle!,
+          mcpServers: [{ name: 'timeline', transport: 'websocket' }],
+        },
+      }],
+    },
+    {
+      ...fullReport,
+      hosts: [{
+        ...firstHost,
+        bundle: {
+          ...firstHost.bundle!,
           durableState: { ...durableState, status: 'failed' },
         },
       }],
@@ -235,5 +270,139 @@ it('surfaces a server diagnostic from a non-success response', async () => {
     code: 'discovery.probe.denied',
     message: 'Host discovery is unavailable in this session.',
     status: 403,
+  });
+});
+
+const okProbeReport = {
+  durationMs: 42,
+  generatedAt: '2026-09-01T12:01:00.000Z',
+  host: 'claude' as const,
+  launch: {
+    args: ['dist/timeline.js'],
+    command: 'node',
+    cwd: '/workspace/dist',
+    env: { NODE_ENV: 'production' },
+    kind: 'stdio' as const,
+  },
+  serverName: 'timeline',
+  snapshot: {
+    capabilities: { tools: true },
+    instructions: 'Read-only timeline inspection.',
+    protocolVersion: '2025-06-18',
+    serverInfo: {
+      name: 'timeline-server',
+      title: 'Timeline',
+      version: '1.0.0',
+    },
+    tools: [{
+      description: 'Lists timeline entries.',
+      name: 'timeline_list',
+      title: 'List timeline',
+    }],
+    toolsTruncated: false,
+  },
+  status: 'ok' as const,
+};
+
+const unreachableProbeReport = {
+  durationMs: 7,
+  failure: {
+    detail: 'The redacted server command exited before initialize completed.',
+    kind: 'connect' as const,
+  },
+  generatedAt: '2026-09-01T12:02:00.000Z',
+  host: 'claude' as const,
+  launch: {
+    args: ['-e', 'process.exit(0)'],
+    command: 'node',
+    env: {},
+    kind: 'stdio' as const,
+  },
+  serverName: 'probe-down',
+  status: 'unreachable' as const,
+};
+
+it('posts a probe request and deeply freezes a successful report', async () => {
+  const calls: RecordedRequest[] = [];
+  const signal = new AbortController().signal;
+  const client = new DiscoveryClient({
+    foreground: authority(calls, () => jsonResponse(okProbeReport)),
+  });
+
+  const result = await client.probe({ host: 'claude', serverName: 'timeline' }, signal);
+
+  expect(result).toEqual(okProbeReport);
+  expect(calls).toEqual([{
+    body: JSON.stringify({ host: 'claude', serverName: 'timeline' }),
+    contentType: 'application/json',
+    method: 'POST',
+    signal,
+    url: '/api/discovery/probes',
+  }]);
+  expect(Object.isFrozen(result)).toBe(true);
+  expect(Object.isFrozen(result.snapshot?.tools)).toBe(true);
+  expect(Object.isFrozen(result.launch)).toBe(true);
+});
+
+it('decodes an honest unreachable probe report', async () => {
+  const client = new DiscoveryClient({
+    foreground: authority([], () => jsonResponse(unreachableProbeReport)),
+  });
+
+  await expect(client.probe({ host: 'claude', serverName: 'probe-down' }))
+    .resolves.toEqual(unreachableProbeReport);
+});
+
+it('rejects probe invariant violations and unknown keys with AB8235', async () => {
+  const { snapshot: _snapshot, ...okWithoutSnapshot } = okProbeReport;
+  const { failure: _failure, ...unreachableWithoutFailure } = unreachableProbeReport;
+  const malformed = [
+    okWithoutSnapshot,
+    unreachableWithoutFailure,
+    { ...okProbeReport, failure: unreachableProbeReport.failure },
+    { ...unreachableProbeReport, snapshot: okProbeReport.snapshot },
+    { ...okProbeReport, extra: true },
+  ];
+
+  for (const body of malformed) {
+    const client = new DiscoveryClient({
+      foreground: authority([], () => jsonResponse(body)),
+    });
+    await expect(client.probe({ host: 'claude', serverName: 'timeline' })).rejects.toMatchObject({
+      code: 'AB8235',
+      message: 'MCP probe route returned an invalid response.',
+    });
+  }
+});
+
+it('surfaces a server diagnostic from a failed probe request', async () => {
+  const client = new DiscoveryClient({
+    foreground: authority([], () => jsonResponse({
+      diagnostic: {
+        code: 'AB8221',
+        message: 'MCP server timeline was not found for claude.',
+      },
+    }, 404)),
+  });
+
+  const failure = await client.probe({ host: 'claude', serverName: 'timeline' })
+    .catch((reason: unknown) => reason);
+  expect(failure).toBeInstanceOf(DiscoveryClientError);
+  expect(failure).toMatchObject({
+    code: 'AB8221',
+    message: 'MCP server timeline was not found for claude.',
+    status: 404,
+  });
+});
+
+it('uses AB8235 with status for a malformed probe failure body', async () => {
+  const client = new DiscoveryClient({
+    foreground: authority([], () => jsonResponse({ error: 'unavailable' }, 503)),
+  });
+
+  await expect(client.probe({ host: 'claude', serverName: 'timeline' })).rejects.toMatchObject({
+    code: 'AB8235',
+    message: 'MCP probe request failed with HTTP 503.',
+    status: 503,
   });
 });

--- a/packages/workbench/tests/discovery-model.test.ts
+++ b/packages/workbench/tests/discovery-model.test.ts
@@ -5,6 +5,8 @@ import {
   findingPresentationFor,
   inventoryPresentationFor,
   isStaleReport,
+  mcpProbePresentationFor,
+  mcpProbeViewFor,
   probePresentationFor,
 } from '../src/discovery/discovery-model.ts';
 
@@ -49,4 +51,49 @@ it('maps risky and healthy finding states to honest tones', () => {
   expect(findingPresentationFor('drifted').tone).toBe('warning');
   expect(findingPresentationFor('failed').tone).toBe('error');
   expect(findingPresentationFor('installed').tone).toBe('neutral');
+});
+
+it('presents successful and down MCP probe statuses honestly', () => {
+  expect(mcpProbePresentationFor('ok')).toEqual({
+    label: 'Connected',
+    tone: 'positive',
+  });
+  expect(mcpProbePresentationFor('unreachable')).toEqual({
+    label: 'Unreachable',
+    tone: 'neutral',
+  });
+  expect(mcpProbePresentationFor('timed-out')).toEqual({
+    label: 'Timed out',
+    tone: 'neutral',
+  });
+});
+
+it('derives a frozen MCP probe view with capability names', () => {
+  const report = {
+    durationMs: 42,
+    generatedAt: '2026-09-01T12:01:00.000Z',
+    host: 'claude' as const,
+    launch: {
+      args: ['dist/timeline.js'],
+      command: 'node',
+      env: {},
+      kind: 'stdio' as const,
+    },
+    serverName: 'timeline',
+    snapshot: {
+      capabilities: { prompts: false, tools: true },
+      protocolVersion: '2025-06-18',
+      serverInfo: { name: 'timeline-server', version: '1.0.0' },
+      tools: [],
+      toolsTruncated: false,
+    },
+    status: 'ok' as const,
+  };
+
+  const view = mcpProbeViewFor(report);
+
+  expect(view.presentation).toEqual({ label: 'Connected', tone: 'positive' });
+  expect(view.capabilityNames).toEqual(['prompts', 'tools']);
+  expect(Object.isFrozen(view)).toBe(true);
+  expect(Object.isFrozen(view.capabilityNames)).toBe(true);
 });

--- a/packages/workbench/tests/discovery.e2e.test.ts
+++ b/packages/workbench/tests/discovery.e2e.test.ts
@@ -1,9 +1,10 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { expect, test, type PlaywrightOptions } from '@rstest/playwright';
 
+import { build } from '../../agent-bundle/src/api.ts';
 import type {
   DoctorCommandRunner,
   DoctorCommandResult,
@@ -65,7 +66,13 @@ e2e(
         : '[{"id":"rsc-agent-runtime-demo@inline"}]\n');
     };
     const pageErrors: Error[] = [];
+    const probeRequests: string[] = [];
     page.on('pageerror', (error) => pageErrors.push(error));
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === '/api/discovery/probes') {
+        probeRequests.push(request.method());
+      }
+    });
 
     await Promise.all([
       mkdir(cursorPluginRoot, { recursive: true }),
@@ -90,6 +97,26 @@ e2e(
           },
           now: () => new Date(Date.UTC(2026, 8, 2, 5, 0, generatedAtTick++)),
         },
+        prepare: async ({ configSource, root }) => {
+          const source = await readFile(configSource, 'utf8');
+          const anchor = '    servers: {\n      timeline: {';
+          if (!source.includes(anchor)) throw new Error('Discovery probe fixture config anchor is missing.');
+          await writeFile(configSource, source.replace(anchor, `    servers: {
+      'probe-down': {
+        args: ['-e', 'process.exit(0)'],
+        command: 'node',
+        targets: ['portable', 'claude', 'codex'],
+        transport: 'stdio',
+      },
+      timeline: {`));
+          const output = join(root, 'dist', 'plugins');
+          const result = await build({ output, root });
+          const errors = result.diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+          if (errors.length > 0) {
+            throw new Error(`Discovery probe fixture build failed: ${JSON.stringify(errors)}`);
+          }
+          await cp(join(output, 'claude'), join(root, 'dist', 'claude'), { recursive: true });
+        },
       });
       await page.goto(workbenchUrl(fixture.url, 'hosts'));
       try {
@@ -108,6 +135,57 @@ e2e(
       const claude = page.getByRole('group', { name: 'Claude' });
       await expect(claude.locator('.discovery-badge').first()).toHaveText('Available');
       await expect(claude.getByText('1.2.3', { exact: true })).toBeVisible();
+      const claudeMcp = claude.getByLabel('Claude MCP servers');
+      try {
+        await expect(claudeMcp.getByRole('heading', { name: 'MCP servers' })).toBeVisible();
+      } catch (reason) {
+        throw new Error(`Claude MCP discovery was not populated:\n${await claude.innerText()}`, {
+          cause: reason,
+        });
+      }
+      await expect(claudeMcp.getByText('timeline', { exact: true })).toBeVisible();
+      await expect(claudeMcp.getByText('stdio', { exact: true }).first()).toBeVisible();
+      expect(probeRequests).toEqual([]);
+
+      await claudeMcp.getByRole('button', { name: 'Probe timeline' }).click();
+      await expect(claudeMcp.getByRole('heading', { name: 'Consent required' })).toBeVisible();
+      await expect(claudeMcp).toContainText('read-only live probe');
+      await expect(claudeMcp).toContainText('Nothing is stored');
+      await claudeMcp.getByRole('button', { name: 'Cancel' }).click();
+      expect(probeRequests).toEqual([]);
+
+      await claudeMcp.getByRole('button', { name: 'Probe timeline' }).click();
+      await claudeMcp.getByRole('button', { name: 'Run live probe' }).click();
+      await expect.poll(() => probeRequests).toEqual(['POST']);
+      await expect(claudeMcp.getByText('Connected', { exact: true })).toBeVisible({
+        timeout: browserTimeout,
+      });
+      const protocol = claudeMcp.locator('.discovery-mcp-server-facts > div')
+        .filter({ hasText: 'Protocol' })
+        .locator('dd');
+      await expect(protocol).not.toHaveText('');
+      await expect.poll(() => claudeMcp.getByLabel('timeline tools').getByRole('row').count())
+        .toBeGreaterThan(1);
+      await expect(claudeMcp.getByLabel('Redacted launch summary')).toBeVisible();
+      await expect(page.getByRole('alert')).toHaveCount(0);
+
+      const downServer = claudeMcp.locator(':scope > ul > li').filter({ hasText: 'probe-down' });
+      await claudeMcp.getByRole('button', { name: 'Probe probe-down' }).click();
+      await downServer.getByRole('button', { name: 'Run live probe' }).click();
+      await expect.poll(() => probeRequests).toEqual(['POST', 'POST']);
+      const downBadge = downServer.getByText(/^(?:Timed out|Unreachable)$/u);
+      await expect(downBadge).toBeVisible({ timeout: browserTimeout });
+      await expect(downBadge).toHaveClass(/(?:^|\s)discovery-badge--neutral(?:\s|$)/u);
+      await expect(downServer).toContainText(/connect|handshake|protocol/u);
+      await expect(page.getByRole('alert')).toHaveCount(0);
+
+      await page.getByRole('button', { name: 'Re-run discovery' }).first().click();
+      await expect(page.getByText('Loading host discovery', { exact: true })).toHaveCount(0, {
+        timeout: browserTimeout,
+      });
+      await expect(claudeMcp.getByText('Connected', { exact: true })).toHaveCount(0);
+      await expect(claudeMcp.getByText(/^(?:Timed out|Unreachable)$/u)).toHaveCount(0);
+      await expect(claudeMcp.getByRole('button', { name: 'Probe timeline' })).toBeVisible();
 
       const codex = page.getByRole('group', { name: 'Codex' });
       const absentBadge = codex.getByText('Not installed', { exact: true });

--- a/rstest.integration-tests.ts
+++ b/rstest.integration-tests.ts
@@ -41,6 +41,7 @@ export const integrationTestFiles: readonly string[] = [
   'packages/agent-bundle/tests/installer-entry.test.ts',
   'packages/agent-bundle/tests/integration-matrix.test.ts',
   'packages/agent-bundle/tests/lifecycle-replay-dev-server.test.ts',
+  'packages/agent-bundle/tests/mcp-probe-dev-server.test.ts',
   'packages/agent-bundle/tests/mcp-session-service.test.ts',
   'packages/agent-bundle/tests/mcp.test.ts',
   'packages/agent-bundle/tests/package-build.test.ts',


### PR DESCRIPTION
## Summary

#105 stage 5 — the final stage: user-initiated **live MCP probing** from the Hosts page, under the #107 G6 gate (read-only; anything that executes is user-initiated; no mutation ever enters the Workbench).

- **Probe targets from discovery**: the discovery report's bundle findings now enumerate the installed bundle's declared MCP servers (`DiscoveryBundleFinding.mcpServers`, read-only via each adapter's MCP runtime manifest; absent = honestly not enumerated, empty = declared none).
- **Server**: session-authorized `POST /api/discovery/probes` (AB8219–AB8223, registered in `docs/diagnostics.md`). The body is only `{ host, serverName }` — browser input never becomes a launcher, path, env, or JSON-RPC frame; the server re-resolves the bundle root from disk and reuses the existing MCP session launch machinery (`resolveMcpSessionLaunch` + `@modelcontextprotocol/client` transports). The probe is structurally read-only: exactly `initialize` + `tools/list` + capability snapshot, then close — the wire admits no operation selection, never `tools/call`. Strict 10 s total budget, named 16 MiB response budget, bounded tool/instruction text, per-target single-flight with no caching past settlement, plugin-data tempdir always removed.
- **Redaction before anything renders**: launch summaries ship only the existing inspector projection (command allowlist, `[REDACTED]` args, env allowlist, sanitized URLs); all server-reported text passes credential redaction (`redactCredentialText`) plus absolute-path redaction per the dev-log wire precedent (bundle paths become `<bundle>/…`, other absolute paths fail closed to `[REDACTED]`).
- **Consent, per probe**: no probe on page load, ever. Probe → explicit consent copy (read-only handshake, starts the server process on this machine, nothing stored) → Cancel sends nothing / confirm sends exactly one POST.
- **Honest states**: endpoint down or timed out is an HTTP-200 report rendered as a structurally neutral `Unreachable`/`Timed out` badge — no error wall, `role="alert"` only for real request/decode failures (client decode is strict zod with AB8235, enforcing the ok⇔snapshot / down⇔failure invariants).
- **Ephemeral**: results live in the sanctioned `discovery-atoms.ts` browser-state module keyed to the current report view; re-running discovery drops them; in-flight probes abort on unmount (disposal-tested). Nothing persisted.

## Test plan (all run locally, green)

- [x] lint 0/0; typecheck across all three projects
- [x] unit 2533 ✓ (one pre-existing `native-claude-contract` load-flake, 17/17 green in isolation), route-unit 19 ✓, projection 57 ✓
- [x] probe service/routes/enumeration units 32 ✓ (redaction incl. secrets/home paths, budgets, single-flight, honest failures, auth, 413, 404)
- [x] real dev-server integration: authenticated probe launches the example's real prebuilt stdio server — initialize + tools/list ✓, env allowlist ✓, 403 without session ✓
- [x] real-Chrome e2e at 1440×900 (`discovery.e2e`): consent flow (zero probe requests before confirm; Cancel sends nothing; exactly one POST), populated live probe of the real `timeline` server, honest neutral down state for a dead stdio server, re-run clears ephemeral results, stale→repair regression, zero page errors
- [x] regressions: `overview.e2e` 13 ✓, `runtime-playground.e2e` 3 ✓, `lifecycles.e2e` ✓, `host-discovery-dev-server` ✓, `lifecycle-replay-dev-server` ✓, all three atom-disposal suites ✓

Changeset: `agent-bundle` patch.