### PR TITLE
chore(license): adopt Apache-2.0 and ship LICENSE/NOTICE in every publishable tarball

### DIFF
--- a/.changeset/license-apache-2-0.md
+++ b/.changeset/license-apache-2-0.md
@@ -1,0 +1,11 @@
+---
+"agent-bundle": patch
+"@agent-bundle/runtime": patch
+"create-agent-bundle": patch
+---
+
+License: Apache-2.0 (previously unspecified/MIT-declared); LICENSE and NOTICE
+shipped in the tarball. Every package manifest now declares
+`"license": "Apache-2.0"`, the build copies the repository LICENSE and NOTICE
+into each publishable package, and `pnpm audit:release` fails if any
+publishable tarball is missing either file or the license field.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The canonical license files are verified byte-for-byte (SHA-256 against
+# apache.org and root-vs-package copies), so they must never be CRLF-converted
+# by core.autocrlf on checkout.
+/LICENSE text eol=lf
+/NOTICE text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ artifacts/
 examples/audiobook-curator/artifact/
 examples/worktree-proximity/artifact/
 
+# Build-time copies of the root LICENSE and NOTICE (scripts/sync-license-files.mjs)
+packages/*/LICENSE
+packages/*/NOTICE
+
 # Aborted runtime-playground fixture workspaces
 .runtime-playground-*/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+agent-bundle
+Copyright 2026 Zack Jackson (ScriptedAlchemy)
+
+This product is licensed under the Apache License, Version 2.0; see the
+LICENSE file distributed with it.
+
+This distribution includes third-party material that is covered by its own
+license and notices, which are preserved unmodified alongside that material:
+
+  - The Agent Bundle Workbench MCP App renderer is derived from the MCP
+    Inspector project (MIT License). See THIRD_PARTY_NOTICES and
+    src/mcp/APP-RENDERER-LICENSE, which the agent-bundle package ships under
+    dist/workbench/.
+
+The repository's vendored reference checkouts under repos/ are read-only
+reference material, retain their own upstream licenses, and are not part of
+any published package.

--- a/README.md
+++ b/README.md
@@ -95,4 +95,10 @@ Run these from the repository root. `pnpm examples:check` validates and builds e
 
 ## Status
 
-Pre-release. The final npm package name and license are not yet chosen; pkg.pr.new previews are the release channel until then.
+Pre-release. The final npm package name is not yet chosen; pkg.pr.new previews are the release channel until then.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE). Third-party material in this
+repository (the Workbench MCP App renderer derived from the MIT-licensed MCP Inspector) is covered by
+its own notices in [packages/workbench/THIRD_PARTY_NOTICES](packages/workbench/THIRD_PARTY_NOTICES).

--- a/examples/audiobook-curator/package.json
+++ b/examples/audiobook-curator/package.json
@@ -2,6 +2,7 @@
   "name": "@agent-bundle-example/audiobook-curator",
   "version": "1.0.0",
   "private": true,
+  "license": "Apache-2.0",
   "description": "A complete framework-mode Claude and Codex audiobook-curation plugin, CLI, Skill, and MCP server.",
   "type": "module",
   "engines": {

--- a/examples/hooks-and-scripts/package.json
+++ b/examples/hooks-and-scripts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-bundle-example/hooks-and-scripts",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "agent-bundle build",

--- a/examples/mcp-app/package.json
+++ b/examples/mcp-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-bundle-example/mcp-app",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "agent-bundle build",

--- a/examples/rsc-agent-runtime/package.json
+++ b/examples/rsc-agent-runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-bundle/rsc-agent-runtime-demo",
   "private": true,
+  "license": "Apache-2.0",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/examples/skills-starter/package.json
+++ b/examples/skills-starter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-bundle-example/skills-starter",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "agent-bundle build",

--- a/examples/worktree-proximity/package.json
+++ b/examples/worktree-proximity/package.json
@@ -2,6 +2,7 @@
   "name": "@agent-bundle-example/worktree-proximity",
   "version": "1.0.0",
   "private": true,
+  "license": "Apache-2.0",
   "description": "An advanced worktree-proximity coordination reference for agent-bundle.",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "agent-bundle-workspace",
   "private": true,
   "version": "0.0.0",
+  "license": "Apache-2.0",
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -678,6 +678,13 @@ harness.
 Third-party notices, including the vendored MCP Inspector snapshot's license and provenance, ship in
 the published package.
 
+## License
+
+Apache License 2.0. The published tarball carries the repository
+[LICENSE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/LICENSE) and
+[NOTICE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/NOTICE); third-party material keeps
+its own notices under `dist/workbench/`.
+
 ## Contributor delivery and release gates
 
 The public examples live at [`../../examples`](../../examples). They are private
@@ -689,6 +696,7 @@ Run the complete local delivery gate with `pnpm check && pnpm check:release`.
 `pnpm pack:dry-run`, `pnpm audit:release`, and `pnpm test:packed:release`, and it does not replace
 `pnpm check`. `pnpm release` runs that release gate before `changeset publish`.
 Native Claude/Codex smokes stay intentionally opt-in and skipped in ordinary CI.
-npm publishing is deferred until the release owner picks the final package name/scope and
-license; pkg.pr.new previews are the interim channel, and the first npm release will use npm
-package provenance (`publishConfig.provenance` is already set).
+npm publishing is deferred until the release owner picks the final package name/scope;
+pkg.pr.new previews are the interim channel, and the first npm release will use npm
+package provenance (`publishConfig.provenance` is already set). `pnpm audit:release` fails if any
+publishable tarball lacks `LICENSE`, `NOTICE`, or the `"license": "Apache-2.0"` manifest field.

--- a/packages/agent-bundle/package.json
+++ b/packages/agent-bundle/package.json
@@ -2,6 +2,7 @@
   "name": "agent-bundle",
   "version": "0.1.0",
   "description": "Compile a typed Agent Bundle configuration into portable, Codex, Claude Code, and Cursor artifacts.",
+  "license": "Apache-2.0",
   "keywords": [
     "agent",
     "claude-code",
@@ -24,13 +25,15 @@
     "node": ">=22.19.0"
   },
   "scripts": {
-    "build": "pnpm build:workbench && rslib build",
+    "build": "node ../../scripts/sync-license-files.mjs && pnpm build:workbench && rslib build",
     "build:workbench": "pnpm --filter agent-bundle-workbench build"
   },
   "files": [
     "bin",
     "dist",
     "!dist/workbench/**/*.map",
+    "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "bin": {

--- a/packages/agent-bundle/tests/license-metadata.test.ts
+++ b/packages/agent-bundle/tests/license-metadata.test.ts
@@ -6,7 +6,7 @@ import { expect, it } from '@rstest/core';
 
 const workspaceRoot = process.cwd();
 const projectLicense = 'Apache-2.0';
-/** SHA-256 of https://www.apache.org/licenses/LICENSE-2.0.txt (canonical text, LF line endings). */
+/** SHA-256 of https://www.apache.org/licenses/LICENSE-2.0.txt (canonical text; .gitattributes pins LF endings). */
 const canonicalApache2Sha256 = 'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30';
 const publishablePackages = ['agent-bundle', 'rsc-runtime', 'create-agent-bundle'] as const;
 

--- a/packages/agent-bundle/tests/license-metadata.test.ts
+++ b/packages/agent-bundle/tests/license-metadata.test.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { expect, it } from '@rstest/core';
+
+const workspaceRoot = process.cwd();
+const projectLicense = 'Apache-2.0';
+/** SHA-256 of https://www.apache.org/licenses/LICENSE-2.0.txt (canonical text, LF line endings). */
+const canonicalApache2Sha256 = 'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30';
+const publishablePackages = ['agent-bundle', 'rsc-runtime', 'create-agent-bundle'] as const;
+
+interface Manifest {
+  readonly files?: readonly string[];
+  readonly license?: string;
+  readonly name?: string;
+  readonly private?: boolean;
+}
+
+const readManifest = async (path: string): Promise<Manifest> => JSON.parse(await readFile(path, 'utf8')) as Manifest;
+
+const workspaceManifestPaths = async (): Promise<readonly string[]> => {
+  const groups = await Promise.all(['packages', 'examples'].map(async (group) => {
+    const entries = await readdir(join(workspaceRoot, group), { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => join(workspaceRoot, group, entry.name, 'package.json'));
+  }));
+  return [join(workspaceRoot, 'package.json'), ...groups.flat()];
+};
+
+it('ships the canonical Apache License 2.0 text and a NOTICE naming the copyright holder', async () => {
+  const license = await readFile(join(workspaceRoot, 'LICENSE'));
+  const notice = await readFile(join(workspaceRoot, 'NOTICE'), 'utf8');
+
+  expect(createHash('sha256').update(license).digest('hex')).toBe(canonicalApache2Sha256);
+  expect(notice.startsWith('agent-bundle\nCopyright 2026 ')).toBe(true);
+  expect(notice).toContain('THIRD_PARTY_NOTICES');
+  expect(notice).toContain('src/mcp/APP-RENDERER-LICENSE');
+});
+
+it('declares Apache-2.0 on every first-party workspace package', async () => {
+  const manifests = await Promise.all((await workspaceManifestPaths()).map(readManifest));
+
+  expect(manifests.length).toBeGreaterThanOrEqual(1 + 4 + 6);
+  for (const manifest of manifests) {
+    expect(manifest.license, `${String(manifest.name)} must declare "license": "${projectLicense}"`).toBe(projectLicense);
+  }
+});
+
+it('lists LICENSE and NOTICE in every publishable package files allowlist', async () => {
+  for (const directory of publishablePackages) {
+    const manifest = await readManifest(join(workspaceRoot, 'packages', directory, 'package.json'));
+    expect(manifest.private).toBeUndefined();
+    expect(manifest.files).toEqual(expect.arrayContaining(['LICENSE', 'NOTICE']));
+  }
+});
+
+it('leaves scaffolded projects free to choose their own license', async () => {
+  const templatesRoot = join(workspaceRoot, 'packages', 'create-agent-bundle', 'templates');
+  const templates = (await readdir(templatesRoot, { withFileTypes: true })).filter((entry) => entry.isDirectory());
+
+  expect(templates.length).toBeGreaterThan(0);
+  for (const template of templates) {
+    const manifest = await readManifest(join(templatesRoot, template.name, 'package_json'));
+    expect(manifest.license, `template ${template.name} must not impose a license`).toBeUndefined();
+  }
+});

--- a/packages/agent-bundle/tests/release-audit.test.ts
+++ b/packages/agent-bundle/tests/release-audit.test.ts
@@ -119,6 +119,32 @@ it('packs generated Workbench legal companion files', async () => {
   expect(productManifest).not.toContain('workspace:');
 }, 120_000);
 
+it('packs the root LICENSE and NOTICE into every publishable tarball', async () => {
+  const [license, notice] = await Promise.all([
+    readFile(join(workspaceRoot, 'LICENSE'), 'utf8'),
+    readFile(join(workspaceRoot, 'NOTICE'), 'utf8'),
+  ]);
+
+  for (const packageName of ['agent-bundle', 'runtime', 'create-agent-bundle'] as const) {
+    const tarballRoot = await mkdtemp(join(tmpdir(), `agent-bundle-license-${packageName}-`));
+    try {
+      const { packOutput, tarball } = await sharedPackedTarball(packageName);
+      const paths = packOutput.files.map((file) => file.path);
+      expect(paths, `${packageName} tarball listing`).toEqual(expect.arrayContaining(['LICENSE', 'NOTICE']));
+
+      await execFile('tar', ['--extract', '--file', tarball, '--directory', tarballRoot]);
+      const manifest = JSON.parse(await readFile(join(tarballRoot, 'package', 'package.json'), 'utf8')) as {
+        readonly license?: string;
+      };
+      expect(manifest.license, `${packageName} license field`).toBe('Apache-2.0');
+      await expect(readFile(join(tarballRoot, 'package', 'LICENSE'), 'utf8')).resolves.toBe(license);
+      await expect(readFile(join(tarballRoot, 'package', 'NOTICE'), 'utf8')).resolves.toBe(notice);
+    } finally {
+      await rm(tarballRoot, { force: true, recursive: true });
+    }
+  }
+}, 120_000);
+
 it('installs public entrypoints and an externally resolved CLI for production consumers', async () => {
   const consumerRoot = await mkdtemp(join(tmpdir(), 'agent-bundle-release-consumer-'));
 

--- a/packages/create-agent-bundle/README.md
+++ b/packages/create-agent-bundle/README.md
@@ -65,3 +65,9 @@ same `-preview-<sha>` suffix, so the scaffolder and the framework it pins
 always come from the same commit. A non-preview build of the scaffolder has
 no derivable default (the `agent-bundle` name on npm currently belongs to an
 unrelated project) and requires `--framework-version` explicitly.
+
+## License
+
+Apache License 2.0. The published tarball carries the repository
+[LICENSE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/LICENSE) and
+[NOTICE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/NOTICE).

--- a/packages/create-agent-bundle/package.json
+++ b/packages/create-agent-bundle/package.json
@@ -2,7 +2,7 @@
   "name": "create-agent-bundle",
   "version": "0.0.0",
   "description": "Scaffold a new agent-bundle plugin project from a checked-in template.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "agent-bundle",
     "create",
@@ -30,13 +30,15 @@
     "bin",
     "dist",
     "templates",
+    "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "bin": {
     "create-agent-bundle": "./bin/create-agent-bundle.js"
   },
   "scripts": {
-    "build": "rslib build",
+    "build": "node ../../scripts/sync-license-files.mjs && rslib build",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {

--- a/packages/rsc-runtime/README.md
+++ b/packages/rsc-runtime/README.md
@@ -258,3 +258,9 @@ content, and the `available`/`read` taxonomy rows from #99 map onto the
 availability and exposure receipts. `selectNoticeDeliveryRoutes()` chooses
 cross-request routes from a per-host advertisement and returns a typed
 unavailable outcome when none is supported; it never fabricates a channel.
+
+## License
+
+Apache License 2.0. The published tarball carries the repository
+[LICENSE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/LICENSE) and
+[NOTICE](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/NOTICE).

--- a/packages/rsc-runtime/package.json
+++ b/packages/rsc-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@agent-bundle/runtime",
   "version": "0.0.0",
   "description": "Agent Document contracts and streaming React Flight dispatch for Agent Bundle runtimes.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "agent-bundle",
     "mcp"
@@ -27,6 +27,8 @@
   },
   "files": [
     "dist",
+    "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "exports": {
@@ -64,7 +66,7 @@
     }
   },
   "scripts": {
-    "build": "rslib build",
+    "build": "node ../../scripts/sync-license-files.mjs && rslib build",
     "test": "rstest tests",
     "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -2,6 +2,7 @@
   "name": "agent-bundle-workbench",
   "version": "0.0.0",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/scripts/audit-packed-release.mjs
+++ b/scripts/audit-packed-release.mjs
@@ -7,10 +7,12 @@ import { promisify } from 'node:util';
 
 import { npmCliInvocation } from './npm-cli.mjs';
 import { packOutputFromJson as sharedPackOutputFromJson } from './npm-pack-json.mjs';
+import { licenseFiles, publishablePackageDirectories } from './sync-license-files.mjs';
 
 const execFile = promisify(executeFile);
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageRoot = join(repositoryRoot, 'packages', 'agent-bundle');
+const projectLicense = 'Apache-2.0';
 const { NODE_PATH: _nodePath, ...productionEnvironment } = process.env;
 const npmCli = npmCliInvocation(productionEnvironment);
 const execNpm = (args, options) => execFile(npmCli.command, [...npmCli.args, ...args], options);
@@ -147,7 +149,40 @@ const validateSbom = (sbom, productManifest, installedPackages) => {
   }
 };
 
+/**
+ * Every publishable tarball must declare the project license and carry the
+ * root LICENSE and NOTICE byte-for-byte; npm's implicit inclusion is not
+ * trusted because the package copies are build outputs that may be stale.
+ */
+const validateLicenseFiles = async (packOutput, packageDirectory) => {
+  const manifest = JSON.parse(await readFile(join(repositoryRoot, packageDirectory, 'package.json'), 'utf8'));
+  if (manifest.license !== projectLicense) {
+    fail(`${packageDirectory} package.json must declare "license": "${projectLicense}"`);
+  }
+  if (!Array.isArray(packOutput.files)) fail(`${packageDirectory} npm pack did not list tarball files`);
+  const packedPaths = new Set(packOutput.files.map((file) => asRecord(file, 'pack file must be an object').path));
+  for (const file of licenseFiles) {
+    if (!packedPaths.has(file)) fail(`${packageDirectory} tarball is missing ${file}`);
+    const [expected, actual] = await Promise.all([
+      readFile(join(repositoryRoot, file), 'utf8'),
+      readFile(join(repositoryRoot, packageDirectory, file), 'utf8').catch(() => fail(`${packageDirectory}/${file} is not readable`)),
+    ]);
+    if (expected !== actual) fail(`${packageDirectory}/${file} differs from the repository root ${file}`);
+  }
+};
+
+const auditLicenseFiles = async () => {
+  for (const packageDirectory of publishablePackageDirectories) {
+    const packOutput = packOutputFromJson((await execNpm(['pack', '--dry-run', '--json'], {
+      cwd: join(repositoryRoot, packageDirectory),
+      env: productionEnvironment,
+    })).stdout);
+    await validateLicenseFiles(packOutput, packageDirectory);
+  }
+};
+
 const auditPackedRelease = async () => {
+  await auditLicenseFiles();
   const auditRoot = await mkdtemp(join(tmpdir(), 'agent-bundle-release-audit-'));
 
   try {

--- a/scripts/audit-packed-release.mjs
+++ b/scripts/audit-packed-release.mjs
@@ -151,8 +151,11 @@ const validateSbom = (sbom, productManifest, installedPackages) => {
 
 /**
  * Every publishable tarball must declare the project license and carry the
- * root LICENSE and NOTICE byte-for-byte; npm's implicit inclusion is not
- * trusted because the package copies are build outputs that may be stale.
+ * root LICENSE and NOTICE byte-for-byte. Like the rest of this audit (attw and
+ * the SBOM install both pack `dist`), it inspects build output and never
+ * regenerates it: the package copies are written by each package's `build`
+ * (scripts/sync-license-files.mjs), and syncing here would hide a build step
+ * that stopped producing them.
  */
 const validateLicenseFiles = async (packOutput, packageDirectory) => {
   const manifest = JSON.parse(await readFile(join(repositoryRoot, packageDirectory, 'package.json'), 'utf8'));
@@ -162,12 +165,14 @@ const validateLicenseFiles = async (packOutput, packageDirectory) => {
   if (!Array.isArray(packOutput.files)) fail(`${packageDirectory} npm pack did not list tarball files`);
   const packedPaths = new Set(packOutput.files.map((file) => asRecord(file, 'pack file must be an object').path));
   for (const file of licenseFiles) {
+    const actual = await readFile(join(repositoryRoot, packageDirectory, file), 'utf8').catch(() => undefined);
+    if (actual === undefined) {
+      fail(`${packageDirectory}/${file} is missing; this audit inspects build output, so run \`pnpm build\` (which runs scripts/sync-license-files.mjs) first`);
+    }
     if (!packedPaths.has(file)) fail(`${packageDirectory} tarball is missing ${file}`);
-    const [expected, actual] = await Promise.all([
-      readFile(join(repositoryRoot, file), 'utf8'),
-      readFile(join(repositoryRoot, packageDirectory, file), 'utf8').catch(() => fail(`${packageDirectory}/${file} is not readable`)),
-    ]);
-    if (expected !== actual) fail(`${packageDirectory}/${file} differs from the repository root ${file}`);
+    if (actual !== await readFile(join(repositoryRoot, file), 'utf8')) {
+      fail(`${packageDirectory}/${file} differs from the repository root ${file}`);
+    }
   }
 };
 

--- a/scripts/sync-license-files.mjs
+++ b/scripts/sync-license-files.mjs
@@ -1,0 +1,26 @@
+import { copyFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Copies the repository's LICENSE and NOTICE into every publishable package so
+ * `npm pack` ships them at the tarball root. The copies are build outputs
+ * (gitignored); the repository root files are the single source of truth.
+ */
+export const licenseFiles = Object.freeze(['LICENSE', 'NOTICE']);
+
+export const publishablePackageDirectories = Object.freeze([
+  'packages/agent-bundle',
+  'packages/rsc-runtime',
+  'packages/create-agent-bundle',
+]);
+
+export const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const syncLicenseFiles = async (root = repositoryRoot) => {
+  await Promise.all(publishablePackageDirectories.flatMap((directory) => (
+    licenseFiles.map((file) => copyFile(join(root, file), join(root, directory, file)))
+  )));
+};
+
+if (import.meta.main) await syncLicenseFiles();


### PR DESCRIPTION
## Summary

- Adds the canonical Apache License 2.0 text as `LICENSE` (sha256 `cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30`, byte-identical to https://www.apache.org/licenses/LICENSE-2.0.txt) and a `NOTICE` naming the copyright holder (Zack Jackson / ScriptedAlchemy, 2026) and pointing at the preserved third-party notices (`THIRD_PARTY_NOTICES`, `APP-RENDERER-LICENSE`, shipped under `dist/workbench/`).
- Declares `"license": "Apache-2.0"` on every first-party workspace package (root, `agent-bundle`, `@agent-bundle/runtime`, `create-agent-bundle`, workbench, all six examples). `@agent-bundle/runtime` and `create-agent-bundle` previously said MIT; `agent-bundle` and the root/workbench had none. Scaffolder templates deliberately stay license-less so scaffolded projects choose their own.
- Each publishable package's `build` first runs `scripts/sync-license-files.mjs`, which copies the root `LICENSE`/`NOTICE` into the package (gitignored build outputs); the `files` allowlists name both so `npm pack` ships them at the tarball root.
- `scripts/audit-packed-release.mjs` (`pnpm audit:release`) now fails if any of the three publishable tarballs lacks `LICENSE`, `NOTICE`, or the `license` field, or if a package copy drifts from the root file.
- Docs: root README gets a License section and drops "license not yet chosen"; package READMEs get License sections; `agent-bundle` README release-gate wording updated. No per-file headers (the repo has no header convention; Apache-2.0 does not require them).
- Changeset (patch) for the three publishable packages.

## Evidence

- `npm pack --dry-run --json` top-level entries for all three packages: `LICENSE, NOTICE, README.md, package.json`; no `repos/` entries; `agent-bundle` also carries `dist/workbench/THIRD_PARTY_NOTICES` and `dist/workbench/src/mcp/APP-RENDERER-LICENSE`.
- `pnpm lint:package` — all three "All good!".
- `pnpm audit:release` — exit 0 (publint, attw, packed audit + SBOM).
- Negative checks: deleting `packages/rsc-runtime/NOTICE` → `Invalid packed release audit: packages/rsc-runtime tarball is missing NOTICE`; a stale `packages/create-agent-bundle/LICENSE` → `... differs from the repository root LICENSE`.
- `pnpm pack:dry-run` — exit 0.
- `pnpm typecheck`, `pnpm lint` — exit 0.
- `pnpm test:unit` — 2673/2680 passed; the 2 failures (`mcp-probe-service` teardown guard, `native-claude-contract` 5s timeout) are timer-based, unrelated to this change, and pass when rerun in isolation.
- `node scripts/run-packed-tests.mjs packages/agent-bundle/tests/release-audit.test.ts` — 5/5 passed, including the new "packs the root LICENSE and NOTICE into every publishable tarball".

## Test plan

- [x] `pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/license-metadata.test.ts`
- [x] `pnpm audit:release`
- [x] `pnpm pack:dry-run`
- [ ] After merge: `gh repo view --json licenseInfo` reports Apache License 2.0