### PR TITLE
test(install): expect the Codex interface.logo field in the packed host-install proof

### DIFF
--- a/packages/agent-bundle/tests/packed-host-install-proof.test.ts
+++ b/packages/agent-bundle/tests/packed-host-install-proof.test.ts
@@ -201,6 +201,7 @@ codexPluginIt(
           'defaultPrompt',
           'developerName',
           'displayName',
+          'logo',
           'longDescription',
           'shortDescription',
         ],


### PR DESCRIPTION
## Summary

- #364 (`305161a1c`) made the Codex adapter honor `plugin.logo` by adding `interface.logo` to `.codex-plugin/plugin.json` and shipping the image. The shared `tests/fixtures/host-install` fixture declares `plugin.logo`, so the binary-gated Codex host-install proofs began failing on the `manifest.interfaceFields` key list.
- #368 (G4 audit lane) fixed the built-bundle proof (`host-install-proof.test.ts`) concurrently; this PR brings the **packed-tarball** proof (`packed-host-install-proof.test.ts`) in line — it was still stale on `origin/main`.
- These proofs only run where a `codex` binary is present (auto-skip otherwise; default CI skips them, `native-host-smoke.yml` runs them), which is why the regression landed silently.
- Test-expectation-only change; product behavior is unchanged; no changeset needed.

Found during the closed-issue re-verification of #181 / #242 (lane G2).

## Evidence

- Pre-fix on `origin/main` (`af1c18551`): `host-install-proof.test.ts :: installs through Codex and observes enabled registration` failed with `+ "logo"` in the received `interfaceFields`; the packed variant asserts the identical key list.
- Post-fix, rebased on `c94df11ca`, real binaries on this machine (claude 2.1.x, codex-cli 0.147.0):
  - `rstest --config rstest.config.ts packages/agent-bundle/tests/packed-host-install-proof.test.ts` → 3 passed / 0 failed.
  - `rstest --config rstest.integration.config.ts packages/agent-bundle/tests/host-install-proof.test.ts` → 9 passed / 0 failed / 0 skipped (Claude + Codex + Cursor + portable lanes all ran).
- `pnpm build`, `pnpm typecheck`, `pnpm lint` (0/0) green on the rebased tree.

## Test plan

- [x] `packed-host-install-proof.test.ts` 3/3 with real Claude and Codex binaries
- [x] `host-install-proof.test.ts` 9/9 with real Claude and Codex binaries
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint`