### PR TITLE
fix(create-agent-bundle): align installer bins with selected targets

### DIFF
--- a/.changeset/fix-portable-scaffold-installers.md
+++ b/.changeset/fix-portable-scaffold-installers.md
@@ -1,0 +1,9 @@
+---
+"agent-bundle": patch
+"create-agent-bundle": patch
+---
+
+Document that artifact output roots remain project-contained even when the CLI
+overrides `output.distPath`. Omit generated installer bins from scaffolds that
+select no installable host, and make the default template install examples use
+a selected host.

--- a/docs/effect-conventions.md
+++ b/docs/effect-conventions.md
@@ -242,14 +242,17 @@ present and match the current v4 docs: their signatures operate over
 family. Revisit at Effect GA or the first time a wire contract genuinely
 diverges between its encoded and decoded sides.
 
-The projections currently have nothing to bridge. Every wire contract in
-`packages/agent-bundle/src/contracts/*` is JSON-plain: timestamps are strings,
-there are no `Date`, `bigint`, `Map`, `Set`, or transformations, and the
-encoded and type sides are structurally identical. `toType` / `toEncoded`
-would therefore be near-identity. The real dual maintenance — contract types
-plus separately hand-written Workbench decoders — is a single-source-of-truth
-problem that the pinned zod can already solve with `z.infer`; it does not
-require a second schema runtime.
+The projections currently have nothing to bridge on the audited JSON DTO
+routes: timestamps are strings, there are no `Date`, `bigint`, `Map`, `Set`,
+or transformations, and the encoded and type sides are structurally
+identical. That claim does not cover every export under `contracts/*`.
+`McpSessionTraceEntry.occurredAt` preserves a numeric Unix timestamp, and
+`DevRuntimeAsset.body` carries a `Uint8Array` through `contracts/runtime.ts`;
+neither is one of the audited JSON DTO routes. `toType` / `toEncoded` would
+therefore be near-identity at the audited seams. The real dual maintenance —
+contract types plus separately hand-written Workbench decoders — is a
+single-source-of-truth problem that the pinned zod can already solve with
+`z.infer`; it does not require a second schema runtime.
 
 Strictness is also call-site-fragile. Effect Schema rejects unknown keys only
 through the per-decode `onExcessProperty: "error"` parse option, whose default

--- a/docs/framework-mode.md
+++ b/docs/framework-mode.md
@@ -107,8 +107,10 @@ such paths as JavaScript, CSS, and SVG subdirectories.
 are also deliberately deferred: host packs have a framework-owned
 `<target>/skills|mcp|scripts|assets/...` layout content-addressed by the
 artifact manifest. Unlike machine-local Rsbuild config, the hashed, portable
-release-identity config rejects absolute paths; use the per-invocation CLI
-flag when an absolute path is required.
+release-identity config rejects absolute paths. The per-invocation CLI
+`--output` flag can override the configured relative artifact root, but it is
+subject to the same project-root containment check; absolute and external
+output roots are unsupported.
 
 ## Distribution
 

--- a/packages/agent-bundle/src/core/types.ts
+++ b/packages/agent-bundle/src/core/types.ts
@@ -124,8 +124,8 @@ export interface AgentBundleOutputConfig {
   /**
    * The artifact output directory of `agent-bundle build`, relative to the
    * project root. Defaults to `dist`. The per-invocation CLI `--output` flag
-   * still wins, and remains the only way to target an absolute path outside
-   * the project.
+   * still wins, but remains subject to the same project-root containment
+   * check; absolute and external output paths are unsupported.
    */
   distPath?: string;
 }

--- a/packages/create-agent-bundle/src/scaffold.ts
+++ b/packages/create-agent-bundle/src/scaffold.ts
@@ -25,6 +25,7 @@ const renamedEntries: Readonly<Record<string, string>> = {
 };
 
 const defaultTargetsLiteral = "targets: ['portable', 'codex', 'claude']";
+const installerTargetNames: readonly TargetName[] = ['claude', 'codex', 'cursor', 'plugin'];
 
 export interface ScaffoldRequest {
   readonly frameworkSpec: string;
@@ -50,6 +51,7 @@ export const assertScaffoldTarget = async (targetDirectory: string, displayName:
 };
 
 interface TemplateManifest {
+  bin?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   name?: string;
@@ -72,6 +74,17 @@ const rewriteManifest = (contents: string, request: ScaffoldRequest, runtimeSpec
       }
     }
   }
+  if (
+    manifest.bin !== undefined &&
+    !request.targets.some((target) => installerTargetNames.includes(target))
+  ) {
+    const suffixedInstallerName = `${request.pluginName}-install`;
+    const installerName = Object.hasOwn(manifest.bin, suffixedInstallerName)
+      ? suffixedInstallerName
+      : request.pluginName;
+    delete manifest.bin[installerName];
+    if (Object.keys(manifest.bin).length === 0) delete manifest.bin;
+  }
   return `${JSON.stringify(manifest, null, 2)}\n`;
 };
 
@@ -85,8 +98,9 @@ const rewriteConfigTargets = (contents: string, targets: readonly TargetName[]):
 /**
  * Copy one template directory into the target, substituting the placeholder
  * project name in every file, rewriting `package.json` (real package name,
- * `workspace:*` framework placeholder pinned to the resolved spec) and the
- * config's target list. Returns the emitted project-relative paths, sorted.
+ * `workspace:*` framework placeholder pinned to the resolved spec, installer
+ * bins omitted when no installable host is selected) and the config's target
+ * list. Returns the emitted project-relative paths, sorted.
  */
 export const scaffold = async (request: ScaffoldRequest): Promise<readonly string[]> => {
   const templateManifest = JSON.parse(

--- a/packages/create-agent-bundle/templates/cli-tool/README.md
+++ b/packages/create-agent-bundle/templates/cli-tool/README.md
@@ -18,7 +18,7 @@ npm run check      # validate + build + typecheck + test
 node dist/bin/my-agent-plugin.js World
 
 # after publishing/installing the package
-npx my-agent-plugin-install install cursor
+npx my-agent-plugin-install install claude
 ```
 
 Installing the npm package does not mutate any host; run the generated

--- a/packages/create-agent-bundle/templates/mcp-server/README.md
+++ b/packages/create-agent-bundle/templates/mcp-server/README.md
@@ -17,7 +17,7 @@ npm run test:projection  # in-memory MCP projection pool
 npx agent-bundle mcp list --server status --target portable --artifact artifact
 
 # after publishing/removing "private" and installing the package
-npx my-agent-plugin install cursor
+npx my-agent-plugin install claude
 ```
 
 Installing the npm package does not mutate any host; run the generated

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -141,6 +141,31 @@ describe('scaffold', () => {
     }
   });
 
+  it('drops generated installer bins when no installable host target is selected', async () => {
+    const [cliTool, mcpServer] = await Promise.all([
+      scaffoldTemplate('cli-tool', { pluginName: 'greeter', targets: ['portable'] }),
+      scaffoldTemplate('mcp-server', { pluginName: 'status-plugin', targets: ['portable'] }),
+    ]);
+    try {
+      const cliManifest = JSON.parse(await readFile(join(cliTool.root, 'package.json'), 'utf8')) as {
+        readonly bin?: Record<string, string>;
+      };
+      expect(cliManifest.bin).toEqual({
+        greeter: './dist/bin/greeter.js',
+      });
+
+      const mcpManifest = JSON.parse(await readFile(join(mcpServer.root, 'package.json'), 'utf8')) as {
+        readonly bin?: Record<string, string>;
+      };
+      expect(mcpManifest.bin).toBeUndefined();
+    } finally {
+      await Promise.all([
+        rm(cliTool.root, { force: true, recursive: true }),
+        rm(mcpServer.root, { force: true, recursive: true }),
+      ]);
+    }
+  });
+
   it('leaves the skills-only template without package-build packaging fields', async () => {
     const { root } = await scaffoldTemplate('minimal');
     try {


### PR DESCRIPTION
## Summary
- scope the Effect Schema decision to the audited JSON DTO routes and document the numeric timestamp and binary asset exceptions
- document that CLI output overrides remain project-contained
- remove generated installer bins from portable-only scaffolds and use a selected host in template install examples

## Test plan
- [x] `pnpm exec rstest run packages/create-agent-bundle/tests/scaffold.test.ts --config rstest.unit.config.ts` (20 tests)
- [x] `pnpm --filter @agent-bundle/runtime build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm changeset status`