### PR TITLE
feat(events): dated deferral rows for deferred native callbacks (#258 close-out)

### DIFF
--- a/.changeset/record-deferred-native-events.md
+++ b/.changeset/record-deferred-native-events.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Record dated deferral rows for every explicitly deferred native host callback from the #258 v2 tracker in a new `deferredNativeEvents` capability-table section: Claude host/UI/protocol callbacks (Setup, UserPromptExpansion, PostToolBatch, MessageDisplay, InstructionsLoaded, CwdChanged, DirectoryAdded, Pre/PostModelSwitch, Elicitation and ElicitationResult, WorktreeCreate/Remove, Notification which belongs to #99 delivery evidence, and the policy_settings exception to config/change blocking), Cursor tab/thought callbacks and the tool-selector native variants, and Codex Interrupt. A pin test enforces the list and the dated reasons.

--- a/packages/agent-bundle/src/adapters/capabilities/claude-2.1.250.json
+++ b/packages/agent-bundle/src/adapters/capabilities/claude-2.1.250.json
@@ -12,6 +12,68 @@
     "source": "https://code.claude.com/docs/en/discover-plugins",
     "state": "supported"
   },
+  "deferredNativeEvents": {
+    "ConfigChange-policy_settings": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: ConfigChange block decisions cannot stop policy_settings changes; recorded so the config/change family's deny channel is not overstated.",
+      "state": "unavailable"
+    },
+    "CwdChanged": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: host environment callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "DirectoryAdded": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: host workspace-registration callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "Elicitation": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: MCP protocol callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "ElicitationResult": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: MCP protocol callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "InstructionsLoaded": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: host context-load callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "MessageDisplay": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: UI display callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "Notification": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: delivery-channel surface tracked by #99 delivery evidence, not an application event route (#258 defer list).",
+      "state": "unavailable"
+    },
+    "PostModelSwitch": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: model-lifecycle callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "PostToolBatch": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: batch-scheduling callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "PreModelSwitch": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: model-lifecycle callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "Setup": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: one-time init/maintenance callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "UserPromptExpansion": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: command-expansion callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "WorktreeCreate": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: worktree-provisioning callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    },
+    "WorktreeRemove": {
+      "reason": "retrieved 2026-09-02 from https://code.claude.com/docs/en/hooks: worktree-provisioning callback outside the canonical application-event vocabulary (#258 defer list).",
+      "state": "unavailable"
+    }
+  },
   "hooks": {
     "config": "hooks/hooks.json",
     "events": {

--- a/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
+++ b/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
@@ -12,6 +12,12 @@
     "source": "https://developers.openai.com/codex/cli/reference",
     "state": "supported"
   },
+  "deferredNativeEvents": {
+    "Interrupt": {
+      "reason": "retrieved 2026-09-02: generated Interrupt schema exists in the codex repository, but release documentation and a pinned CLI revision do not yet agree on its contract (#258 defer list).",
+      "state": "unavailable"
+    }
+  },
   "hooks": {
     "config": "hooks/hooks.json",
     "events": {

--- a/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
+++ b/packages/agent-bundle/src/adapters/capabilities/cursor-2026-08-28.json
@@ -12,6 +12,52 @@
     "source": "https://cursor.com/docs/plugins",
     "state": "supported"
   },
+  "deferredNativeEvents": {
+    "afterAgentResponse": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native/deferred until a canonical consumer is accepted (#258 defer list).",
+      "state": "unavailable"
+    },
+    "afterAgentThought": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native/deferred until a canonical consumer is accepted (#258 defer list).",
+      "state": "unavailable"
+    },
+    "afterFileEdit": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: agent-edit variant overlapping canonical tool/after per the #258 selector rule; a dedicated family requires fixture evidence that the generic tool route loses information.",
+      "state": "unavailable"
+    },
+    "afterMCPExecution": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native variant of canonical tool/after with mcp selector per the #258 selector rule.",
+      "state": "unavailable"
+    },
+    "afterShellExecution": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native variant of canonical tool/after with shell selector per the #258 selector rule.",
+      "state": "unavailable"
+    },
+    "afterTabFileEdit": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: Tab-surface callback, native/deferred until a canonical consumer is accepted (#258 defer list).",
+      "state": "unavailable"
+    },
+    "beforeMCPExecution": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native variant of canonical tool/before with mcp selector per the #258 selector rule.",
+      "state": "unavailable"
+    },
+    "beforeReadFile": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native variant of canonical tool/before with file.read selector per the #258 selector rule.",
+      "state": "unavailable"
+    },
+    "beforeShellExecution": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: native variant of canonical tool/before with shell selector per the #258 selector rule.",
+      "state": "unavailable"
+    },
+    "beforeSubmitPrompt-cloud": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: cloud/desktop availability differences are capability dimensions; cloud rows stay scoped per surface rather than universal-support claims (#258 defer list).",
+      "state": "unavailable"
+    },
+    "beforeTabFileRead": {
+      "reason": "retrieved 2026-09-02 from https://cursor.com/docs/hooks: Tab-surface callback, native/deferred until a canonical consumer is accepted (#258 defer list).",
+      "state": "unavailable"
+    }
+  },
   "hooks": {
     "config": "hooks/hooks.json",
     "events": {

--- a/packages/agent-bundle/tests/adapter-capability-states.test.ts
+++ b/packages/agent-bundle/tests/adapter-capability-states.test.ts
@@ -1022,3 +1022,33 @@ it('reports evidence-backed installation support only for real host targets', ()
     expect(registry.supports(target, 'install')).toBe(false);
   }
 });
+
+it('pins dated deferral rows for every explicitly deferred native callback from #258', async () => {
+  const { readFile } = await import('node:fs/promises');
+  const tables = {
+    claude: JSON.parse(await readFile(new URL('../src/adapters/capabilities/claude-2.1.250.json', import.meta.url), 'utf8')) as Record<string, unknown>,
+    codex: JSON.parse(await readFile(new URL('../src/adapters/capabilities/codex-0.147.0.json', import.meta.url), 'utf8')) as Record<string, unknown>,
+    cursor: JSON.parse(await readFile(new URL('../src/adapters/capabilities/cursor-2026-08-28.json', import.meta.url), 'utf8')) as Record<string, unknown>,
+  };
+  const expected = {
+    claude: [
+      'ConfigChange-policy_settings', 'CwdChanged', 'DirectoryAdded', 'Elicitation', 'ElicitationResult',
+      'InstructionsLoaded', 'MessageDisplay', 'Notification', 'PostModelSwitch', 'PostToolBatch',
+      'PreModelSwitch', 'Setup', 'UserPromptExpansion', 'WorktreeCreate', 'WorktreeRemove',
+    ],
+    codex: ['Interrupt'],
+    cursor: [
+      'afterAgentResponse', 'afterAgentThought', 'afterFileEdit', 'afterMCPExecution', 'afterShellExecution',
+      'afterTabFileEdit', 'beforeMCPExecution', 'beforeReadFile', 'beforeShellExecution',
+      'beforeSubmitPrompt-cloud', 'beforeTabFileRead',
+    ],
+  } as const;
+  for (const [host, names] of Object.entries(expected)) {
+    const deferred = tables[host as keyof typeof tables].deferredNativeEvents as Record<string, { reason: string; state: string }>;
+    expect(Object.keys(deferred).sort()).toEqual([...names].sort());
+    for (const name of names) {
+      expect(deferred[name]!.state).toMatch(/^(unavailable|prohibited)$/u);
+      expect(deferred[name]!.reason).toMatch(/2026-09-02/u);
+    }
+  }
+});

--- a/packages/agent-bundle/tests/adapter-metadata.test.ts
+++ b/packages/agent-bundle/tests/adapter-metadata.test.ts
@@ -210,10 +210,10 @@ it('records observed capability versions and rehashes schema snapshots against p
     }
 
     if (target === 'claude') {
-      expect(sha256Hex(capability)).toBe('59e190a26734a6bcca0f22ceee6151ebdd73c690eddb979a78b6b25f0136cb45');
+      expect(sha256Hex(capability)).toBe('98938d9685411227acee422f90d2e5bb51f33da96ba499aa2ad7b5d3422b37f1');
     }
     if (target === 'cursor') {
-      expect(sha256Hex(capability)).toBe('52b1fb8776ffe0848e9ee8c35a604052c59fb292cabbfbaf7a482cd03ce3d918');
+      expect(sha256Hex(capability)).toBe('e36e84f829f1c69562647a4bc26ecfbaea2dbd0559f194ed7f52bbf133688fe5');
       const pluginSchema = JSON.parse(await readFile(
         new URL('../src/adapters/schemas/cursor/plugin.schema.json', import.meta.url),
         'utf8',


### PR DESCRIPTION
## Summary
- New `deferredNativeEvents` capability-table section records a dated unavailable row with native name + reason for every explicitly deferred callback on the #258 tracker: 15 Claude host/UI/protocol callbacks (incl. Notification → #99 and the policy_settings exception to config/change blocking), 11 Cursor tab/thought/tool-selector natives, and Codex Interrupt
- Pin test enforces the exact per-host list and dated reasons; capability hashes re-pinned; changeset

## Test plan
- [x] capability-states + metadata + hooks suites (only failure = known pre-existing worktree-env workspace/open starter)
- [x] typecheck + lint