### PR TITLE
docs(runtime): record the dated deferral of task-augmented MCP tool calls (#369)

### DIFF
--- a/.changeset/mcp-tasks-deferral.md
+++ b/.changeset/mcp-tasks-deferral.md
@@ -1,0 +1,11 @@
+---
+"@agent-bundle/runtime": patch
+---
+
+Record the dated deferral of task-augmented MCP tool calls (`CreateTaskResult`,
+`tasks/get`, `tasks/result`, `tasks/cancel`): the installed MCP SDK ships only
+the `2025-11-25` task wire vocabulary with no task runtime, and the
+`2026-07-28` revision moves tasks into an extension. Generated servers stay
+fail-closed — no `tasks` capability is advertised and task-augmented requests
+are processed as ordinary calls — and a sentinel test pins the audited SDK
+version so the deferral cannot go stale silently.

--- a/docs/entry-conventions.md
+++ b/docs/entry-conventions.md
@@ -383,6 +383,13 @@ name).
 Self-connecting entries — modules that construct and connect a transport at
 top level without a default export — keep today's behavior byte for byte.
 
+Every served tool call is one ordinary `tools/call`: optional
+`notifications/progress` while the caller's progress token is live, then one
+final `CallToolResult`. The shell advertises no `tasks` capability and
+processes a task-augmented request as an ordinary one; task-augmented calls
+are deferred until the MCP SDK ships a task runtime (see
+[MCP conformance evidence](./mcp-conformance.md#task-augmented-requests-deferred-2026-09-02)).
+
 The same lifecycle is public API for hand-rolled entries:
 
 ```ts

--- a/docs/mcp-conformance.md
+++ b/docs/mcp-conformance.md
@@ -43,3 +43,65 @@ the canonical content-specific tools, resources, and prompts that the reused
 route harness does not provide. The official runner rejects both unexpected
 failures and stale baseline entries, so newly fixed scenarios must be removed
 from the baseline.
+
+## Task-augmented requests: deferred 2026-09-02
+
+Issue [#369](https://github.com/ScriptedAlchemy/agent-bundle/issues/369) tracks
+the #96 acceptance remainder: a task-augmented `tools/call` that returns a
+`CreateTaskResult` and resolves through `tasks/get` / `tasks/result`, with
+`tasks/cancel` mapped into the renderer `AbortSignal`. It is deferred because
+the installed SDK has no task runtime to build on; the repository does not
+hand-roll the protocol outside the SDK's typed surface.
+
+Audited state (2026-09-02):
+
+- Generated servers use `@modelcontextprotocol/server@2.0.0` with
+  `@modelcontextprotocol/client@2.0.0` for in-memory proof; both share
+  `@modelcontextprotocol/core@2.0.0`. Their latest core protocol revision is
+  `2025-11-25`, the revision this conformance lane records.
+- The SDK ships the `2025-11-25` task wire vocabulary as importable types only.
+  Its own declaration states that `tasks/get`, `tasks/result`, `tasks/list`,
+  `tasks/cancel`, and `notifications/tasks/status` are "wire vocabulary with no
+  SDK runtime": the typed `request()`, `setRequestHandler()`, and
+  `ctx.mcpReq.send()` surfaces exclude them, the client refuses to issue them
+  as spec methods, the only task-named runtime exports are
+  `RELATED_TASK_META_KEY` and a deprecated `isTaskAugmentedRequestParams`
+  guard, and no `TaskStore` or `experimental.tasks` namespace exists (the 1.x
+  experimental API was not carried into v2).
+- The `2026-07-28` specification revision moved tasks out of the core protocol
+  into the `io.modelcontextprotocol/tasks` extension
+  ([SEP-2663](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2663)):
+  `tasks/result` and `tasks/list` are gone, polling goes through `tasks/get`,
+  and `tasks/update` is new. Implementing the `2025-11-25` core shape now would
+  target a surface the next revision removes. The SDK tracks the extension in
+  [typescript-sdk#2189](https://github.com/modelcontextprotocol/typescript-sdk/issues/2189)
+  (open, "needs decision"); reported v2 gaps include custom `tasks/get` /
+  `tasks/cancel` handlers being unreachable on a `2026-07-28` session
+  ([#2598](https://github.com/modelcontextprotocol/typescript-sdk/issues/2598))
+  and `Client.callTool()` rejecting a `CreateTaskResult`
+  ([#2637](https://github.com/modelcontextprotocol/typescript-sdk/issues/2637)).
+
+Behaviour while deferred (fail-closed, both proven at the `mcp-in-memory`
+level):
+
+- Generated servers never advertise a `tasks` capability, even to a client that
+  negotiated one, so no client is invited into a lifecycle the server cannot
+  serve.
+- A `tools/call` carrying task augmentation is processed as an ordinary request
+  and returns one final `CallToolResult` with no task handle — the behaviour
+  the `2025-11-25` Tasks utility requires of a receiver that declared no task
+  capability for that request type. `tasks/get`, `tasks/result`, `tasks/list`,
+  and `tasks/cancel` answer with JSON-RPC `-32601`.
+- Ordinary progress-token gating and the single final `CallToolResult` pinned
+  by #175 are unchanged.
+
+Unblock condition: a published `@modelcontextprotocol/server` /
+`@modelcontextprotocol/client` release that routes task operations through its
+typed surface — a server-side task store or `registerTool` task handler, a
+typed client path for `CreateTaskResult` and task polling, and a `tasks`
+capability the SDK itself gates — for whichever revision the conformance lane
+then records. `packages/rsc-runtime/tests/mcp-tasks-deferral.test.ts` pins the
+audited SDK version and asserts each fact above against the installed
+packages; when one stops holding, that test (or `pnpm typecheck`, through its
+`@ts-expect-error` sentinel on `setRequestHandler('tasks/get', …)`) fails and
+this section must be re-audited before the pin is moved.

--- a/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
+++ b/packages/agent-bundle/tests/projection/mcp-in-memory.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import type { McpServer } from '@modelcontextprotocol/server';
 import { describe, expect, it } from '@rstest/core';
 import { createMemoryStateDriver, defineState, type AgentStateDriver } from '@agent-bundle/runtime/state';
 import { createSqliteStateDriver } from '@agent-bundle/runtime/state/sqlite';
@@ -280,6 +281,43 @@ describe('the in-memory MCP projection level', () => {
 
     expect((await listMcpSurface()).resources).not.toContain('agent-bundle://notices/inbox');
   });
+
+  // Issue #369: task-augmented tool calls are deferred until the MCP SDK ships
+  // a task runtime (docs/mcp-conformance.md). Until then the generated server
+  // must stay fail-closed — no `tasks` capability claim — and must process a
+  // task-augmented request as an ordinary one, which is what the 2025-11-25
+  // Tasks utility requires of a receiver that declared no task support.
+  it('never advertises the MCP Tasks capability', async () => {
+    await using session = await openInMemoryMcpServer();
+
+    const capabilities = session.client.getServerCapabilities();
+    expect(capabilities).toMatchObject({ tools: expect.any(Object) });
+    expect(Object.hasOwn(capabilities ?? {}, 'tasks')).toBe(false);
+  });
+
+  it('processes a task-augmented tools/call as an ordinary request', async () => {
+    await using session = await openInMemoryMcpServer();
+
+    const result = await session.client.request({
+      method: 'tools/call',
+      params: { arguments: { message: 'deferred' }, name: 'echo', task: { ttl: 60_000 } },
+    });
+
+    expect(result).toMatchObject({ structuredContent: { message: 'deferred' } });
+    for (const key of ['task', 'taskId', 'status', 'createdAt', 'ttl', 'pollInterval']) {
+      expect(Object.hasOwn(result, key)).toBe(false);
+    }
+  });
+
+  // Compile-time half of the #369 sentinel: the SDK's spec-method handler
+  // overload rejects task methods today. When a release admits them, this
+  // directive becomes unused, `pnpm typecheck` fails, and the deferral in
+  // docs/mcp-conformance.md must be re-audited. Never invoked at runtime.
+  const typedTaskSurfaceSentinel = (server: McpServer): void => {
+    // @ts-expect-error tasks/get is 2025-11-25 wire vocabulary without an SDK runtime.
+    server.server.setRequestHandler('tasks/get', async () => ({}));
+  };
+  void typedTaskSurfaceSentinel;
 
   it('leaves the browser App surface off the in-memory server', async () => {
     const surface = await listMcpSurface();

--- a/packages/rsc-runtime/README.md
+++ b/packages/rsc-runtime/README.md
@@ -24,6 +24,16 @@ fallback or a typed `McpProjectionError`, never a silent drop. The existing
 `lowerMcpResult` / `lowerHookResult` helpers remain synchronous compatibility
 APIs for the operations-model path.
 
+Task-augmented tool calls (`CreateTaskResult`, `tasks/get`, `tasks/result`,
+`tasks/cancel`) are deferred, not partially implemented. The generated servers
+never advertise a `tasks` capability, and a request that carries task
+augmentation is processed as an ordinary `tools/call` — the fallback the
+2025-11-25 Tasks utility requires of a receiver that declared no task support.
+The deferral, its SDK pin, and the exact unblock condition are recorded in
+[MCP conformance evidence](https://github.com/ScriptedAlchemy/agent-bundle/blob/main/docs/mcp-conformance.md#task-augmented-requests-deferred-2026-09-02)
+and enforced by `tests/mcp-tasks-deferral.test.ts`, which fails the day the
+installed SDK grows a task runtime.
+
 ```tsx
 import { Mcp, lowerMcpResult } from '@agent-bundle/runtime';
 

--- a/packages/rsc-runtime/tests/mcp-tasks-deferral.test.ts
+++ b/packages/rsc-runtime/tests/mcp-tasks-deferral.test.ts
@@ -1,0 +1,178 @@
+// Deferral sentinel for issue #369 (task-augmented MCP tool calls, the #96
+// acceptance remainder). The installed MCP SDK carries the 2025-11-25 Tasks
+// wire vocabulary but no task runtime, and the 2026-07-28 revision moved
+// tasks into the `io.modelcontextprotocol/tasks` extension (SEP-2663) with a
+// redesigned lifecycle. Rather than hand-roll a protocol fork on a surface the
+// SDK labels "interoperability only", the repository defers and pins the exact
+// conditions of that deferral here. Every assertion below is a fact about the
+// SDK as installed; the day one of them stops holding, this file fails and the
+// deferral recorded in docs/mcp-conformance.md must be re-audited.
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import * as clientModule from '@modelcontextprotocol/client';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import * as serverModule from '@modelcontextprotocol/server';
+import { McpServer as ProtocolMcpServer } from '@modelcontextprotocol/server';
+import { afterAll, describe, expect, it } from '@rstest/core';
+import { createElement } from 'react';
+import { z } from 'zod';
+
+import { Mcp, createRscMcpServer, defineOperation, defineRscApplication } from '../src/index.js';
+
+/** The SDK revision this deferral was audited against (2026-09-02). */
+const AUDITED_SDK_VERSION = '2.0.0';
+
+/** The task vocabulary the 2025-11-25 revision defines and the SDK leaves unrouted. */
+const TASK_METHODS = ['tasks/get', 'tasks/result', 'tasks/list', 'tasks/cancel'] as const;
+
+/**
+ * The only task-named exports the audited SDK exposes: a `_meta` key and a
+ * deprecated wire-shape guard. A `TaskStore`, `registerToolTask`, an
+ * `experimental.tasks` namespace, or exported task result schemas would mean
+ * the SDK grew a runtime and the deferral is stale.
+ */
+const AUDITED_TASK_EXPORTS = ['RELATED_TASK_META_KEY', 'isTaskAugmentedRequestParams'];
+
+const installedVersion = async (packageName: string): Promise<string> => {
+  const manifestPath = fileURLToPath(new URL(`../node_modules/${packageName}/package.json`, import.meta.url));
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as { readonly version: string };
+  return manifest.version;
+};
+
+const taskNamedExports = (module: Readonly<Record<string, unknown>>): readonly string[] =>
+  Object.keys(module).filter((name) => /task/iu.test(name)).sort();
+
+const slowOperation = defineOperation({
+  execute: async () => ({ ok: true }),
+  id: 'slow',
+  inputSchema: z.object({}).strict(),
+  mcp: {
+    description: 'A render the Tasks utility would let a client defer.',
+    name: 'slow',
+    readOnly: true,
+    server: 'demo',
+  },
+  render: (result) => createElement(
+    Mcp.Result,
+    { structuredContent: result },
+    createElement(Mcp.Text, null, 'done'),
+  ),
+  resultSchema: z.object({ ok: z.boolean() }).strict(),
+});
+
+const application = defineRscApplication({
+  name: 'tasks-deferral-demo',
+  operations: [slowOperation],
+  version: '1.0.0',
+});
+
+interface WireMessage {
+  readonly error?: { readonly code: number; readonly message: string };
+  readonly id?: number | string;
+  readonly result?: Record<string, unknown>;
+}
+
+const openClients: Client[] = [];
+
+/**
+ * Connects a real client that negotiates the 2025-11-25 `tasks` capability
+ * and returns a raw-frame injector: the typed client refuses task methods, so
+ * the wire shape a task-aware peer would send is delivered straight to the
+ * server transport and the serialized response captured.
+ */
+const connectTaskNegotiatingClient = async (): Promise<{
+  readonly client: Client;
+  readonly inject: (id: number, method: string, params: Record<string, unknown>) => Promise<WireMessage>;
+  readonly server: ProtocolMcpServer;
+}> => {
+  const server = createRscMcpServer(application, 'demo');
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const sent: WireMessage[] = [];
+  const originalSend = serverTransport.send.bind(serverTransport);
+  serverTransport.send = async (message, options) => {
+    sent.push(JSON.parse(JSON.stringify(message)) as WireMessage);
+    return originalSend(message, options);
+  };
+  const client = new Client(
+    { name: 'tasks-deferral-test', version: '0.0.0' },
+    { capabilities: { tasks: { requests: { tools: { call: {} } } } } as never },
+  );
+  openClients.push(client);
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const inject = async (id: number, method: string, params: Record<string, unknown>): Promise<WireMessage> => {
+    serverTransport.onmessage?.({ id, jsonrpc: '2.0', method, params });
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const response = sent.find((message) => message.id === id);
+      if (response !== undefined) return response;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`No response for ${method} (id ${String(id)})`);
+  };
+  return { client, inject, server };
+};
+
+afterAll(async () => {
+  await Promise.allSettled(openClients.map((client) => client.close()));
+});
+
+describe('MCP Tasks deferral sentinel (#369)', () => {
+  it('pins the SDK revision the deferral was audited against', async () => {
+    await expect(installedVersion('@modelcontextprotocol/server')).resolves.toBe(AUDITED_SDK_VERSION);
+    await expect(installedVersion('@modelcontextprotocol/client')).resolves.toBe(AUDITED_SDK_VERSION);
+  });
+
+  it('exposes only task wire vocabulary, not a task runtime', () => {
+    expect(taskNamedExports(serverModule)).toEqual(AUDITED_TASK_EXPORTS);
+    expect(taskNamedExports(clientModule)).toEqual(AUDITED_TASK_EXPORTS);
+    const server = new ProtocolMcpServer({ name: 'probe', version: '0.0.0' });
+    expect('experimental' in server).toBe(false);
+    expect('experimental' in server.server).toBe(false);
+  });
+
+  it('keeps task methods off the typed request surface', async () => {
+    const { client } = await connectTaskNegotiatingClient();
+    for (const method of TASK_METHODS) {
+      // The audited client rejects synchronously; a later SDK might reject the
+      // returned promise instead, so both shapes are funnelled through one promise.
+      await expect(Promise.resolve().then(() => client.request({ method, params: { taskId: 'never-created' } } as never)))
+        .rejects.toThrow(/not a spec method/u);
+    }
+    // The compile-time half of this sentinel (a `@ts-expect-error` on the
+    // typed `setRequestHandler('tasks/get', …)` overload) lives in
+    // packages/agent-bundle/tests/projection/mcp-in-memory.test.ts, which
+    // `pnpm typecheck` covers; this package's tests are not type-checked.
+  });
+
+  it('never advertises tasks, even to a client that negotiated them', async () => {
+    const { client, server } = await connectTaskNegotiatingClient();
+    expect(server.server.getClientCapabilities()).toMatchObject({ tasks: { requests: { tools: { call: {} } } } });
+    expect(client.getServerCapabilities()).toBeDefined();
+    expect(Object.hasOwn(client.getServerCapabilities() ?? {}, 'tasks')).toBe(false);
+  });
+
+  it('processes a task-augmented tools/call as an ordinary request', async () => {
+    // 2025-11-25 Tasks: a receiver that does not declare the capability MUST
+    // process the request normally, ignoring task-augmentation metadata.
+    const { inject } = await connectTaskNegotiatingClient();
+    const response = await inject(101, 'tools/call', { arguments: {}, name: 'slow', task: { ttl: 60_000 } });
+    expect(response.error).toBeUndefined();
+    expect(response.result).toMatchObject({
+      content: [{ text: 'done', type: 'text' }],
+      structuredContent: { ok: true },
+    });
+    for (const key of ['task', 'taskId', 'status', 'createdAt', 'ttl', 'pollInterval']) {
+      expect(Object.hasOwn(response.result ?? {}, key)).toBe(false);
+    }
+  });
+
+  it('answers every task operation with JSON-RPC method-not-found', async () => {
+    const { inject } = await connectTaskNegotiatingClient();
+    for (const [index, method] of TASK_METHODS.entries()) {
+      const response = await inject(200 + index, method, { taskId: 'never-created' });
+      expect(response.result).toBeUndefined();
+      expect(response.error?.code).toBe(-32_601);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Issue #369 asked for task-augmented MCP tool calls (`CreateTaskResult` → `tasks/get` / `tasks/result`, `tasks/cancel` into the renderer `AbortSignal`) — the #96 acceptance remainder. The assessment lands on the honest-deferral branch: the installed SDK has no task runtime to build on, so this PR records the deferral precisely and makes it impossible to go stale silently, instead of hand-rolling the protocol outside the SDK's typed surface.

- **Spec + SDK audit**: conformance revision `2025-11-25`; generated servers use `@modelcontextprotocol/server@2.0.0` / `client@2.0.0` / `core@2.0.0`. The SDK declares task methods "2025-11-25 wire vocabulary with no SDK runtime" — `request()`, `setRequestHandler()`, `ctx.mcpReq.send()` exclude `tasks/*`; runtime exports are only `RELATED_TASK_META_KEY` and a `@deprecated` `isTaskAugmentedRequestParams`; no `TaskStore` / `experimental.tasks`. The `2026-07-28` revision moved tasks into the `io.modelcontextprotocol/tasks` extension (SEP-2663) and removed `tasks/result`. Upstream tracker: [typescript-sdk#2189](https://github.com/modelcontextprotocol/typescript-sdk/issues/2189) (+ [#2598](https://github.com/modelcontextprotocol/typescript-sdk/issues/2598), [#2637](https://github.com/modelcontextprotocol/typescript-sdk/issues/2637)).
- **Fail-closed behaviour, proven**: generated servers never advertise `tasks` (even to a client that negotiated it); a task-augmented `tools/call` is processed as an ordinary request with no task handle (the 2025-11-25 fallback MUST); `tasks/get|result|list|cancel` answer `-32601`. #175's progress/final contract is untouched.
- **Sentinels**: `packages/rsc-runtime/tests/mcp-tasks-deferral.test.ts` pins the audited SDK version and asserts each fact against the installed packages; `mcp-in-memory.test.ts` carries the two behavioural proofs on the generated server plus a `@ts-expect-error` on the typed `setRequestHandler('tasks/get', …)` overload (verified load-bearing: removing it fails `tsc`).
- **Docs**: new dated section in `docs/mcp-conformance.md` with the SDK pin, spec facts, upstream links, and the exact unblock condition; `docs/entry-conventions.md` stdio lifecycle shell; runtime README; changeset for `@agent-bundle/runtime`.

No production code changes. Closes nothing — #369 stays open with the unblock condition.

## Evidence

- `pnpm typecheck` ✅ (and negative check: dropping the `@ts-expect-error` yields `TS2345: '"tasks/get"' is not assignable to parameter of type 'RequestMethod'`)
- `pnpm lint` ✅ 0 errors / 0 warnings
- `rstest packages/rsc-runtime/tests/mcp-tasks-deferral.test.ts` ✅ 6/6
- `pnpm test:projection` ✅ 65/65 (post-rebase)
- `pnpm test:unit` 2673 passed; 4 files failed on 5 s timeouts / 150 ms elapsed budgets under load ~120 (`event-ipc`, `mcp-probe-service`, `dispatcher`, `native-claude-contract`); first three pass in isolation, `native-claude-contract` still hits its 5 s cap in isolation on this loaded box — untouched by this PR, left to CI.
- `pnpm test:route-unit` 34 passed, 1 timeout (`lifecycle-replay`) → passes in isolation
- `pnpm build && pnpm test:integration:run` ✅ 938/938
- `pnpm test:mcp-conformance` ✅ (official runner, `2025-11-25`, no unexpected failures)

## Test plan

- [x] Sentinel test green against the installed SDK
- [x] Projection pool green
- [x] Conformance lane green
- [ ] CI green on this PR