### PR TITLE
fix(test): cap Rstest worker socket paths

### DIFF
--- a/.changeset/short-rstest-socket-roots.md
+++ b/.changeset/short-rstest-socket-roots.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Keep Doctor socket fixtures reliable under long local-CI temporary directory names by deriving short, isolated Rstest worker roots.

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -42,9 +42,12 @@ each other's temp traffic: suites that assert temp-root hygiene (for example
 `cli.test.ts` scans `os.tmpdir()` for leaked `agent-bundle-artifact-*`
 directories) only ever see their own leg's directories, so a sibling leg's
 in-flight work cannot fail them — while a directory the leg itself leaks
-still fails its own scan. Legs live under `.worktrees/local-ci/`
-(gitignored), are reused across runs for warm caches, and can be recreated
-with `--fresh`.
+still fails its own scan. Rstest re-hashes that leg directory and worker ID
+to `/tmp/ab-rstest-<hash16>` before exposing its worker `TMPDIR`; this leaves
+headroom below Linux's 108-byte `sun_path` cap for nested socket fixtures
+without sacrificing per-leg or per-worker isolation. Legs live under
+`.worktrees/local-ci/` (gitignored), are reused across runs for warm caches,
+and can be recreated with `--fresh`.
 
 The three Verify legs below mirror the hosted `main`-push matrix. On PRs,
 only `verify (24)` runs hosted.

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -42,10 +42,11 @@ each other's temp traffic: suites that assert temp-root hygiene (for example
 `cli.test.ts` scans `os.tmpdir()` for leaked `agent-bundle-artifact-*`
 directories) only ever see their own leg's directories, so a sibling leg's
 in-flight work cannot fail them — while a directory the leg itself leaks
-still fails its own scan. Rstest re-hashes that leg directory and worker ID
-to `/tmp/ab-rstest-<hash16>` before exposing its worker `TMPDIR`; this leaves
-headroom below Linux's 108-byte `sun_path` cap for nested socket fixtures
-without sacrificing per-leg or per-worker isolation. Legs live under
+still fails its own scan. Rstest re-hashes that leg directory, worker ID, and
+invocation identity to `/tmp/ab-rstest-<hash16>` before exposing its worker
+`TMPDIR`; this leaves headroom below Linux's 108-byte `sun_path` cap for nested
+socket fixtures without sacrificing per-leg, per-worker, or concurrent-run
+isolation. Legs live under
 `.worktrees/local-ci/` (gitignored), are reused across runs for warm caches,
 and can be recreated with `--fresh`.
 

--- a/packages/agent-bundle/tests/rstest-worker-isolation.test.ts
+++ b/packages/agent-bundle/tests/rstest-worker-isolation.test.ts
@@ -20,3 +20,10 @@ it('keeps Doctor socket fixtures below the Linux AF_UNIX pathname cap', () => {
   // Linux sun_path is 108 bytes including NUL; 96 leaves 12 bytes of headroom.
   expect(Buffer.byteLength(longestDoctorEndpoint, 'utf8') + 1).toBeLessThanOrEqual(96);
 });
+
+it('isolates concurrent Rstest invocations that share a host temporary root', () => {
+  const firstRoot = rstestWorkerRootPath('/tmp', '1', 'linux', '/workspace/first\0' + '101');
+  const secondRoot = rstestWorkerRootPath('/tmp', '1', 'linux', '/workspace/second\0' + '202');
+
+  expect(firstRoot).not.toBe(secondRoot);
+});

--- a/packages/agent-bundle/tests/rstest-worker-isolation.test.ts
+++ b/packages/agent-bundle/tests/rstest-worker-isolation.test.ts
@@ -1,0 +1,22 @@
+import { join } from 'node:path';
+
+import { expect, it } from '@rstest/core';
+
+import { rstestWorkerRootPath } from '../../../rstest.worker-isolation.ts';
+
+it('keeps Doctor socket fixtures below the Linux AF_UNIX pathname cap', () => {
+  const longLocalCiRoot = join(
+    '/tmp',
+    `abci-repository-hash-${'verify-current-pathological-node-version-'.repeat(3)}`,
+  );
+  const workerRoot = rstestWorkerRootPath(longLocalCiRoot, '123', 'linux');
+  const longestDoctorEndpoint = join(
+    workerRoot,
+    'agent-bundle-doctor-XXXXXX',
+    'endpoints',
+    'event-identity.sock',
+  );
+
+  // Linux sun_path is 108 bytes including NUL; 96 leaves 12 bytes of headroom.
+  expect(Buffer.byteLength(longestDoctorEndpoint, 'utf8') + 1).toBeLessThanOrEqual(96);
+});

--- a/rstest.worker-isolation.ts
+++ b/rstest.worker-isolation.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,8 +7,23 @@ export const rstestWorkerId = (): string => process.env['RSTEST_WORKER_ID'] ?? '
 
 const hostTemporaryRoot = tmpdir();
 
+export const rstestWorkerRootPath = (
+  temporaryRoot: string,
+  workerId: string,
+  platform: NodeJS.Platform = process.platform,
+): string => {
+  if (platform === 'win32') return join(temporaryRoot, 'agent-bundle-rstest-w' + workerId);
+  const hash = createHash('sha256')
+    .update(temporaryRoot, 'utf8')
+    .update('\0', 'utf8')
+    .update(workerId, 'utf8')
+    .digest('hex')
+    .slice(0, 16);
+  return join('/tmp', `ab-rstest-${hash}`);
+};
+
 export const rstestWorkerRoot = (): string => {
-  const root = join(hostTemporaryRoot, 'agent-bundle-rstest-w' + rstestWorkerId());
+  const root = rstestWorkerRootPath(hostTemporaryRoot, rstestWorkerId());
   mkdirSync(root, { recursive: true });
   return root;
 };

--- a/rstest.worker-isolation.ts
+++ b/rstest.worker-isolation.ts
@@ -11,12 +11,15 @@ export const rstestWorkerRootPath = (
   temporaryRoot: string,
   workerId: string,
   platform: NodeJS.Platform = process.platform,
+  invocationId: string = process.cwd() + '\0' + String(process.pid),
 ): string => {
   if (platform === 'win32') return join(temporaryRoot, 'agent-bundle-rstest-w' + workerId);
   const hash = createHash('sha256')
     .update(temporaryRoot, 'utf8')
     .update('\0', 'utf8')
     .update(workerId, 'utf8')
+    .update('\0', 'utf8')
+    .update(invocationId, 'utf8')
     .digest('hex')
     .slice(0, 16);
   return join('/tmp', `ab-rstest-${hash}`);


### PR DESCRIPTION
Closes #335

## Summary
- derive POSIX Rstest worker roots from a 16-hex SHA-256 digest of the upstream temporary root and worker ID, keeping the stable root at `/tmp/ab-rstest-<hash16>`
- preserve per-leg/per-worker isolation while reserving at least 12 bytes of documented headroom below Linux's 108-byte `sun_path` cap for nested Doctor socket fixtures
- add a pathological long-leg regression, local-CI documentation, and a patch changeset

## Red/green evidence
- baseline issue reproduction: **32/36 Doctor tests passed**, with the four socket-bearing cases failing
- regression before fix: **1/1 failed**, requiring 232 bytes against the 96-byte safety budget
- after fix under the issue's long current-node TMPDIR: **36/36 Doctor tests passed**
- regression after fix: **1/1 passed**

## Test plan
- [x] `pnpm build`
- [x] long-TMPDIR `packages/agent-bundle/tests/doctor.test.ts` — 36/36
- [x] `packages/agent-bundle/tests/rstest-worker-isolation.test.ts` — 1/1
- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm check:local-ci --current-node-only` through unit — build/typecheck/lint and 2616/2621 unit tests passed (5 skipped); the untouched integration `cli.test.ts` then hit the machine-installed Codex 0.147.0 host-validation diagnostic mismatch