### PR TITLE
chore(build): gate published packages with publint

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "playwright": "1.62.1",
     "playwright-core": "1.62.1",
     "publint": "0.3.24",
+    "rsbuild-plugin-publint": "1.0.0",
     "typescript": "7.0.2"
   }
 }

--- a/packages/agent-bundle/rslib.config.ts
+++ b/packages/agent-bundle/rslib.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 import packageManifest from './package.json' with { type: 'json' };
 
 export default defineConfig({
@@ -21,6 +22,8 @@ export default defineConfig({
     legalComments: 'linked',
     target: 'node',
   },
+  // Suggestions stay informational; errors and warnings block publishing.
+  plugins: [pluginPublint({ throwOn: 'warning' })],
   root: import.meta.dirname,
   source: {
     tsconfigPath: './tsconfig.build.json',

--- a/packages/create-agent-bundle/rslib.config.ts
+++ b/packages/create-agent-bundle/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 /**
  * Single self-contained ESM bundle: `@clack/prompts` is a devDependency so
@@ -20,6 +21,8 @@ export default defineConfig({
     filenameHash: false,
     target: 'node',
   },
+  // Suggestions stay informational; errors and warnings block publishing.
+  plugins: [pluginPublint({ throwOn: 'warning' })],
   root: import.meta.dirname,
   source: {
     entry: {

--- a/packages/rsc-runtime/rslib.config.ts
+++ b/packages/rsc-runtime/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 const sharedLib = {
   bundle: true,
@@ -84,6 +85,8 @@ export default defineConfig({
     filenameHash: false,
     target: 'node',
   },
+  // Suggestions stay informational; errors and warnings block publishing.
+  plugins: [pluginPublint({ throwOn: 'warning' })],
   root: import.meta.dirname,
   source: {
     tsconfigPath: './tsconfig.build.json',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       publint:
         specifier: 0.3.24
         version: 0.3.24
+      rsbuild-plugin-publint:
+        specifier: 1.0.0
+        version: 1.0.0(@rsbuild/core@2.2.1)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -2429,6 +2432,15 @@ packages:
       '@typescript/native-preview':
         optional: true
       typescript:
+        optional: true
+
+  rsbuild-plugin-publint@1.0.0:
+    resolution: {integrity: sha512-QNu6zL0TOmFZfrCiKSmkw092jDhhPpiA1QYDRkvhkW1wDLowuVEYOqdV87Eo/I6geV0nuKKnCgLHT+Fevbz6pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
         optional: true
 
   rsbuild-plugin-rsc@0.1.1:
@@ -4851,6 +4863,12 @@ snapshots:
       '@rsbuild/core': 2.1.13
     optionalDependencies:
       typescript: 7.0.2
+
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.1):
+    dependencies:
+      publint: 0.3.24
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1
 
   rsbuild-plugin-rsc@0.1.1(@rsbuild/core@2.2.1)(react-server-dom-rspack@0.1.0(@rspack/core@2.2.1(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:


### PR DESCRIPTION
## Summary
- pin `rsbuild-plugin-publint@1.0.0` as a shared build-time dependency
- run publint after the standalone Rslib builds for `agent-bundle`, `@agent-bundle/runtime`, and the independently published `create-agent-bundle`
- fail builds on publint errors and warnings while keeping suggestion-level messages informational; generated consumer artifacts, templates, examples, and Workbench builds remain unchanged

## Publint findings
- All three package builds passed publint without findings, so no package manifests or exports changed.
- No changeset is included because the dependency and configuration changes are development-only.

## Test plan
- [x] `pnpm test:packed` — 26 passed, 1 skipped; includes all three package builds with `Publint passed`
- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `git diff --check`

Final verification was run after rebasing onto `origin/main` at `5d3d264d5` (PR #341).
