### PR TITLE
chore(changesets): backfill changesets for merged PRs that shipped without one

### DIFF
--- a/.changeset/backfill-pr-118.md
+++ b/.changeset/backfill-pr-118.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Make Workbench MCP App teardown and project reloads robust under load: the MCP App frame relay default `closeTimeoutMs` is now 5s and the server graceful-close receipt window 35s, so a healthy graceful close is no longer superseded by the force-close timer; project preparation re-reads a config that changed between load and snapshot instead of serving a stale model under a fresh revision; script playground readiness is sequenced through the process tree and PID files are published atomically. (#118)

--- a/.changeset/backfill-pr-118.md
+++ b/.changeset/backfill-pr-118.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Make Workbench MCP App teardown and project reloads robust under load: the MCP App frame relay default `closeTimeoutMs` is now 5s and the server graceful-close receipt window 35s, so a healthy graceful close is no longer superseded by the force-close timer; project preparation re-reads a config that changed between load and snapshot instead of serving a stale model under a fresh revision; script playground readiness is sequenced through the process tree and PID files are published atomically. (#118)
+Make Workbench MCP App teardown and project reloads robust under load: raise the MCP App frame relay default `closeTimeoutMs` to 5s and the dev-server graceful-close receipt window to 35s so a healthy graceful close is no longer superseded by the force-close timer, and re-read a project config that changed between load and snapshot instead of serving a stale model under a fresh revision. (#118)

--- a/.changeset/backfill-pr-163.md
+++ b/.changeset/backfill-pr-163.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-MCP sessions re-check the caller abort signal after the asynchronous epoch availability probe and before tool dispatch, so a request cancelled while the probe is pending no longer dispatches the tool. (#163)
+Stop dispatching an MCP tool call whose request was cancelled while the epoch availability probe was pending: the dev-server MCP session re-checks the caller abort signal after the probe and before dispatch. (#163)

--- a/.changeset/backfill-pr-163.md
+++ b/.changeset/backfill-pr-163.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+MCP sessions re-check the caller abort signal after the asynchronous epoch availability probe and before tool dispatch, so a request cancelled while the probe is pending no longer dispatches the tool. (#163)

--- a/.changeset/backfill-pr-164.md
+++ b/.changeset/backfill-pr-164.md
@@ -1,6 +1,5 @@
 ---
-"agent-bundle": patch
 "@agent-bundle/runtime": patch
 ---
 
-Close an abort race in the Effect boundary bridges of both packages: `interruptWhenAborted` now re-checks `signal.aborted` after subscribing, so a signal aborted between composition and start interrupts the effect instead of hanging. (#164)
+Interrupt `projectMcpRenderStream` promptly when its `signal` was already aborted between composition and start: the Effect boundary bridge re-checks `signal.aborted` after subscribing, so a pre-aborted projection rejects instead of hanging. (#164)

--- a/.changeset/backfill-pr-164.md
+++ b/.changeset/backfill-pr-164.md
@@ -1,0 +1,6 @@
+---
+"agent-bundle": patch
+"@agent-bundle/runtime": patch
+---
+
+Close an abort race in the Effect boundary bridges of both packages: `interruptWhenAborted` now re-checks `signal.aborted` after subscribing, so a signal aborted between composition and start interrupts the effect instead of hanging. (#164)

--- a/.changeset/backfill-pr-165.md
+++ b/.changeset/backfill-pr-165.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Static route config extraction rejects non-finite numeric literals such as `1e999` with the `AB4806` dynamic-config diagnostic instead of digesting them as `null`, preserves a literal `__proto__` key as an own property, and route discovery now includes `.jsx` script modules, which were previously skipped silently. (#165)

--- a/.changeset/backfill-pr-165.md
+++ b/.changeset/backfill-pr-165.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Static route config extraction rejects non-finite numeric literals such as `1e999` with the `AB4806` dynamic-config diagnostic instead of digesting them as `null`, preserves a literal `__proto__` key as an own property, and route discovery now includes `.jsx` script modules, which were previously skipped silently. (#165)
+Reject non-finite numeric literals such as `1e999` in a route `export const config` with the `AB4806` dynamic-config diagnostic instead of digesting them as `null`, keep a literal `__proto__` config key as an own property, and discover `.jsx` modules under `src/scripts/` as script routes instead of skipping them silently. (#165)

--- a/.changeset/backfill-pr-168.md
+++ b/.changeset/backfill-pr-168.md
@@ -1,0 +1,6 @@
+---
+"agent-bundle": patch
+"create-agent-bundle": patch
+---
+
+Generated route declarations exclude schema-less script routes, and `create-agent-bundle` requires coherent `agent-bundle` / `@agent-bundle/runtime` identities when scaffolding from local tarballs. (#168)

--- a/.changeset/backfill-pr-168.md
+++ b/.changeset/backfill-pr-168.md
@@ -3,4 +3,4 @@
 "create-agent-bundle": patch
 ---
 
-Generated route declarations exclude schema-less script routes, and `create-agent-bundle` requires coherent `agent-bundle` / `@agent-bundle/runtime` identities when scaffolding from local tarballs. (#168)
+Omit schema-less script routes from the generated route declarations, and make `create-agent-bundle` refuse local-tarball scaffolds whose `agent-bundle` and `@agent-bundle/runtime` identities disagree. (#168)

--- a/.changeset/backfill-pr-183.md
+++ b/.changeset/backfill-pr-183.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+The published `agent-bundle` manifest no longer carries a `workspace:*` devDependency on `@agent-bundle/runtime`, which npm refuses to install; the optional peer is satisfied through a workspace override instead. (#183)

--- a/.changeset/backfill-pr-183.md
+++ b/.changeset/backfill-pr-183.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-The published `agent-bundle` manifest no longer carries a `workspace:*` devDependency on `@agent-bundle/runtime`, which npm refuses to install; the optional peer is satisfied through a workspace override instead. (#183)
+Ship the `agent-bundle` package manifest without a `workspace:*` devDependency on `@agent-bundle/runtime`, which npm refused to install; the optional peer is satisfied through a workspace override instead. (#183)

--- a/.changeset/backfill-pr-2.md
+++ b/.changeset/backfill-pr-2.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Add the `agent-bundle` compiler, the `agent-bundle` CLI, and the developer Workbench: compile a typed Agent Bundle configuration into portable, Codex, and Claude Code plugin artifacts and iterate on them from a local dev server. (#2)

--- a/.changeset/backfill-pr-208.md
+++ b/.changeset/backfill-pr-208.md
@@ -2,4 +2,4 @@
 "@agent-bundle/runtime": patch
 ---
 
-The sqlite state driver closes its connection through an infallible finalizer again: a close failure on the success path surfaces as a defect instead of breaking the declaration build, and on the failing path the original failure stays the reported cause. (#208)
+Close the `@agent-bundle/runtime/state/sqlite` connection through an infallible finalizer again: a close failure on the success path surfaces as a defect, and on the failing path the original failure stays the reported cause. (#208)

--- a/.changeset/backfill-pr-208.md
+++ b/.changeset/backfill-pr-208.md
@@ -1,0 +1,5 @@
+---
+"@agent-bundle/runtime": patch
+---
+
+The sqlite state driver closes its connection through an infallible finalizer again: a close failure on the success path surfaces as a defect instead of breaking the declaration build, and on the failing path the original failure stays the reported cause. (#208)

--- a/.changeset/backfill-pr-303.md
+++ b/.changeset/backfill-pr-303.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Bump the published `open` dependency from 11.0.1 to 11.0.2. (#303)
+Open the Workbench from `agent-bundle dev --open` through `open` 11.0.2 instead of 11.0.1; `agent-bundle` installs pull the updated dependency. (#303)

--- a/.changeset/backfill-pr-303.md
+++ b/.changeset/backfill-pr-303.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Bump the published `open` dependency from 11.0.1 to 11.0.2. (#303)

--- a/.changeset/backfill-pr-304.md
+++ b/.changeset/backfill-pr-304.md
@@ -2,4 +2,4 @@
 "@agent-bundle/runtime": patch
 ---
 
-Bump the published `zod` dependency from 4.4.3 to 4.5.4. (#304)
+Validate runtime operation inputs, state conformance, and the notice inbox route with `zod` 4.5.4 instead of 4.4.3 (fixes an upstream default-factory misfire during cycle walks); `@agent-bundle/runtime` installs pull the updated dependency. (#304)

--- a/.changeset/backfill-pr-304.md
+++ b/.changeset/backfill-pr-304.md
@@ -1,0 +1,5 @@
+---
+"@agent-bundle/runtime": patch
+---
+
+Bump the published `zod` dependency from 4.4.3 to 4.5.4. (#304)

--- a/.changeset/backfill-pr-305.md
+++ b/.changeset/backfill-pr-305.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Bump the published `ignore` dependency from 7.0.6 to 7.0.7. (#305)
+Evaluate `ignore` patterns for config and skill file discovery with `ignore` 7.0.7 instead of 7.0.6; `agent-bundle` installs pull the updated dependency. (#305)

--- a/.changeset/backfill-pr-305.md
+++ b/.changeset/backfill-pr-305.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Bump the published `ignore` dependency from 7.0.6 to 7.0.7. (#305)

--- a/.changeset/backfill-pr-348.md
+++ b/.changeset/backfill-pr-348.md
@@ -4,4 +4,4 @@
 "create-agent-bundle": patch
 ---
 
-Consolidate duplicated guards and helpers onto canonical modules, with hot-path fixes riding along: route-graph module text is read once per build instead of once per surface, the sqlite state driver caches prepared statements, directory walks run with bounded concurrency, and the MCP App consent-capability vocabulary now lives in a browser-safe module so the Workbench bundle no longer pulls in `node:*` imports. (#348)
+Speed up `agent-bundle build` and the dev server by reading each route module once per build instead of once per surface, caching prepared statements in the `@agent-bundle/runtime/state/sqlite` driver, and bounding directory-walk concurrency; keep `node:*` imports out of the Workbench browser bundle by moving the MCP App consent-capability vocabulary to a browser-safe module. `create-agent-bundle` shares the same corrected helpers. (#348)

--- a/.changeset/backfill-pr-348.md
+++ b/.changeset/backfill-pr-348.md
@@ -1,0 +1,7 @@
+---
+"agent-bundle": patch
+"@agent-bundle/runtime": patch
+"create-agent-bundle": patch
+---
+
+Consolidate duplicated guards and helpers onto canonical modules, with hot-path fixes riding along: route-graph module text is read once per build instead of once per surface, the sqlite state driver caches prepared statements, directory walks run with bounded concurrency, and the MCP App consent-capability vocabulary now lives in a browser-safe module so the Workbench bundle no longer pulls in `node:*` imports. (#348)

--- a/.changeset/backfill-pr-348.md
+++ b/.changeset/backfill-pr-348.md
@@ -1,7 +1,6 @@
 ---
 "agent-bundle": patch
 "@agent-bundle/runtime": patch
-"create-agent-bundle": patch
 ---
 
-Speed up `agent-bundle build` and the dev server by reading each route module once per build instead of once per surface, caching prepared statements in the `@agent-bundle/runtime/state/sqlite` driver, and bounding directory-walk concurrency; keep `node:*` imports out of the Workbench browser bundle by moving the MCP App consent-capability vocabulary to a browser-safe module. `create-agent-bundle` shares the same corrected helpers. (#348)
+Speed up `agent-bundle build` and the dev server by reading each route module once per build instead of once per surface, caching prepared statements in the `@agent-bundle/runtime/state/sqlite` driver, and bounding directory-walk concurrency; keep `node:*` imports out of the Workbench browser bundle by moving the MCP App consent-capability vocabulary to a browser-safe module. (#348)

--- a/.changeset/backfill-pr-7.md
+++ b/.changeset/backfill-pr-7.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Bump the published `@rslint/core` dependency from 0.8.0 to 0.8.1. (#7)
+Run the Workbench lint diagnostics service (`dev/diagnostic-service`) on `@rslint/core` 0.8.1 instead of 0.8.0; `agent-bundle` installs pull the updated dependency. (#7)

--- a/.changeset/backfill-pr-7.md
+++ b/.changeset/backfill-pr-7.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Bump the published `@rslint/core` dependency from 0.8.0 to 0.8.1. (#7)


### PR DESCRIPTION
## Summary

Follow-up to #403. Every merged PR was enumerated (`gh pr list --state merged --limit 400`, 299 PRs; 212 touched a publishable package) and checked for (a) changes to a publishable package's non-`tests/**` files and (b) a `.changeset/*.md` in its diff. Thirteen PRs had (a) without (b) and get a `patch` changeset (`.changeset/backfill-pr-<N>.md`, summary in the documented style, trailing `(#N)`); none was breaking.

| PR | Package(s) | Bump |
| --- | --- | --- |
| #2 | agent-bundle | patch |
| #7 | agent-bundle (`@rslint/core` runtime dep) | patch |
| #118 | agent-bundle | patch |
| #163 | agent-bundle | patch |
| #164 | agent-bundle, @agent-bundle/runtime | patch |
| #165 | agent-bundle | patch |
| #168 | agent-bundle, create-agent-bundle | patch |
| #183 | agent-bundle | patch |
| #208 | @agent-bundle/runtime | patch |
| #303 | agent-bundle (`open` runtime dep) | patch |
| #304 | @agent-bundle/runtime (`zod` runtime dep; devDependency only in agent-bundle) | patch |
| #305 | agent-bundle (`ignore` runtime dep) | patch |
| #348 | agent-bundle, @agent-bundle/runtime, create-agent-bundle | patch |

Deliberately **not** backfilled (no consumer-observable change, per `.changeset/README.md`; would carry `skip-changeset` today): #22, #27, #69 (package README only), #40 (`publishConfig.provenance` + README), #345 (build-time publint plugin in `rslib.config.ts`), #14, #18, #238 (refactors declared "no behavior change" in their PR bodies).

## Evidence

- `pnpm changeset status --verbose`: all 13 parse; resulting pending bumps are `agent-bundle` 0.1.0 → 0.2.0, `@agent-bundle/runtime` 0.0.0 → 0.1.0, `create-agent-bundle` 0.0.0 → 0.1.0 (the minors come from pre-existing changesets; every backfill entry is a patch).
- `pnpm lint:package`: publint "All good!" for all three packages.
- `pnpm pack:dry-run`: exit 0 (`agent-bundle-0.1.0.tgz`).

## Test plan

- [ ] `Changeset present` passes (changesets only; no publishable source changed)
- [ ] CI green, Codex review threads addressed
- [ ] After merge, the Version Packages PR picks up the 13 entries