### PR TITLE
feat(events): promote file/config/task/idle families (#258 v2 s4)

### DIFF
--- a/.changeset/promote-lifecycle-observation-events.md
+++ b/.changeset/promote-lifecycle-observation-events.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Promote the `file/change`, `config/change`, `task/create`, `task/complete`, and `agent/idle` canonical event-route families as Claude-only capabilities with their documented decision channels: `config/change` and `task/create` project deny as a top-level block decision, `agent/idle` projects deny as `continue: false` with a stop reason, while `file/change` and `task/complete` are observation-only with fail-closed errors explaining the host's side-effect-only and exit-code-only control models. Codex, Cursor, and portable carry dated `unavailable` rows per family.

--- a/examples/rsc-agent-runtime/README.md
+++ b/examples/rsc-agent-runtime/README.md
@@ -241,6 +241,11 @@ Host/Origin allowlists mitigate DNS rebinding and cross-origin requests, but the
 | `permission/denied` | Unavailable | `PermissionDenied` (observe-only) | Unavailable |
 | `stop` | Supported | `Stop` | `Stop` |
 | `stop/failure` | Unavailable | `StopFailure` (observe-only) | Unavailable |
+| `file/change` | Unavailable (agent-edit `afterFileEdit` stays a `tool/after` variant) | `FileChanged` (observe-only) | Unavailable |
+| `config/change` | Unavailable | `ConfigChange` (deny) | Unavailable |
+| `task/create` | Unavailable | `TaskCreated` (deny) | Unavailable |
+| `task/complete` | Unavailable | `TaskCompleted` (observe-only; blocking is exit-code-only) | Unavailable |
+| `agent/idle` | Unavailable | `TeammateIdle` (deny via continue:false) | Unavailable |
 | `agent/start` | `subagentStart` | `SubagentStart` | `SubagentStart` |
 | `agent/stop` | `subagentStop` | `SubagentStop` | `SubagentStop` |
 | `workspace/open` | Supported (observe-only; native `pluginPaths` return not modeled) | Unavailable | Unavailable |

--- a/packages/agent-bundle/src/adapters/capabilities/claude-2.1.250.json
+++ b/packages/agent-bundle/src/adapters/capabilities/claude-2.1.250.json
@@ -23,10 +23,13 @@
       "stop": "Stop"
     },
     "eventRoutes": {
+      "agent/idle": { "nativeEvent": "TeammateIdle", "state": "supported" },
       "agent/start": { "nativeEvent": "SubagentStart", "state": "supported" },
       "agent/stop": { "nativeEvent": "SubagentStop", "state": "supported" },
       "compact/after": { "nativeEvent": "PostCompact", "state": "supported" },
       "compact/before": { "nativeEvent": "PreCompact", "state": "supported" },
+      "config/change": { "nativeEvent": "ConfigChange", "state": "supported" },
+      "file/change": { "nativeEvent": "FileChanged", "state": "supported" },
       "permission/denied": { "nativeEvent": "PermissionDenied", "state": "supported" },
       "permission/request": { "nativeEvent": "PermissionRequest", "state": "supported" },
       "prompt/submit": { "nativeEvent": "UserPromptSubmit", "state": "supported" },
@@ -34,6 +37,8 @@
       "session/start": { "nativeEvent": "SessionStart", "state": "supported" },
       "stop": { "nativeEvent": "Stop", "state": "supported" },
       "stop/failure": { "nativeEvent": "StopFailure", "state": "supported" },
+      "task/complete": { "nativeEvent": "TaskCompleted", "state": "supported" },
+      "task/create": { "nativeEvent": "TaskCreated", "state": "supported" },
       "tool/after": { "nativeEvent": "PostToolUse", "state": "supported" },
       "tool/before": { "nativeEvent": "PreToolUse", "state": "supported" },
       "tool/failure": { "nativeEvent": "PostToolUseFailure", "state": "supported" },

--- a/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
+++ b/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
@@ -23,10 +23,22 @@
       "stop": "Stop"
     },
     "eventRoutes": {
+      "agent/idle": {
+        "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no teammate-idle event.",
+        "state": "unavailable"
+      },
       "agent/start": { "nativeEvent": "SubagentStart", "state": "supported" },
       "agent/stop": { "nativeEvent": "SubagentStop", "state": "supported" },
       "compact/after": { "nativeEvent": "PostCompact", "state": "supported" },
       "compact/before": { "nativeEvent": "PreCompact", "state": "supported" },
+      "config/change": {
+        "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no config-change event.",
+        "state": "unavailable"
+      },
+      "file/change": {
+        "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no file-changed event.",
+        "state": "unavailable"
+      },
       "permission/denied": {
         "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no permission-denied event.",
         "state": "unavailable"
@@ -38,6 +50,14 @@
       "stop": { "nativeEvent": "Stop", "state": "supported" },
       "stop/failure": {
         "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no stop-failure event.",
+        "state": "unavailable"
+      },
+      "task/complete": {
+        "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no task-completed event.",
+        "state": "unavailable"
+      },
+      "task/create": {
+        "reason": "retrieved 2026-09-02: the complete rust-v0.147.0 generated hook schema directory contains no task-created event.",
         "state": "unavailable"
       },
       "tool/after": { "nativeEvent": "PostToolUse", "state": "supported" },

--- a/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
+++ b/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
@@ -23,6 +23,10 @@
       "stop": "stop"
     },
     "eventRoutes": {
+      "agent/idle": {
+        "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no teammate-idle event.",
+        "state": "unavailable"
+      },
       "agent/start": { "nativeEvent": "subagentStart", "state": "supported" },
       "agent/stop": { "nativeEvent": "subagentStop", "state": "supported" },
       "compact/after": {
@@ -30,6 +34,14 @@
         "state": "unavailable"
       },
       "compact/before": { "nativeEvent": "preCompact", "state": "supported" },
+      "config/change": {
+        "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no configChange event.",
+        "state": "unavailable"
+      },
+      "file/change": {
+        "reason": "retrieved 2026-09-02: Cursor documents afterFileEdit as an agent-edit tool variant that overlaps canonical tool/after per the #258 selector rule, not a disk-watch FileChanged equivalent; no dedicated family is inferred without fixture evidence of loss.",
+        "state": "unavailable"
+      },
       "permission/denied": {
         "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no permission-denied event.",
         "state": "unavailable"
@@ -54,6 +66,14 @@
       "stop": { "nativeEvent": "stop", "state": "supported" },
       "stop/failure": {
         "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no stop-failure event.",
+        "state": "unavailable"
+      },
+      "task/complete": {
+        "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no taskCompleted event.",
+        "state": "unavailable"
+      },
+      "task/create": {
+        "reason": "retrieved 2026-09-02: the complete https://cursor.com/docs/hooks event inventory documents no taskCreated event.",
         "state": "unavailable"
       },
       "tool/after": { "nativeEvent": "postToolUse", "state": "supported" },

--- a/packages/agent-bundle/src/adapters/capabilities/portable-1.0.0.json
+++ b/packages/agent-bundle/src/adapters/capabilities/portable-1.0.0.json
@@ -10,6 +10,10 @@
     "state": "unavailable"
   },
   "eventRoutes": {
+    "agent/idle": {
+      "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native TeammateIdle equivalent (https://agent-plugins.org/).",
+      "state": "unavailable"
+    },
     "agent/start": { "reason": "Agent Plugins 1.0.0 does not define hooks.", "state": "unavailable" },
     "agent/stop": { "reason": "Agent Plugins 1.0.0 does not define hooks.", "state": "unavailable" },
     "compact/after": {
@@ -18,6 +22,14 @@
     },
     "compact/before": {
       "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native PreCompact/preCompact equivalent (https://agent-plugins.org/).",
+      "state": "unavailable"
+    },
+    "config/change": {
+      "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native ConfigChange equivalent (https://agent-plugins.org/).",
+      "state": "unavailable"
+    },
+    "file/change": {
+      "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native FileChanged equivalent (https://agent-plugins.org/).",
       "state": "unavailable"
     },
     "permission/denied": {
@@ -40,6 +52,14 @@
     "stop": { "reason": "Agent Plugins 1.0.0 does not define hooks.", "state": "unavailable" },
     "stop/failure": {
       "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native StopFailure equivalent (https://agent-plugins.org/).",
+      "state": "unavailable"
+    },
+    "task/complete": {
+      "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native TaskCompleted equivalent (https://agent-plugins.org/).",
+      "state": "unavailable"
+    },
+    "task/create": {
+      "reason": "2026-09-02: Agent Plugins 1.0.0 defines no hooks and therefore no native TaskCreated equivalent (https://agent-plugins.org/).",
       "state": "unavailable"
     },
     "tool/after": { "reason": "Agent Plugins 1.0.0 does not define hooks.", "state": "unavailable" },

--- a/packages/agent-bundle/src/adapters/hook-contract.ts
+++ b/packages/agent-bundle/src/adapters/hook-contract.ts
@@ -255,6 +255,30 @@ export const createNativeEventStarter = (
         last_assistant_message: null,
         stop_hook_active: false,
       });
+    case 'file/change':
+      return deepFreeze({ ...base, file_path: '/tmp/lifecycle-replay-watched.txt' });
+    case 'config/change':
+      return deepFreeze({ ...base, file_path: '/tmp/lifecycle-replay-settings.json', source: 'project_settings' });
+    case 'task/create':
+      return deepFreeze({
+        ...base,
+        task_id: 'lifecycle-replay-task',
+        task_subject: 'Lifecycle replay task.',
+      });
+    case 'task/complete':
+      return deepFreeze({
+        ...base,
+        permission_mode: 'default',
+        task_id: 'lifecycle-replay-task',
+        task_subject: 'Lifecycle replay task.',
+      });
+    case 'agent/idle':
+      return deepFreeze({
+        ...base,
+        permission_mode: 'default',
+        team_name: 'lifecycle-replay-team',
+        teammate_name: 'lifecycle-replay-teammate',
+      });
     case 'workspace/open':
       return deepFreeze(target === 'cursor'
         ? {

--- a/packages/agent-bundle/src/config/normalize.ts
+++ b/packages/agent-bundle/src/config/normalize.ts
@@ -116,6 +116,11 @@ const hookEventForRoute: Readonly<Record<CanonicalAgentEvent, NormalizedHookEven
   'permission/request': 'permissionRequest',
   'permission/denied': 'permissionDenied',
   'stop/failure': 'stopFailure',
+  'file/change': 'fileChange',
+  'config/change': 'configChange',
+  'task/create': 'taskCreate',
+  'task/complete': 'taskComplete',
+  'agent/idle': 'agentIdle',
   'workspace/open': 'workspaceOpen',
 });
 

--- a/packages/agent-bundle/src/core/types.ts
+++ b/packages/agent-bundle/src/core/types.ts
@@ -49,6 +49,11 @@ export const eventRouteOnlyHookEvents = Object.freeze([
   'permissionRequest',
   'permissionDenied',
   'stopFailure',
+  'fileChange',
+  'configChange',
+  'taskCreate',
+  'taskComplete',
+  'agentIdle',
 ] as const);
 
 export type EventRouteOnlyHookEvent = (typeof eventRouteOnlyHookEvents)[number];

--- a/packages/agent-bundle/src/events/projection.ts
+++ b/packages/agent-bundle/src/events/projection.ts
@@ -246,6 +246,24 @@ export const validateNativeEventEnvelope = (
       return nativeEventError('native stop_hook_active must be a boolean');
     }
   }
+  if (canonicalEvent === 'file/change') requireNativeString(native, 'file_path');
+  if (canonicalEvent === 'config/change') {
+    if (!['user_settings', 'project_settings', 'local_settings', 'policy_settings', 'skills'].includes(String(native.source))) {
+      return nativeEventError('native source is invalid');
+    }
+    if (Object.hasOwn(native, 'file_path')) requireNativeString(native, 'file_path');
+  }
+  if (canonicalEvent === 'task/create' || canonicalEvent === 'task/complete') {
+    requireNativeString(native, 'task_id');
+    requireNativeString(native, 'task_subject');
+    for (const field of ['task_description', 'teammate_name', 'team_name']) {
+      if (Object.hasOwn(native, field)) requireNativeString(native, field);
+    }
+  }
+  if (canonicalEvent === 'agent/idle') {
+    requireNativeString(native, 'teammate_name');
+    requireNativeString(native, 'team_name');
+  }
   if (canonicalEvent === 'compact/before' || canonicalEvent === 'compact/after') {
     requireCompactTrigger(native);
     if (target === 'codex') {
@@ -573,6 +591,60 @@ export const projectEventDocument = (
       throw new TypeError('stop/failure has no documented context/output channel.');
     }
     return undefined;
+  }
+  if (event === 'file/change') {
+    if (
+      parsedValue?.outcome === 'deny'
+      || parsedValue?.reason !== undefined
+      || parsedValue?.updatedInput !== undefined
+    ) {
+      throw new TypeError('file/change has no decision control on Claude FileChanged; it is side-effect-only.');
+    }
+    if (additionalContext !== undefined) {
+      throw new TypeError('file/change has no documented context/output channel.');
+    }
+    return undefined;
+  }
+  if (event === 'config/change' || event === 'task/create') {
+    if (parsedValue?.updatedInput !== undefined) {
+      throw new TypeError(`${event} cannot replace native input.`);
+    }
+    if (additionalContext !== undefined) {
+      throw new TypeError(`${event} has no documented additional-context channel.`);
+    }
+    if (parsedValue?.reason !== undefined && parsedValue.outcome !== 'deny') {
+      throw new TypeError(`${event} reason is only valid when outcome is deny.`);
+    }
+    return parsedValue?.outcome === 'deny'
+      ? Object.freeze({ decision: 'block', reason: requireDenyReason() })
+      : undefined;
+  }
+  if (event === 'task/complete') {
+    if (
+      parsedValue?.outcome === 'deny'
+      || parsedValue?.reason !== undefined
+      || parsedValue?.updatedInput !== undefined
+    ) {
+      throw new TypeError('task/complete blocking is exit-code-only on Claude TaskCompleted (JSON continue:false redirects to teammate stop and is ignored for TaskUpdate); it is not projected.');
+    }
+    if (additionalContext !== undefined) {
+      throw new TypeError('task/complete has no documented context/output channel.');
+    }
+    return undefined;
+  }
+  if (event === 'agent/idle') {
+    if (parsedValue?.updatedInput !== undefined) {
+      throw new TypeError('agent/idle cannot replace native input.');
+    }
+    if (additionalContext !== undefined) {
+      throw new TypeError('agent/idle has no documented additional-context channel.');
+    }
+    if (parsedValue?.reason !== undefined && parsedValue.outcome !== 'deny') {
+      throw new TypeError('agent/idle reason is only valid when outcome is deny.');
+    }
+    return parsedValue?.outcome === 'deny'
+      ? Object.freeze({ continue: false, stopReason: requireDenyReason() })
+      : undefined;
   }
   if (event === 'tool/before') {
     if (target === 'cursor') {

--- a/packages/agent-bundle/src/routes/public.ts
+++ b/packages/agent-bundle/src/routes/public.ts
@@ -24,6 +24,11 @@ export const canonicalAgentEvents = Object.freeze([
   'permission/request',
   'permission/denied',
   'stop/failure',
+  'file/change',
+  'config/change',
+  'task/create',
+  'task/complete',
+  'agent/idle',
 ] as const);
 
 export type CanonicalAgentEvent = (typeof canonicalAgentEvents)[number];

--- a/packages/agent-bundle/tests/adapter-metadata.test.ts
+++ b/packages/agent-bundle/tests/adapter-metadata.test.ts
@@ -210,10 +210,10 @@ it('records observed capability versions and rehashes schema snapshots against p
     }
 
     if (target === 'claude') {
-      expect(sha256Hex(capability)).toBe('d898da04491d8742c18b25c472bd4f0a64b679cfd26ebc5b4af6e55cd5447dc1');
+      expect(sha256Hex(capability)).toBe('59e190a26734a6bcca0f22ceee6151ebdd73c690eddb979a78b6b25f0136cb45');
     }
     if (target === 'cursor') {
-      expect(sha256Hex(capability)).toBe('1efea5192a8858d2d335561607aa94a6d12edb8cdfa0e4c861d93a4a2be5c276');
+      expect(sha256Hex(capability)).toBe('52b1fb8776ffe0848e9ee8c35a604052c59fb292cabbfbaf7a482cd03ce3d918');
       const pluginSchema = JSON.parse(await readFile(
         new URL('../src/adapters/schemas/cursor/plugin.schema.json', import.meta.url),
         'utf8',

--- a/packages/agent-bundle/tests/fixtures/events/claude-config-change.json
+++ b/packages/agent-bundle/tests/fixtures/events/claude-config-change.json
@@ -1,0 +1,8 @@
+{
+    "cwd": "/workspace",
+    "file_path": "/workspace/.claude/settings.json",
+    "hook_event_name": "ConfigChange",
+    "session_id": "session-claude-1",
+    "source": "project_settings",
+    "transcript_path": "/workspace/.claude/projects/session.jsonl"
+}

--- a/packages/agent-bundle/tests/fixtures/events/claude-file-changed.json
+++ b/packages/agent-bundle/tests/fixtures/events/claude-file-changed.json
@@ -1,0 +1,7 @@
+{
+    "cwd": "/workspace",
+    "file_path": "/workspace/.env",
+    "hook_event_name": "FileChanged",
+    "session_id": "session-claude-1",
+    "transcript_path": "/workspace/.claude/projects/session.jsonl"
+}

--- a/packages/agent-bundle/tests/fixtures/events/claude-task-completed.json
+++ b/packages/agent-bundle/tests/fixtures/events/claude-task-completed.json
@@ -1,0 +1,11 @@
+{
+    "cwd": "/workspace",
+    "hook_event_name": "TaskCompleted",
+    "permission_mode": "default",
+    "session_id": "session-claude-1",
+    "task_id": "task-001",
+    "task_subject": "Implement user authentication",
+    "team_name": "session-a1b2c3d4",
+    "teammate_name": "implementer",
+    "transcript_path": "/workspace/.claude/projects/session.jsonl"
+}

--- a/packages/agent-bundle/tests/fixtures/events/claude-task-created.json
+++ b/packages/agent-bundle/tests/fixtures/events/claude-task-created.json
@@ -1,0 +1,11 @@
+{
+    "cwd": "/workspace",
+    "hook_event_name": "TaskCreated",
+    "session_id": "session-claude-1",
+    "task_description": "Add login and signup endpoints",
+    "task_id": "task-001",
+    "task_subject": "Implement user authentication",
+    "team_name": "session-a1b2c3d4",
+    "teammate_name": "implementer",
+    "transcript_path": "/workspace/.claude/projects/session.jsonl"
+}

--- a/packages/agent-bundle/tests/fixtures/events/claude-teammate-idle.json
+++ b/packages/agent-bundle/tests/fixtures/events/claude-teammate-idle.json
@@ -1,0 +1,9 @@
+{
+    "cwd": "/workspace",
+    "hook_event_name": "TeammateIdle",
+    "permission_mode": "default",
+    "session_id": "session-claude-1",
+    "team_name": "session-a1b2c3d4",
+    "teammate_name": "researcher",
+    "transcript_path": "/workspace/.claude/projects/session.jsonl"
+}

--- a/packages/agent-bundle/tests/route-unit/event-project.test.ts
+++ b/packages/agent-bundle/tests/route-unit/event-project.test.ts
@@ -596,3 +596,77 @@ it('projects permission/denied and stop/failure as observation-only Claude famil
   expect(() => projectEventDocument(failureRejected.document, 'stop/failure', 'claude', 'StopFailure'))
     .toThrow(/observes an API-error turn end/u);
 });
+
+it('projects the stage-4 Claude-only families with their documented decision channels', async () => {
+  const render = async (event: string, native: Record<string, unknown>, nativeEvent: string, value?: JsonValue, context?: string) => {
+    const props = createCanonicalEventProps(
+      event as never,
+      native,
+      'claude',
+      nativeEvent,
+      '2.1.250',
+      new AbortController().signal,
+    );
+    return renderRoute({
+      default: async () => createElement(
+        Agent.Result,
+        value === undefined ? null : { value },
+        context === undefined ? undefined : createElement(Agent.Context, null, context),
+      ),
+    }, {
+      input: { canonical: props.canonical, native: props.native },
+      kind: 'event-route',
+      routeId: `event:${event}`,
+    });
+  };
+  const base = {
+    cwd: '/workspace',
+    session_id: 'session-1',
+    transcript_path: '/workspace/transcript.jsonl',
+  };
+
+  // file/change: side-effect only.
+  const fileNative = { ...base, file_path: '/workspace/.env', hook_event_name: 'FileChanged' };
+  const fileObserved = await render('file/change', fileNative, 'FileChanged');
+  expect(projectEventDocument(fileObserved.document, 'file/change', 'claude', 'FileChanged')).toBeUndefined();
+  const fileDenied = await render('file/change', fileNative, 'FileChanged', { outcome: 'deny', reason: 'No.' });
+  expect(() => projectEventDocument(fileDenied.document, 'file/change', 'claude', 'FileChanged'))
+    .toThrow(/no decision control on Claude FileChanged/u);
+
+  // config/change: top-level decision block.
+  const configNative = { ...base, hook_event_name: 'ConfigChange', source: 'project_settings' };
+  const configDenied = await render('config/change', configNative, 'ConfigChange', { outcome: 'deny', reason: 'Config changes are frozen during release.' });
+  expect(projectEventDocument(configDenied.document, 'config/change', 'claude', 'ConfigChange')).toEqual({
+    decision: 'block',
+    reason: 'Config changes are frozen during release.',
+  });
+
+  // task/create: decision block cancels the task.
+  const taskNative = { ...base, hook_event_name: 'TaskCreated', task_id: 'task-001', task_subject: 'Subject' };
+  const taskDenied = await render('task/create', taskNative, 'TaskCreated', { outcome: 'deny', reason: 'Tasks are frozen.' });
+  expect(projectEventDocument(taskDenied.document, 'task/create', 'claude', 'TaskCreated')).toEqual({
+    decision: 'block',
+    reason: 'Tasks are frozen.',
+  });
+
+  // task/complete: exit-code-only blocking is not projected.
+  const completeNative = { ...base, hook_event_name: 'TaskCompleted', permission_mode: 'default', task_id: 'task-001', task_subject: 'Subject' };
+  const completeObserved = await render('task/complete', completeNative, 'TaskCompleted');
+  expect(projectEventDocument(completeObserved.document, 'task/complete', 'claude', 'TaskCompleted')).toBeUndefined();
+  const completeDenied = await render('task/complete', completeNative, 'TaskCompleted', { outcome: 'deny', reason: 'Not done.' });
+  expect(() => projectEventDocument(completeDenied.document, 'task/complete', 'claude', 'TaskCompleted'))
+    .toThrow(/exit-code-only on Claude TaskCompleted/u);
+
+  // agent/idle: continue:false keeps the teammate working.
+  const idleNative = { ...base, hook_event_name: 'TeammateIdle', permission_mode: 'default', team_name: 'team', teammate_name: 'researcher' };
+  const idleDenied = await render('agent/idle', idleNative, 'TeammateIdle', { outcome: 'deny', reason: 'Backlog remains.' });
+  expect(projectEventDocument(idleDenied.document, 'agent/idle', 'claude', 'TeammateIdle')).toEqual({
+    continue: false,
+    stopReason: 'Backlog remains.',
+  });
+  const idleObserved = await render('agent/idle', idleNative, 'TeammateIdle');
+  expect(projectEventDocument(idleObserved.document, 'agent/idle', 'claude', 'TeammateIdle')).toBeUndefined();
+  const idleContextual = await render('agent/idle', idleNative, 'TeammateIdle', undefined, 'Context.');
+  expect(() => projectEventDocument(idleContextual.document, 'agent/idle', 'claude', 'TeammateIdle'))
+    .toThrow(/no documented additional-context channel/u);
+});


### PR DESCRIPTION
## Summary
- Promotes the five Claude-only #258 stage-4 families with their documented decision channels (code.claude.com/docs/en/hooks, retrieved 2026-09-02):
  - `config/change` + `task/create`: deny projects as top-level `{decision: "block", reason}` (documented block channels)
  - `agent/idle` (TeammateIdle): deny projects as `{continue: false, stopReason}` (keeps the teammate working)
  - `file/change` (FileChanged): side-effect-only — any decision/context fails closed
  - `task/complete` (TaskCompleted): observation-only — blocking is exit-code-only upstream and JSON continue:false has divergent semantics, so it fails closed with that explanation
- Codex/Cursor/portable carry dated per-family `unavailable` rows; Cursor `afterFileEdit` is explicitly recorded as a tool/after selector variant per the #258 selector rule, not inferred as file/change
- Envelope validation, replay starters, fixtures, capability-hash re-pins, README matrix rows, changeset

## Test plan
- [x] projection + envelope suites incl. fail-closed negatives (route-unit pool green)
- [x] adapter metadata/capability/hooks/replay suites (only failure = known pre-existing worktree-env workspace/open starter)
- [x] typecheck + lint