### PR TITLE
test: repair main verification fixtures

### DIFF
--- a/packages/agent-bundle/tests/mcp-app-sandbox.test.ts
+++ b/packages/agent-bundle/tests/mcp-app-sandbox.test.ts
@@ -296,18 +296,26 @@ it('provides a valid built App resource without imposing the runtime message-siz
 });
 
 it('uses an opaque child relay shell with real MCP Apps JSON-RPC notification methods', async () => {
-  const proxy = await createMcpAppSandboxProxy({
-    hostOrigin: 'http://127.0.0.1:43123',
-    maxMessageBytes: 1_024,
-    port: 0,
-  });
-  const frame = createMcpAppSandboxFrame({
-    consent,
-    declaration,
-    hostOrigin: 'http://127.0.0.1:43123',
-    proxy,
-  });
+  const host = createServer();
+  host.listen({ host: '127.0.0.1', port: 0 });
+  await once(host, 'listening');
+  const address = host.address();
+  if (address === null || typeof address === 'string') throw new Error('The MCP App sandbox test host did not receive a TCP address.');
+  const hostOrigin = `http://127.0.0.1:${address.port}`;
+  let proxy: Awaited<ReturnType<typeof createMcpAppSandboxProxy>> | undefined;
+
   try {
+    proxy = await createMcpAppSandboxProxy({
+      hostOrigin,
+      maxMessageBytes: 1_024,
+      port: 0,
+    });
+    const frame = createMcpAppSandboxFrame({
+      consent,
+      declaration,
+      hostOrigin,
+      proxy,
+    });
     const shell = await fetch(proxy.url).then((response) => response.text());
     expect(shell).toContain('sandbox="allow-scripts"');
     expect(shell).toContain("event.origin !== 'null'");
@@ -318,7 +326,8 @@ it('uses an opaque child relay shell with real MCP Apps JSON-RPC notification me
     expect(shell).not.toContain('byteLength(message) > maxMessageBytes');
     expect(new URL(frame.src).hash).toContain('maxMessageBytes');
   } finally {
-    await proxy.close();
+    await proxy?.close();
+    await new Promise<void>((resolve, reject) => host.close((error) => error === undefined ? resolve() : reject(error)));
   }
 });
 

--- a/packages/agent-bundle/tests/path-token-resolver.test.ts
+++ b/packages/agent-bundle/tests/path-token-resolver.test.ts
@@ -246,8 +246,8 @@ it('resolves Claude path tokens outside command when launching a generated artif
             fixture: {
               args: [`${pathTokens.workspaceRoot}/tool`],
               command: `${pathTokens.pluginRoot}/bin/unchanged`,
-              cwd: pathTokens.pluginData,
               env: {
+                DATA: pathTokens.pluginData,
                 ROOT: pathTokens.pluginRoot,
                 WORKSPACE: pathTokens.workspaceRoot,
               },
@@ -295,8 +295,8 @@ it('resolves Claude path tokens outside command when launching a generated artif
     expect(stdio[0]).toMatchObject({
       args: [`${fixture.roots.workspaceRoot}/tool`],
       command: '${CLAUDE_PLUGIN_ROOT}/bin/unchanged',
-      cwd: expect.any(String),
       env: {
+        DATA: expect.any(String),
         ROOT: expect.any(String),
         WORKSPACE: fixture.roots.workspaceRoot,
       },


### PR DESCRIPTION
## Summary
- reserve a real loopback host listener in the relay-shell sandbox test so ephemeral proxy allocation cannot reuse its origin
- align the Claude path-token integration fixture with #347's documented field matrix by moving plugin-data coverage from unsupported `cwd` to supported `env`
- keep #335's short Rstest worker-root regressions unchanged and green

## Root cause and provenance
### Node 22.19 sandbox origin
- CI assigned the proxy's `port: 0` listener the test's hard-coded `43123`, correctly triggering the production different-origin guard
- deterministic red proof reproduced the exact assertion by binding the proxy to the hard-coded host port
- candidate merges #337, #341, #342, and #343 do not change the sandbox source or test; #341's `/tmp/ab-rstest-*` worker roots are unrelated
- the hard-coded fixture originates in `099744222` from #2; `3a1c235c6` later reserved the host origin for the first test but left this second occurrence latent

### Node 24 path token
- #347 correctly rejected path tokens in Claude MCP `cwd`, but `path-token-resolver.test.ts` still built a fixture with `cwd: pluginData`
- the updated fixture exercises the same plugin-data substitution through documented MCP `env` support

## Test plan
- [x] Red: Node 22.19 targeted collision fails with `MCP App sandbox proxy must use a different origin from its host`
- [x] Green: Node 22.19 targeted relay-shell test passes
- [x] Node 22.19 full `mcp-app-sandbox.test.ts` — 11/11
- [x] Node 22.19 `rstest-worker-isolation.test.ts` — 2/2 (#335 regression coverage)
- [x] Red: Node 24 targeted path-token test fails with `claude.substitution.token.unsupported`
- [x] Green: Node 24 full `path-token-resolver.test.ts` — 9/9
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors, 0 warnings