### PR TITLE
fix(dev): bound MCP probe teardown and path redaction

### DIFF
--- a/.changeset/bound-probe-teardown-redaction.md
+++ b/.changeset/bound-probe-teardown-redaction.md
@@ -1,0 +1,7 @@
+---
+"agent-bundle": patch
+---
+
+Keep timed-out MCP probes responsive when transport teardown stalls, while
+continuing the transport close path that terminates stdio children. Redact
+absolute paths that follow common key-value and list separators.

--- a/packages/agent-bundle/src/dev/playground/mcp-probe-service.ts
+++ b/packages/agent-bundle/src/dev/playground/mcp-probe-service.ts
@@ -45,6 +45,7 @@ export const mcpProbeFailureTextLimit = 2_048;
 
 const mcpProbeCapabilityLimit = 32;
 const mcpProbeNameTextLimit = 256;
+const mcpProbeTeardownWaitMs = 50;
 const safeCapabilityName = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/u;
 const connectionErrorCodes = new Set([
   'EACCES',
@@ -126,7 +127,7 @@ const bundlePathPattern = (bundleRoot: string): RegExp => {
 };
 
 const hasAbsolutePath = (value: string): boolean =>
-  /(?:file:|(?:^|[\s"'([{])\/[^\s,;{}()[\]<>"']+|(?:^|[\s"'([{])[A-Za-z]:[\\/]|\\\\)/u.test(value);
+  /(?:file:|(?:^|[\s"'([{=,:])\/[^\s,;{}()[\]<>"']+|(?:^|[\s"'([{=,:])[A-Za-z]:[\\/]|\\\\)/u.test(value);
 
 /**
  * Probe text follows the Dev Log browser-wire precedent without coupling this
@@ -465,7 +466,19 @@ export class McpProbeService {
       });
       return report;
     } finally {
-      await Promise.allSettled([client.close(), transport.close()]);
+      let timer: NodeJS.Timeout | undefined;
+      // Keep transport teardown running through its TERM/KILL path without
+      // allowing a stalled close to extend the probe's total time budget.
+      const teardown = Promise.allSettled([client.close(), transport.close()]);
+      const teardownWait = new Promise<void>((resolvePromise) => {
+        timer = setTimeout(resolvePromise, mcpProbeTeardownWaitMs);
+        timer.unref();
+      });
+      try {
+        await Promise.race([teardown, teardownWait]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
     }
   }
 

--- a/packages/agent-bundle/tests/mcp-probe-service.test.ts
+++ b/packages/agent-bundle/tests/mcp-probe-service.test.ts
@@ -127,6 +127,41 @@ it('maps a bounded, frozen successful probe snapshot and redacted launch', async
   }
 });
 
+it('redacts absolute paths after key-value and list separators', async () => {
+  const root = await createBundle();
+  try {
+    const service = serviceFor(root, {
+      createClient: () => client({
+        getInstructions: () => 'config=/home/alice/private.json',
+        listTools: async () => ({
+          tools: [
+            {
+              description: String.raw`cwd:C:\Users\alice\private`,
+              inputSchema: { type: 'object' as const },
+              name: 'windows-path',
+            },
+            {
+              description: 'paths,/var/private/config.json',
+              inputSchema: { type: 'object' as const },
+              name: 'list-path',
+            },
+          ],
+        }),
+      }),
+    });
+
+    const report = await service.probe({ host: 'claude', serverName: 'timeline' });
+
+    expect(report.snapshot?.instructions).toBe('[REDACTED]');
+    expect(report.snapshot?.tools.map((tool) => tool.description)).toEqual([
+      '[REDACTED]',
+      '[REDACTED]',
+    ]);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 it('truncates server instructions to the named text budget', async () => {
   const root = await createBundle();
   try {
@@ -190,6 +225,48 @@ it('times out within the total budget and destroys the transport', async () => {
     expect(report.failure?.kind).toBe('connect');
     expect(transportCloses).toBeGreaterThan(0);
   } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('returns a timed-out report without awaiting stalled teardown', async () => {
+  const root = await createBundle();
+  let clientCloses = 0;
+  let transportCloses = 0;
+  let guard: NodeJS.Timeout | undefined;
+  try {
+    const stalledClose = async (): Promise<void> =>
+      new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    const service = serviceFor(root, {
+      createClient: () => client({
+        close: async () => {
+          clientCloses += 1;
+          await stalledClose();
+        },
+        connect: () => new Promise(() => undefined),
+      }),
+      createStdioTransport: () => transport(async () => {
+        transportCloses += 1;
+        await stalledClose();
+      }),
+      timeoutMs: 10,
+    });
+
+    const report = await Promise.race([
+      service.probe({ host: 'claude', serverName: 'timeline' }),
+      new Promise<never>((_resolve, reject) => {
+        guard = setTimeout(
+          () => reject(new Error('The timed-out probe remained blocked on teardown.')),
+          150,
+        );
+      }),
+    ]);
+
+    expect(report.status).toBe('timed-out');
+    expect(clientCloses).toBe(1);
+    expect(transportCloses).toBeGreaterThan(0);
+  } finally {
+    if (guard !== undefined) clearTimeout(guard);
     await rm(root, { force: true, recursive: true });
   }
 });


### PR DESCRIPTION
## Summary
- bound MCP probe teardown waiting to 50 ms while the close promises continue through the stdio transport's TERM/KILL path
- redact POSIX and Windows absolute paths after `=`, `:`, and `,` separators
- add focused regressions and a patch changeset

## Test plan
- [x] red proof: both new unit regressions failed without the production fix
- [x] `pnpm exec rstest run packages/agent-bundle/tests/mcp-probe-service.test.ts --config rstest.unit.config.ts`
- [x] `AGENT_BUNDLE_INTEGRATION_MAX_WORKERS=1 AGENT_BUNDLE_TEST_TIME_SCALE=4 pnpm exec rstest run packages/agent-bundle/tests/mcp-probe-dev-server.test.ts --config rstest.integration.config.ts`
- [x] `AGENT_BUNDLE_INTEGRATION_MAX_WORKERS=1 AGENT_BUNDLE_TEST_TIME_SCALE=4 pnpm exec rstest run packages/agent-bundle/tests/host-discovery-dev-server.test.ts --config rstest.integration.config.ts`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] discovery browser e2e not run locally: host load reached 52 and all 47 GiB swap was consumed