### PR TITLE
test(route-unit): pin the provider fixture seam of the route harness (#95)

### DIFF
--- a/docs/entry-conventions.md
+++ b/docs/entry-conventions.md
@@ -154,6 +154,11 @@ of throwing. `invocation.kind` stays surface-specific (`tool`, `event`, `cli`,
 `processLifetime` is reserved for the framework-owned process identity and hit
 counter, so provider filenames must not derive that key.
 
+Route-unit and CLI-dispatch tests inject provider values through the same
+`context` seam as identity axes (`renderRoute(id, { context: { providers:
+{ library: fixture } } })`); the harness never executes conventional provider
+modules, so a test chooses exactly the values a component observes.
+
 ### Handler request context
 
 Conventional route components receive only their surface props, such as

--- a/packages/agent-bundle/tests/route-unit/render-route.test.ts
+++ b/packages/agent-bundle/tests/route-unit/render-route.test.ts
@@ -1,4 +1,6 @@
+import { Agent, agent } from '@agent-bundle/runtime';
 import { describe, expect, it } from '@rstest/core';
+import { createElement } from 'react';
 
 import Echo from '../../fixtures/route-harness/src/mcp/harness/tools/echo.tsx';
 import { AgentTestError } from '../../src/test/errors.ts';
@@ -259,6 +261,38 @@ describe('renderRoute through the real renderer', () => {
       .toContainMarkdown('Observed tool/after from claude.')
       .toContainContext('actor unavailable:not-provided')
       .toHaveValue(undefined);
+  });
+
+  it('mounts provider fixture values through the context seam instead of executing provider modules', async () => {
+    const library = { stages: ['discover', 'curate'], tooling: { ffmpeg: { available: false } } };
+    const Providers = async (): Promise<unknown> => {
+      const { providers } = await agent();
+      return createElement(Agent.Result, {
+        value: {
+          frozen: Object.isFrozen(providers),
+          keys: Object.keys(providers).sort(),
+          library: providers['library'] as never,
+        },
+      }, createElement(Agent.Text, null, 'providers observed'));
+    };
+
+    const rendered = await renderRoute({ default: Providers as never }, {
+      context: { providers: { library } },
+      routeId: 'tool:harness/providers (module)',
+    });
+
+    expectDocument(rendered).toHaveStatus('success').toHaveValue({
+      frozen: true,
+      keys: ['library'],
+      library,
+    });
+
+    // A render without fixtures observes an empty, frozen provider map — the
+    // harness never runs conventional src/providers modules on the test's behalf.
+    const unfixtured = await renderRoute({ default: Providers as never }, {
+      routeId: 'tool:harness/providers (module)',
+    });
+    expectDocument(unfixtured).toHaveValue({ frozen: true, keys: [], library: undefined });
   });
 
   it('renders a route module handed in directly, without the compiled manifest', async () => {


### PR DESCRIPTION
## Summary

Reduced after #366 landed the identical plain-routed-CLI provider mounting, rendered-bridge `invocation` fix, shared codegen helpers, docs, and changeset while this PR was in CI. What remains here is the non-overlapping piece:

- Route-unit proof of the provider fixture seam: `renderRoute(module, { context: { providers } })` mounts the fixture values as the request's frozen provider map, and an unfixtured render observes an empty frozen map — the harness never executes conventional `src/providers` modules on a test's behalf (#95 "gives Rstest a provider fixture boundary").
- One paragraph in `docs/entry-conventions.md` documenting that seam beside the provider conventions.

No source or published-package change, so no changeset.

## Evidence

- `packages/agent-bundle/tests/route-unit/render-route.test.ts` — new "mounts provider fixture values through the context seam instead of executing provider modules". Route-unit pool 36/36 after rebase onto `ccb9cd18a`.
- `pnpm typecheck` green, `pnpm lint` 0/0 after rebase.
- Earlier revision of this PR (identical fix to #366) was fully green in CI: Verify (Node 24), Examples check, Release gates, micro-eval.

## Test plan

- [x] route-unit pool, typecheck, lint after rebase
- [ ] CI