### PR TITLE
feat(codex): record plugins-overview parts (MCP UI, browser extensions, scheduled tasks) as dated capability rows (#188)

### DIFF
--- a/.changeset/codex-overview-surfaces.md
+++ b/.changeset/codex-overview-surfaces.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': minor
+---
+
+Record the Codex plugins-overview parts as dated four-state rows (`plugin.overviewSurfaces`): optional MCP UI is `degraded` (compiled `ui://` MCP Apps resources are served per the open standard ChatGPT renders; Codex CLI 0.147.0 renders no components and tools stay usable without UI), and browser extensions and scheduled task templates are `unavailable` because no package or manifest contract publishes an authoring field for them. The Codex adapter exposes `mcpUi`, `browserExtensions`, and `scheduledTaskTemplates` capabilities and the unified plugin adapter intersects them to `unavailable`; Codex adapter revision `1.9.0`, unified plugin adapter revision `1.24.0`.

--- a/.changeset/codex-overview-surfaces.md
+++ b/.changeset/codex-overview-surfaces.md
@@ -1,5 +1,5 @@
 ---
-'agent-bundle': minor
+'agent-bundle': patch
 ---
 
-Record the Codex plugins-overview parts as dated four-state rows (`plugin.overviewSurfaces`): optional MCP UI is `degraded` (compiled `ui://` MCP Apps resources are served per the open standard ChatGPT renders; Codex CLI 0.147.0 renders no components and tools stay usable without UI), and browser extensions and scheduled task templates are `unavailable` because no package or manifest contract publishes an authoring field for them. The Codex adapter exposes `mcpUi`, `browserExtensions`, and `scheduledTaskTemplates` capabilities and the unified plugin adapter intersects them to `unavailable`; Codex adapter revision `1.9.0`, unified plugin adapter revision `1.24.0`.
+Publish dated four-state Codex capability rows for the plugins-overview parts under `plugin.overviewSurfaces`, exposed on the `codex` adapter as `mcpUi`, `browserExtensions`, and `scheduledTaskTemplates` and intersected to `unavailable` by the unified `plugin` adapter: optional MCP UI is `degraded` because the compiled MCP server serves `ui://` MCP Apps resources that Codex CLI 0.147.0 does not render, and browser extensions and scheduled task templates are `unavailable` because no plugin manifest or package contract publishes an authoring field for them (#415)

--- a/packages/agent-bundle/README.md
+++ b/packages/agent-bundle/README.md
@@ -74,7 +74,12 @@ npm `version` must be a semver version, range, or dist-tag, and Git `ref` must s
 enable state, `features.plugins` / `features.hooks`, inline `[hooks]` TOML, `requirements.toml`
 managed hooks, `allow_managed_hooks_only`, and `restrict_to_allowed_sources` are host- or
 admin-owned and are recorded in `codex-0.147.0.json` (`distribution`) with dated evidence instead of
-being claimed.
+being claimed. The overview-level plugin parts get the same treatment (`plugin.overviewSurfaces`):
+optional MCP UI is `degraded` (the compiled MCP server serves `ui://` resources per the open MCP
+Apps standard that ChatGPT renders, while Codex CLI renders no components and every tool stays
+usable without UI), and browser extensions and scheduled task templates are `unavailable`
+because no package or manifest contract publishes an authoring field for them, so nothing is
+inferred.
 
 agent-bundle also owns the npm-facing package build: `bin` entries become self-executing
 `dist/bin/<name>.js` bundles (shebang, executable bit, generated `main(argv)` envelope) and the

--- a/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
+++ b/packages/agent-bundle/src/adapters/capabilities/codex-0.147.0.json
@@ -416,6 +416,33 @@
         "state": "supported"
       }
     },
+    "overviewSurfaces": {
+      "mcpUi": {
+        "evidence": [
+          "retrieved 2026-09-03: https://learn.chatgpt.com/docs/plugins lists connectors that 'can optionally include custom UI' among plugin parts and points builders at the optional UI guide when a plugin needs custom UI.",
+          "retrieved 2026-09-03: https://developers.openai.com/plugins/build/chatgpt-ui states that custom UI is optional, that ChatGPT implements the open MCP Apps standard (`_meta.ui.resourceUri`, the `ui/*` JSON-RPC bridge over postMessage), that components run inside an iframe in ChatGPT, and that tools must stay useful without a component 'so ChatGPT and Codex can complete the workflow without UI'.",
+          "observed 2026-09-03: codex-cli 0.147.0 is a terminal client with no component-rendering surface, and the pinned .codex-plugin/plugin.json contract publishes no UI field; the compiled MCP server serves `ui://` resources with `_meta` passthrough per the open MCP Apps standard regardless of host."
+        ],
+        "reason": "Agent Bundle compiles MCP Apps as `ui://` resources with `_meta` passthrough served by the compiled MCP server, which is the open MCP Apps contract that ChatGPT renders; Codex CLI 0.147.0 renders no components, so the emitted UI is inert there and every tool remains usable without it. Rendering is a ChatGPT host surface, not a Codex plugin artifact.",
+        "state": "degraded"
+      },
+      "browserExtensions": {
+        "evidence": [
+          "retrieved 2026-09-03: https://learn.chatgpt.com/docs/plugins lists 'Browser extensions: browser capabilities that a plugin needs for its workflow' among the parts a plugin can contain.",
+          "retrieved 2026-09-03: https://learn.chatgpt.com/docs/build-plugins and https://developers.openai.com/plugins/build/plugins describe an installable plugin as skills, an MCP server, or both, and publish no browser-extension authoring field; the pinned plugin.schema.json is closed to name, version, description, author, homepage, repository, license, keywords, interface, skills, mcpServers, hooks, and apps."
+        ],
+        "reason": "Browser extensions are host-managed plugin parts with no schema-backed authoring field in the pinned .codex-plugin/plugin.json contract; the compiler infers nothing and the closed manifest schema rejects any authored field until a package contract publishes one.",
+        "state": "unavailable"
+      },
+      "scheduledTaskTemplates": {
+        "evidence": [
+          "retrieved 2026-09-03: https://learn.chatgpt.com/docs/plugins lists 'Scheduled task templates: reusable starting points for recurring tasks where scheduled tasks are available' among the parts a plugin can contain.",
+          "retrieved 2026-09-03: https://learn.chatgpt.com/docs/build-plugins and https://developers.openai.com/plugins/build/plugins publish no scheduled-task authoring field, and the pinned plugin.schema.json is closed to the documented manifest fields."
+        ],
+        "reason": "Scheduled task templates are host-managed plugin parts with no schema-backed authoring field in the pinned .codex-plugin/plugin.json contract; the compiler infers nothing and the closed manifest schema rejects any authored field until a package contract publishes one.",
+        "state": "unavailable"
+      }
+    },
     "hookEnvironment": {
       "claudePluginData": {
         "evidence": [

--- a/packages/agent-bundle/src/adapters/codex.ts
+++ b/packages/agent-bundle/src/adapters/codex.ts
@@ -175,7 +175,7 @@ const hookContract = Object.freeze({
   wrapperSource: (entry) => nativeHookWrapperSource(entry, 'Codex'),
 } satisfies TargetHookContract);
 const metadata = Object.freeze({
-  adapterRevision: '1.8.0',
+  adapterRevision: '1.9.0',
   observedVersion: capabilityTable.observedCliVersion,
   schemas: schemaDescriptorsFrom(schemaProvenance, schemaProvenance.observedCliVersion),
 });
@@ -197,6 +197,7 @@ const tableCapability = (row: { readonly reason?: string; readonly state: string
 
 const hookContractTable = capabilityTable.hooks.contract;
 const distributionTable = capabilityTable.distribution;
+const overviewSurfacesTable = capabilityTable.plugin.overviewSurfaces;
 const codexReleaseHookEvents: readonly string[] = capabilityTable.hooks.releaseEvents;
 const codexHookRules = Object.freeze({
   additionalContextEvents: hookContractTable.additionalContextLimit.additionalContextEvents as readonly string[],
@@ -1326,6 +1327,9 @@ export const codexAdapter: TargetAdapter = Object.freeze({
     repoMarketplaceDiscovery: tableCapability(distributionTable.repoMarketplaceDiscovery),
     restrictToAllowedSources: tableCapability(distributionTable.restrictToAllowedSources),
     workspacePublishing: tableCapability(distributionTable.workspacePublishing),
+    browserExtensions: tableCapability(overviewSurfacesTable.browserExtensions),
+    mcpUi: tableCapability(overviewSurfacesTable.mcpUi),
+    scheduledTaskTemplates: tableCapability(overviewSurfacesTable.scheduledTaskTemplates),
     hooks: supportedCapability(evidence),
     hookAdditionalContextLimit: tableCapability(hookContractTable.additionalContextLimit),
     hookAsyncCommands: tableCapability(hookContractTable.asyncCommandHooks),

--- a/packages/agent-bundle/src/adapters/plugin.ts
+++ b/packages/agent-bundle/src/adapters/plugin.ts
@@ -132,6 +132,9 @@ const codexDistributionCapabilities = [
   'restrictToAllowedSources',
   'workspacePublishing',
 ] as const;
+const overviewSurfacesUnifiedReason =
+  'The Codex plugins overview names optional MCP UI, browser extensions, and scheduled task templates as plugin parts, but the pinned Claude and Cursor plugin contracts publish no shared field for any of them.';
+const codexOverviewSurfaceCapabilities = ['browserExtensions', 'mcpUi', 'scheduledTaskTemplates'] as const;
 const codexHookContractCapabilities = [
   'hookAdditionalContextLimit',
   'hookAsyncCommands',
@@ -228,7 +231,7 @@ const artifactValidation = deepFreeze({
 });
 
 const metadata = Object.freeze({
-  adapterRevision: '1.23.0',
+  adapterRevision: '1.24.0',
   observedVersion: `${claudeAdapter.metadata.observedVersion}+${codexAdapter.metadata.observedVersion}+${cursorAdapter.metadata.observedVersion}`,
   // Metadata schemas must exactly match the validation contract: each host's
   // documents, with one shared Claude-format hook schema (the pinned Codex
@@ -634,6 +637,13 @@ const codexHookContractUnifiedCapabilities = Object.freeze(Object.fromEntries([
     intersectCapabilityStates(
       codexAdapter.capabilities[capability]!,
       unavailableCapability(distributionUnifiedReason),
+    ),
+  ]),
+  ...codexOverviewSurfaceCapabilities.map((capability) => [
+    capability,
+    intersectCapabilityStates(
+      codexAdapter.capabilities[capability]!,
+      unavailableCapability(overviewSurfacesUnifiedReason),
     ),
   ]),
 ]));

--- a/packages/agent-bundle/tests/adapter-metadata.test.ts
+++ b/packages/agent-bundle/tests/adapter-metadata.test.ts
@@ -68,7 +68,7 @@ it('records exact immutable metadata for every built-in target', () => {
     ],
   });
   expect(registryMetadata(registry, 'codex')).toEqual({
-    adapterRevision: '1.8.0',
+    adapterRevision: '1.9.0',
     observedVersion: '0.147.0',
     schemas: [
       {
@@ -170,7 +170,7 @@ it('records exact immutable metadata for every built-in target', () => {
       },
     ],
   });
-  expect(registryMetadata(registry, 'plugin').adapterRevision).toBe('1.23.0');
+  expect(registryMetadata(registry, 'plugin').adapterRevision).toBe('1.24.0');
 });
 
 it('records observed capability versions and rehashes schema snapshots against pinned provenance', async () => {

--- a/packages/agent-bundle/tests/codex-distribution.test.ts
+++ b/packages/agent-bundle/tests/codex-distribution.test.ts
@@ -338,6 +338,38 @@ it.each([
   expect(rejected.document).toBeUndefined();
 });
 
+it('records the overview-level plugin parts (optional MCP UI, browser extensions, scheduled task templates) as dated rows', () => {
+  const registry = createDefaultRegistry();
+  const unified = registry.get('plugin');
+  const table = codexCapabilityTable.plugin.overviewSurfaces as Readonly<Record<string, {
+    readonly evidence: readonly string[];
+    readonly reason: string;
+    readonly state: string;
+  }>>;
+  const expected = { browserExtensions: 'unavailable', mcpUi: 'degraded', scheduledTaskTemplates: 'unavailable' } as const;
+
+  expect(Object.keys(table).sort()).toEqual(Object.keys(expected).sort());
+  for (const [capability, expectedState] of Object.entries(expected)) {
+    const row = table[capability]!;
+    expect(row.state, capability).toBe(expectedState);
+    expect(row.evidence.length, capability).toBeGreaterThan(1);
+    expect(row.evidence.every((line) => /^(?:retrieved|observed) 2026-09-03:/u.test(line)), capability).toBe(true);
+    expect(row.reason, capability).toMatch(/\S/u);
+    expect(codexAdapter.capabilities[capability]).toMatchObject({
+      reason: row.reason,
+      state: expectedState,
+      ...(expectedState === 'degraded' ? { evidence: { observedVersion: '0.147.0', target: 'codex' } } : {}),
+    });
+    expect(registry.supports('codex', capability)).toBe(false);
+    expect(unified.capabilities[capability]).toMatchObject({ state: 'unavailable' });
+    expect(registry.supports('plugin', capability)).toBe(false);
+  }
+  // No authoring field is inferred: the closed manifest schema rejects any attempt.
+  expect(table.mcpUi!.evidence.some((line) => line.includes('_meta.ui.resourceUri'))).toBe(true);
+  expect(table.browserExtensions!.reason).toContain('no schema-backed authoring field');
+  expect(table.scheduledTaskTemplates!.reason).toContain('no schema-backed authoring field');
+});
+
 it('keeps NOT_AVAILABLE documented in the pinned schema but refuses it for the self-installing artifact', () => {
   // Live codex-cli 0.147.0 registers a NOT_AVAILABLE marketplace entry and then refuses
   // `codex plugin add <plugin>@<marketplace>`, the exact command INSTALL.md and installBundle() run.


### PR DESCRIPTION
## Summary
- Adds `plugin.overviewSurfaces` to the Codex 0.147.0 capability table with dated, four-state rows for the three plugin parts the public Codex plugins overview names that had no row yet:
  - `mcpUi` — `degraded`: the compiled MCP server serves `ui://` MCP Apps resources per the open standard that ChatGPT renders; Codex CLI 0.147.0 renders no components, and tools stay usable without UI.
  - `browserExtensions` — `unavailable`: no package or manifest contract publishes an authoring field.
  - `scheduledTaskTemplates` — `unavailable`: same reason.
- The Codex adapter exposes the three keys as capabilities; the unified `plugin` adapter intersects them to `unavailable` with a dated reason (the Claude and Cursor contracts publish no shared field).
- Bumps the Codex adapter revision `1.8.0 -> 1.9.0` (also covering the #392 marketplace-policy diagnostics) and the unified plugin adapter `1.23.0 -> 1.24.0`; README documents the rows; changeset added.

Closes the last open parity slice for #188; the closing evidence table follows on the issue.

## Test plan
- [x] `pnpm build && pnpm typecheck && pnpm lint`
- [x] `adapter-metadata`, `codex-distribution` (new overview-surface assertions), `host-adapters`, `codex-plugin-validation` unit files pass
- [x] Full `pnpm test:unit`: 2753 pass; the 4 load-induced timeouts (`inspect-state`, `mcp-probe-service`, `native-claude-contract`, `rsc-runtime/dispatcher`) pass on isolated rerun
- [ ] CI green and Codex review threads addressed before merge