### PR TITLE
fix(test): scale MCP App readiness polling and drop the #122 retry

### DIFF
--- a/packages/workbench/tests/mcp-app-real.e2e.test.ts
+++ b/packages/workbench/tests/mcp-app-real.e2e.test.ts
@@ -455,8 +455,7 @@ e2e('runs a generated SDK-v2 App through the real foreground session and separat
   if (cleanupFailure !== undefined) throw cleanupFailure;
 });
 
-// Flaky under gate load (expect.poll budget, #122); retry while the root cause stays open.
-e2e('opens the real RSC runtime timeline App from provider-owned run evidence', { retry: 2, timeout: 120_000 }, async ({ page }) => {
+e2e('opens the real RSC runtime timeline App from provider-owned run evidence', { timeout: 120_000 * timeScale }, async ({ page }) => {
   const fixture = await startRuntimePlaygroundFixture({
     prepare: async ({ root }) => {
       const definitionSource = join(root, 'src', 'definition.ts');
@@ -567,7 +566,7 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     const bootstrap = await clientPage.goto(clientSurface.bootstrapUrl, { waitUntil: 'domcontentloaded' });
     expect(bootstrap?.status()).toBe(200);
     try {
-      await expect.poll(() => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 3_000 * timeScale }).toBe('1');
+      await expect.poll(() => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 15_000 * timeScale }).toBe('1');
     } catch {
       throw new Error(`Runtime App HMR proxy did not connect: ${JSON.stringify({
         console: clientSurfaceConsole,
@@ -581,12 +580,12 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     // main page's CDP session; Playwright's websocket event arrives on the
     // client page's session and can lag it, so the socket list must be
     // awaited rather than asserted synchronously.
-    await expect.poll(() => clientSurfaceSockets, { timeout: 3_000 * timeScale }).toEqual([`${clientSurface.origin.replace('http:', 'ws:')}${runtimeClientSurfaceReloadChannelPath}`]);
+    await expect.poll(() => clientSurfaceSockets, { timeout: 15_000 * timeScale }).toEqual([`${clientSurface.origin.replace('http:', 'ws:')}${runtimeClientSurfaceReloadChannelPath}`]);
     expect(clientSurfaceSockets.every((socket) => new URL(socket).search.length === 0)).toBe(true);
     expect(clientSurfaceHmrRequests.every((request) => new URL(request.url).search.length === 0)).toBe(true);
     await clientPage.close();
     clientPage = undefined;
-    await expect.poll(() => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 3_000 * timeScale }).toBe('0');
+    await expect.poll(() => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 15_000 * timeScale }).toBe('0');
     await page.routeWebSocket((url) => url.pathname === runtimeClientSurfaceReloadChannelPath, (route) => {
       runtimePreviewHmrRoutes.push(route);
       route.connectToServer();
@@ -645,7 +644,7 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
     await expect.poll(() => runtimeIdentity.getAttribute('data-runtime-hmr-client-count'), { timeout: 15_000 * timeScale }).toBe('1');
     // Awaited for the same reason as clientSurfaceSockets above: the
     // websocket event can arrive after the server already counts the client.
-    await expect.poll(() => runtimePreviewSockets, { timeout: 3_000 * timeScale }).toEqual([`${created.preview.clientSurface.origin.replace('http:', 'ws:')}${runtimeClientSurfaceReloadChannelPath}`]);
+    await expect.poll(() => runtimePreviewSockets, { timeout: 15_000 * timeScale }).toEqual([`${created.preview.clientSurface.origin.replace('http:', 'ws:')}${runtimeClientSurfaceReloadChannelPath}`]);
     const runtimeAppFrame = async () => {
       for (const frame of page.frames()) {
         if (await frame.getByRole('heading', { name: 'Runtime edit timeline' }).count() === 1) return frame;
@@ -953,7 +952,7 @@ e2e('opens the real RSC runtime timeline App from provider-owned run evidence', 
 
     await appFrame.getByRole('button', { name: 'Refresh' }).click();
     try {
-      await expect.poll(() => consentRequests('action'), { timeout: 3_000 * timeScale }).toHaveLength(1);
+      await expect.poll(() => consentRequests('action'), { timeout: 15_000 * timeScale }).toHaveLength(1);
     } catch {
       throw new Error(`Runtime App call relay did not reach consent: ${JSON.stringify({
         console: browserConsole,


### PR DESCRIPTION
## Summary
- Root cause for the `mcp-app-real.e2e.test.ts` flake tracked in #122: the timeline test's readiness waits carried short fixed budgets (originally an unscaled 1-3s `expect.poll` ceiling at the consent relay; the failing gate hit `expect.poll(...).toHaveLength(1)` inside a 1s budget). Green runs return immediately, so a short ceiling only converts machine load into failures.
- Per the issue's acceptance, all readiness waits are now tied to the existing time-scale mechanism: the five remaining `3_000 * timeScale` polls (HMR client connect/disconnect, client + preview socket recording, consent relay) move to the file's standard `15_000 * timeScale`, and the test-level timeout becomes `120_000 * timeScale` (it was the only unscaled test-level timeout in the file). Diagnostic try/catch wrappers and every negative assertion are unchanged.
- Removes the `{ retry: 2 }` interim from PR #138.

## Evidence
- Stability: 8 consecutive green serial runs pre-rebase plus 2 post-rebase, all 4 tests per run, under load average 40-90 (the load regime the gate flake manifests in).
- `pnpm lint` and `pnpm typecheck` green; test-only change, no changeset needed.

Part of #122 (MCP App polling scope). The dev-watcher scope landed in #329.