### PR TITLE
fix(tests): isolate native Claude home, settle IPC contenders, select pack entries by name

### DIFF
--- a/.changeset/pack-entry-by-name.md
+++ b/.changeset/pack-entry-by-name.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Select the intended `npm pack --json` entry by package name in `packOutputFromJson`, `scripts/run-packed-tests.mjs`, the release audit, and the packed test harnesses, so workspace-aware pack output that lists sibling packages no longer breaks `test:packed`, `test:packed:native`, or `audit-packed-release` (#PR)
+Select the intended `npm pack --json` entry by package name in `packOutputFromJson`, `scripts/run-packed-tests.mjs`, the release audit, and the packed test harnesses, so workspace-aware pack output that lists sibling packages no longer breaks `test:packed`, `test:packed:native`, or `audit-packed-release` (#432)

--- a/.changeset/pack-entry-by-name.md
+++ b/.changeset/pack-entry-by-name.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Select the intended `npm pack --json` entry by package name in `packOutputFromJson`, `scripts/run-packed-tests.mjs`, the release audit, and the packed test harnesses, so workspace-aware pack output that lists sibling packages no longer breaks `test:packed`, `test:packed:native`, or `audit-packed-release` (#PR)

--- a/packages/agent-bundle/src/build/pack-inventory.ts
+++ b/packages/agent-bundle/src/build/pack-inventory.ts
@@ -22,20 +22,45 @@ export interface PackOutput {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-export const packOutputFromJson = (stdout: string): PackOutput => {
+const packEntryName = (entry: unknown, key: string | undefined): string | undefined =>
+  isRecord(entry) && typeof entry.name === 'string' ? entry.name : key;
+
+/**
+ * Parses `npm pack --json` output into one pack entry. npm emits either an
+ * array or a package-keyed object depending on version; both are accepted.
+ *
+ * When `packageName` is given, the entry is selected by package name rather
+ * than by position, so a pack that also lists sibling workspace packages
+ * still resolves the intended tarball deterministically. Without it, the
+ * output must contain exactly one entry.
+ */
+export const packOutputFromJson = (stdout: string, packageName?: string): PackOutput => {
   const parsed: unknown = JSON.parse(stdout);
-  const entries = Array.isArray(parsed)
-    ? parsed
+  const entries: readonly (readonly [string | undefined, unknown])[] | undefined = Array.isArray(parsed)
+    ? parsed.map((entry: unknown) => [undefined, entry] as const)
     : isRecord(parsed)
-      ? Object.values(parsed)
+      ? Object.entries(parsed)
       : undefined;
   if (entries === undefined) {
     throw new TypeError('npm pack --json returned neither an array nor a package-keyed object.');
   }
-  if (entries.length !== 1) {
-    throw new TypeError(`npm pack --json returned ${String(entries.length)} entries; expected exactly one.`);
+  let entry: unknown;
+  if (packageName === undefined) {
+    if (entries.length !== 1) {
+      throw new TypeError(`npm pack --json returned ${String(entries.length)} entries; expected exactly one.`);
+    }
+    entry = entries[0]?.[1];
+  } else {
+    const named = entries.filter(([key, candidate]) => packEntryName(candidate, key) === packageName);
+    if (named.length !== 1) {
+      const seen = entries.map(([key, candidate]) => packEntryName(candidate, key) ?? '<unnamed>');
+      throw new TypeError(
+        `npm pack --json returned ${String(named.length)} entries named ${JSON.stringify(packageName)}; `
+        + `expected exactly one (saw: ${seen.map((name) => JSON.stringify(name)).join(', ')}).`,
+      );
+    }
+    entry = named[0]?.[1];
   }
-  const [entry] = entries;
   if (!isRecord(entry) || typeof entry.filename !== 'string' || !Array.isArray(entry.files)) {
     throw new TypeError('npm pack --json returned an invalid pack entry; expected one object.');
   }

--- a/packages/agent-bundle/tests/cli.test.ts
+++ b/packages/agent-bundle/tests/cli.test.ts
@@ -130,7 +130,7 @@ const createPackedConsumer = async (): Promise<{ readonly cli: string; readonly 
   const { stdout } = await execFile(
     'npm', ['pack', '--json', '--pack-destination', root], { cwd: packageRoot },
   );
-  const packed = packOutputFromJson(stdout);
+  const packed = packOutputFromJson(stdout, 'agent-bundle');
   await writeFile(join(root, 'package.json'), '{"type":"module"}\n');
   await execFile(
     'npm', ['install', ...cachedNpmInstallArguments, join(root, packed.filename)],

--- a/packages/agent-bundle/tests/event-ipc.test.ts
+++ b/packages/agent-bundle/tests/event-ipc.test.ts
@@ -12,10 +12,27 @@ import {
   createEventRuntimeServer,
   createEventRuntimeServerForTest,
   eventRuntimeEndpoint,
+  type EventRuntimeServer,
   EventRuntimeTransportError,
   requestEventRuntime,
   requestEventRuntimeStatus,
 } from '../src/events/ipc.ts';
+
+type ContenderOutcome =
+  | Readonly<{ readonly server: EventRuntimeServer; readonly status: 'opened' }>
+  | Readonly<{ readonly error: unknown; readonly status: 'failed' }>;
+
+/**
+ * Attaches the settlement handler the moment a racing server is created. The
+ * losing contender rejects as soon as the winner listens, while the test only
+ * reaches its `await` after the winner has fully resolved; on a loaded machine
+ * that gap is wide enough for the rejection to surface as an unhandled
+ * file-level "already has a live server" failure.
+ */
+const settleContender = (server: Promise<EventRuntimeServer>): Promise<ContenderOutcome> => server.then(
+  (opened): ContenderOutcome => ({ server: opened, status: 'opened' }),
+  (error: unknown): ContenderOutcome => ({ error, status: 'failed' }),
+);
 
 interface EndpointClaimOwner {
   readonly linuxStartTime?: string;
@@ -331,7 +348,7 @@ it.live('does not unlink a concurrent winner after both servers probe a stale en
   let releaseSecond!: () => void;
   const secondProbed = new Promise<void>((resolve) => { markSecondProbed = resolve; });
   const secondCanContinue = new Promise<void>((resolve) => { releaseSecond = resolve; });
-  const secondServer = createEventRuntimeServerForTest({
+  const secondServer = settleContender(createEventRuntimeServerForTest({
     artifactEpoch: 'epoch-1',
     endpointId,
     handle: async () => ({ owner: 'second' }),
@@ -341,7 +358,7 @@ it.live('does not unlink a concurrent winner after both servers probe a stale en
       markSecondProbed();
       await secondCanContinue;
     },
-  });
+  }));
   yield* Effect.promise(() => secondProbed);
 
   releaseFirst();
@@ -352,13 +369,7 @@ it.live('does not unlink a concurrent winner after both servers probe a stale en
   expect(winner.endpoint).toBe(endpoint);
 
   releaseSecond();
-  const loser = yield* Effect.promise(async () => {
-    try {
-      return { server: await secondServer, status: 'opened' as const };
-    } catch (error) {
-      return { error, status: 'failed' as const };
-    }
-  });
+  const loser = yield* Effect.promise(() => secondServer);
   if (loser.status === 'opened') {
     yield* Effect.promise(() => loser.server.close());
     expect(loser.status).toBe('failed');
@@ -450,7 +461,7 @@ it.live('serializes concurrent reclamation before either contender can unlink a 
   const secondSnapshot = new Promise<void>((resolve) => { markSecondSnapshot = resolve; });
   const secondCanReclaim = new Promise<void>((resolve) => { releaseSecondSnapshot = resolve; });
   const secondReclamation = new Promise<void>((resolve) => { markSecondReclamation = resolve; });
-  const secondServer = createEventRuntimeServerForTest({
+  const secondServer = settleContender(createEventRuntimeServerForTest({
     artifactEpoch: 'epoch-1',
     endpointId,
     handle: async () => ({ owner: 'second' }),
@@ -464,7 +475,7 @@ it.live('serializes concurrent reclamation before either contender can unlink a 
       markSecondSnapshot();
       await secondCanReclaim;
     },
-  });
+  }));
 
   yield* Effect.promise(() => Promise.all([firstSnapshot, secondSnapshot]));
   expect(firstSnapshotIdentity).toEqual({ device: originalClaim.dev, inode: originalClaim.ino });
@@ -486,13 +497,7 @@ it.live('serializes concurrent reclamation before either contender can unlink a 
     Effect.promise(() => firstServer),
     (server) => Effect.promise(() => server.close()),
   );
-  const loser = yield* Effect.promise(async () => {
-    try {
-      return { server: await secondServer, status: 'opened' as const };
-    } catch (error) {
-      return { error, status: 'failed' as const };
-    }
-  });
+  const loser = yield* Effect.promise(() => secondServer);
   if (loser.status === 'opened') {
     yield* Effect.promise(() => loser.server.close());
     expect(loser.status).toBe('failed');
@@ -566,7 +571,7 @@ it.live('excludes a second orphan-claim remover while the recovery gate is held'
   const secondCanAttemptReclamation = new Promise<void>((resolve) => { releaseSecondSnapshot = resolve; });
   const secondReclamation = new Promise<void>((resolve) => { markSecondReclamation = resolve; });
   const secondCanRetry = new Promise<void>((resolve) => { releaseSecondReclamation = resolve; });
-  const secondServer = createEventRuntimeServerForTest({
+  const secondServer = settleContender(createEventRuntimeServerForTest({
     artifactEpoch: 'epoch-1',
     endpointId,
     handle: async () => ({ owner: 'second' }),
@@ -580,7 +585,7 @@ it.live('excludes a second orphan-claim remover while the recovery gate is held'
       markSecondSnapshot();
       await secondCanAttemptReclamation;
     },
-  });
+  }));
 
   yield* Effect.promise(() => Promise.all([firstSnapshot, secondSnapshot]));
   releaseFirstSnapshot();
@@ -604,13 +609,7 @@ it.live('excludes a second orphan-claim remover while the recovery gate is held'
     (server) => Effect.promise(() => server.close()),
   );
   releaseSecondReclamation();
-  const loser = yield* Effect.promise(async () => {
-    try {
-      return { server: await secondServer, status: 'opened' as const };
-    } catch (error) {
-      return { error, status: 'failed' as const };
-    }
-  });
+  const loser = yield* Effect.promise(() => secondServer);
   if (loser.status === 'opened') {
     yield* Effect.promise(() => loser.server.close());
     expect(loser.status).toBe('failed');

--- a/packages/agent-bundle/tests/native-claude-contract.test.ts
+++ b/packages/agent-bundle/tests/native-claude-contract.test.ts
@@ -11,6 +11,22 @@ const candidatePluginName = 'agent-bundle-native-smoke';
 const candidateSkillName = 'agent-bundle-native-smoke';
 const candidateSkillEventName = `${candidatePluginName}:${candidateSkillName}`;
 
+/**
+ * Every enabled `runNativeClaudeSmoke` digests the normal Claude home before
+ * and after the run. Without an injected `homeDirectory` (or
+ * `CLAUDE_CONFIG_DIR`) that is the developer's real `~/.claude`, which on a
+ * machine with the Claude CLI installed holds gigabytes of plugin caches and
+ * pushes a stubbed smoke past its 5 s budget. Each test gets an empty home.
+ */
+const withIsolatedHome = async <T>(run: (homeDirectory: string) => Promise<T>): Promise<T> => {
+  const homeDirectory = await mkdtemp(join(tmpdir(), 'agent-bundle-claude-contract-home-'));
+  try {
+    return await run(homeDirectory);
+  } finally {
+    await rm(homeDirectory, { force: true, recursive: true });
+  }
+};
+
 it('builds a subscription-authenticated Claude command with the explicit candidate plugin', async () => {
   const harness = await loadNativeClaudeContract();
   expect(harness).toBeDefined();
@@ -96,8 +112,7 @@ it('runs strict validation before the subscription-backed stream command and ret
   expect(harness).toBeDefined();
 
   const calls: unknown[] = [];
-  const homeDirectory = await mkdtemp(join(tmpdir(), 'agent-bundle-claude-contract-home-'));
-  const report = await harness!.runNativeClaudeSmoke({
+  const report = await withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
@@ -124,8 +139,7 @@ it('runs strict validation before the subscription-backed stream command and ret
           ].join('\n'),
         };
     },
-  });
-  await rm(homeDirectory, { force: true, recursive: true });
+  }));
 
   expect(report).toEqual({
     diagnostics: [],
@@ -347,19 +361,20 @@ it('reports an incompatible Claude version as a harness failure before candidate
   expect(harness).toBeDefined();
 
   const calls: unknown[] = [];
-  const report = await harness!.runNativeClaudeSmoke({
+  const report = await withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
     enabled: true,
     environment: {},
+    homeDirectory,
     pluginDirectory: '/candidate/plugin',
     prompt: 'irrelevant after the preflight failure',
     run: async (request: unknown) => {
       calls.push(request);
       return { exitCode: 0, stderr: '', stdout: '2.1.231 (Claude Code)\n' };
     },
-  });
+  }));
 
   expect(report).toEqual({
     diagnostics: [{
@@ -429,7 +444,7 @@ it('requires the signed-in subscription preflight, loaded candidate plugin, and 
   expect(harness).toBeDefined();
 
   const calls: unknown[] = [];
-  const report = await harness!.runNativeClaudeSmoke({
+  const report = await withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
@@ -441,6 +456,7 @@ it('requires the signed-in subscription preflight, loaded candidate plugin, and 
       CLAUDE_CODE_USE_BEDROCK: '1',
       PATH: '/usr/bin',
     },
+    homeDirectory,
     pluginDirectory: '/candidate/plugin',
     prompt: 'Use the candidate skill.',
     run: async (request: unknown) => {
@@ -461,7 +477,7 @@ it('requires the signed-in subscription preflight, loaded candidate plugin, and 
               ].join('\n'),
             };
     },
-  });
+  }));
 
   expect(report).toMatchObject({
     diagnostics: [],
@@ -501,12 +517,13 @@ it('fails closed when the candidate plugin, exact Skill event, or subscription a
   const harness = await loadNativeClaudeContract();
   expect(harness).toBeDefined();
 
-  const smokeWithExecution = async (execution: string) => harness!.runNativeClaudeSmoke({
+  const smokeWithExecution = async (execution: string) => withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
     enabled: true,
     environment: {},
+    homeDirectory,
     pluginDirectory: '/candidate/plugin',
     prompt: 'Use the candidate skill.',
     run: async (request: { readonly args: readonly string[] }) => {
@@ -517,7 +534,7 @@ it('fails closed when the candidate plugin, exact Skill event, or subscription a
       if (request.args[0] === 'plugin') return { exitCode: 0, stderr: '', stdout: 'Plugin is valid.\n' };
       return { exitCode: 0, stderr: '', stdout: execution };
     },
-  });
+  }));
 
   await expect(smokeWithExecution([
     '{"type":"system","plugins":[]}',
@@ -551,12 +568,13 @@ it('rejects an API-key or alternate-provider auth status before plugin validatio
   expect(harness).toBeDefined();
 
   const calls: unknown[] = [];
-  const report = await harness!.runNativeClaudeSmoke({
+  const report = await withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
     enabled: true,
     environment: {},
+    homeDirectory,
     pluginDirectory: '/candidate/plugin',
     prompt: 'irrelevant after authentication fails',
     run: async (request: unknown) => {
@@ -565,7 +583,7 @@ it('rejects an API-key or alternate-provider auth status before plugin validatio
         ? { exitCode: 0, stderr: '', stdout: '2.1.232 (Claude Code)\n' }
         : { exitCode: 0, stderr: '', stdout: '{"loggedIn":true,"authMethod":"api-key","subscriptionType":"pro"}\n' };
     },
-  });
+  }));
 
   expect(report).toMatchObject({
     diagnostics: [{ code: 'claude-native.auth.unsupported' }],
@@ -578,18 +596,19 @@ it('reports a signed-out Claude execution as a redacted harness failure', async 
   const harness = await loadNativeClaudeContract();
   expect(harness).toBeDefined();
 
-  const report = await harness!.runNativeClaudeSmoke({
+  const report = await withIsolatedHome((homeDirectory) => harness!.runNativeClaudeSmoke({
     candidatePluginName: 'agent-bundle-native-smoke',
     candidateSkillName: 'agent-bundle-native-smoke',
     cwd: '/fresh/fixture',
     enabled: true,
     environment: {},
+    homeDirectory,
     pluginDirectory: '/candidate/plugin',
     prompt: 'irrelevant after authentication fails',
     run: async (request: { readonly args: readonly string[] }) => request.args[0] === '--version'
       ? { exitCode: 0, stderr: '', stdout: '2.1.232 (Claude Code)\n' }
       : { exitCode: 0, stderr: '', stdout: '{"loggedIn":false}\n' },
-  });
+  }));
 
   expect(report).toMatchObject({
     diagnostics: [{

--- a/packages/agent-bundle/tests/packed-consumer.test.ts
+++ b/packages/agent-bundle/tests/packed-consumer.test.ts
@@ -92,7 +92,7 @@ it('uses only an installed tarball after source deletion', async () => {
       cwd: packedPackageRoot,
       env: installedEnvironment(),
     });
-    const tarball = join(consumerRoot, packOutputFromJson(packed).filename);
+    const tarball = join(consumerRoot, packOutputFromJson(packed, 'agent-bundle').filename);
     await cp(fixtureRoot, projectRoot, { recursive: true });
     const [sourceShellMode, sourcePythonMode] = await Promise.all([
       stat(join(projectRoot, 'src', 'shell.sh')).then((metadata) => metadata.mode & 0o777),

--- a/packages/agent-bundle/tests/prepack.test.ts
+++ b/packages/agent-bundle/tests/prepack.test.ts
@@ -72,6 +72,30 @@ it('parses npm 11 arrays and npm 12 package-keyed pack output', () => {
   expect(packOutputFromJson(JSON.stringify({ 'installer-fixture': entry }))).toEqual(entry);
 });
 
+it('selects the intended pack entry by package name when npm lists sibling workspace packages', () => {
+  const runtime = { filename: 'agent-bundle-runtime-0.1.0.tgz', files: [{ path: 'dist/runtime.js' }], name: '@agent-bundle/runtime' };
+  const bundle = { filename: 'agent-bundle-0.1.0.tgz', files: [{ path: 'dist/index.js' }], name: 'agent-bundle' };
+  const scaffolder = { filename: 'create-agent-bundle-0.1.0.tgz', files: [{ path: 'dist/cli.js' }], name: 'create-agent-bundle' };
+  const expected = { filename: bundle.filename, files: bundle.files };
+
+  expect(packOutputFromJson(JSON.stringify([runtime, bundle, scaffolder]), 'agent-bundle')).toEqual(expected);
+  expect(packOutputFromJson(JSON.stringify({
+    '@agent-bundle/runtime': runtime,
+    'agent-bundle': bundle,
+    'create-agent-bundle': scaffolder,
+  }), 'agent-bundle')).toEqual(expected);
+  // npm 12 keys the object by name even when entries omit `name`.
+  const { name: _name, ...unnamedBundle } = bundle;
+  expect(packOutputFromJson(JSON.stringify({ 'agent-bundle': unnamedBundle }), 'agent-bundle')).toEqual(expected);
+
+  expect(() => packOutputFromJson(JSON.stringify([runtime, bundle, scaffolder])))
+    .toThrow(/returned 3 entries; expected exactly one/u);
+  expect(() => packOutputFromJson(JSON.stringify([runtime, scaffolder]), 'agent-bundle'))
+    .toThrow(/0 entries named "agent-bundle".*"@agent-bundle\/runtime", "create-agent-bundle"/u);
+  expect(() => packOutputFromJson(JSON.stringify([bundle, bundle]), 'agent-bundle'))
+    .toThrow(/2 entries named "agent-bundle"/u);
+});
+
 it('prepack validates the complete dry-run inventory', async () => {
   expect(await diagnostics()).toEqual([]);
   expect(result.pack.files.map((file) => file.path)).toContain('dist/bin/installer-fixture.js');

--- a/packages/agent-bundle/tests/support/packed-native-smoke.ts
+++ b/packages/agent-bundle/tests/support/packed-native-smoke.ts
@@ -356,10 +356,12 @@ export const runPackedNativeSmoke = async (options: {
       cwd: packageRoot,
       environment,
     });
-    const packOutput = packOutputFromJson(packed.stdout);
     if (packed.exitCode !== 0) {
-      throw new Error('Packed native smoke could not create exactly one release tarball.');
+      throw new Error('Packed native smoke could not create the release tarball.');
     }
+    // Select the agent-bundle entry by name: a workspace-aware `npm pack --json`
+    // can list sibling packages, and index 0 is not necessarily this one.
+    const packOutput = packOutputFromJson(packed.stdout, 'agent-bundle');
     const installed = await runNodeEntrypoint(npmEntrypoint, [
       'install',
       '--omit=dev',

--- a/packages/agent-bundle/tests/support/shared-pack.ts
+++ b/packages/agent-bundle/tests/support/shared-pack.ts
@@ -18,12 +18,19 @@ export { packOutputFromJson };
 export type { SharedPackOutput };
 
 export interface SharedPack {
-  /** First `npm pack --json` entry recorded when the tarball was produced. */
+  /** The package's own `npm pack --json` entry recorded when the tarball was produced. */
   readonly packOutput: SharedPackOutput;
   readonly tarball: string;
 }
 
 export type SharedPackPackage = 'agent-bundle' | 'create-agent-bundle' | 'runtime';
+
+/** packages/ directory and npm package name for each shared-pack key. */
+const sharedPackPackages: Readonly<Record<SharedPackPackage, Readonly<{ directory: string; npmName: string }>>> = {
+  'agent-bundle': { directory: 'agent-bundle', npmName: 'agent-bundle' },
+  'create-agent-bundle': { directory: 'create-agent-bundle', npmName: 'create-agent-bundle' },
+  runtime: { directory: 'rsc-runtime', npmName: '@agent-bundle/runtime' },
+};
 
 /**
  * NODE_PATH-free environment with per-command npm cache and tmp roots under
@@ -79,11 +86,14 @@ const packOnce = async (packageName: SharedPackPackage): Promise<SharedPack> => 
   process.once('exit', () => {
     rmSync(destination, { force: true, recursive: true });
   });
+  const { directory, npmName } = sharedPackPackages[packageName];
   const { stdout } = await execFile('npm', ['pack', '--json', '--pack-destination', destination], {
-    cwd: join(workspaceRoot, 'packages', packageName === 'runtime' ? 'rsc-runtime' : packageName),
+    cwd: join(workspaceRoot, 'packages', directory),
     env: { ...installedEnvironment(), NODE_ENV: 'production' },
   });
-  const packOutput = packOutputFromJson(stdout);
+  // Select by npm name: a workspace-aware `npm pack --json` can list sibling
+  // packages, and the first entry is not necessarily this one.
+  const packOutput = packOutputFromJson(stdout, npmName);
   return { packOutput, tarball: join(destination, packOutput.filename) };
 };
 

--- a/scripts/audit-packed-release.mjs
+++ b/scripts/audit-packed-release.mjs
@@ -31,13 +31,22 @@ const asString = (value, message) => {
   return value;
 };
 
-const packOutputFromJson = (stdout) => {
+const packOutputFromJson = (stdout, packageName) => {
   try {
-    return sharedPackOutputFromJson(stdout);
+    return sharedPackOutputFromJson(stdout, packageName);
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error));
   }
 };
+
+/** npm package name declared by a workspace package directory. */
+const packageNameOf = async (packageDirectory) => asString(
+  asRecord(
+    JSON.parse(await readFile(join(repositoryRoot, packageDirectory, 'package.json'), 'utf8')),
+    `${packageDirectory}/package.json is not an object`,
+  ).name,
+  `${packageDirectory}/package.json has no name`,
+);
 
 /** Every name -> Set(version) reachable under the consumer's own node_modules tree. */
 const collectInstalledPackages = async (nodeModulesRoot) => {
@@ -181,7 +190,7 @@ const auditLicenseFiles = async () => {
     const packOutput = packOutputFromJson((await execNpm(['pack', '--dry-run', '--json'], {
       cwd: join(repositoryRoot, packageDirectory),
       env: productionEnvironment,
-    })).stdout);
+    })).stdout, await packageNameOf(packageDirectory));
     await validateLicenseFiles(packOutput, packageDirectory);
   }
 };
@@ -204,7 +213,7 @@ const auditPackedRelease = async () => {
       'pack',
       '--json',
       '--pack-destination', tarballs,
-    ], { cwd: packageRoot, env: productionEnvironment })).stdout);
+    ], { cwd: packageRoot, env: productionEnvironment })).stdout, 'agent-bundle');
     const tarball = join(tarballs, asString(filename, 'npm pack did not produce a tarball filename'));
     // No `--prefer-offline` here (unlike the packed pool's
     // cachedNpmInstallArguments): the tree this install produces is what

--- a/scripts/npm-pack-json.mjs
+++ b/scripts/npm-pack-json.mjs
@@ -1,23 +1,46 @@
 /**
- * Parses `npm pack --json` output into its single pack entry. npm emits
- * either an array or a package-keyed object depending on version; both are
- * accepted, anything else throws.
+ * Parses `npm pack --json` output into one pack entry. npm emits either an
+ * array or a package-keyed object depending on version; both are accepted,
+ * anything else throws.
+ *
+ * When `packageName` is given, the entry is selected by package name rather
+ * than by position, so a pack that also lists sibling workspace packages
+ * still resolves the intended tarball deterministically. Without it, the
+ * output must contain exactly one entry. Mirrors
+ * packages/agent-bundle/src/build/pack-inventory.ts.
  */
-export const packOutputFromJson = (stdout) => {
+const isRecord = (value) => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const packEntryName = (entry, key) => (isRecord(entry) && typeof entry.name === 'string' ? entry.name : key);
+
+export const packOutputFromJson = (stdout, packageName) => {
   const parsed = JSON.parse(stdout);
   const entries = Array.isArray(parsed)
-    ? parsed
-    : parsed !== null && typeof parsed === 'object'
-      ? Object.values(parsed)
+    ? parsed.map((entry) => [undefined, entry])
+    : isRecord(parsed)
+      ? Object.entries(parsed)
       : undefined;
   if (entries === undefined) {
     throw new TypeError('npm pack --json returned neither an array nor a package-keyed object.');
   }
-  if (entries.length !== 1) {
-    throw new TypeError(`npm pack --json returned ${String(entries.length)} entries; expected exactly one.`);
+  let entry;
+  if (packageName === undefined) {
+    if (entries.length !== 1) {
+      throw new TypeError(`npm pack --json returned ${String(entries.length)} entries; expected exactly one.`);
+    }
+    entry = entries[0][1];
+  } else {
+    const named = entries.filter(([key, candidate]) => packEntryName(candidate, key) === packageName);
+    if (named.length !== 1) {
+      const seen = entries.map(([key, candidate]) => packEntryName(candidate, key) ?? '<unnamed>');
+      throw new TypeError(
+        `npm pack --json returned ${String(named.length)} entries named ${JSON.stringify(packageName)}; `
+        + `expected exactly one (saw: ${seen.map((name) => JSON.stringify(name)).join(', ')}).`,
+      );
+    }
+    entry = named[0][1];
   }
-  const [entry] = entries;
-  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+  if (!isRecord(entry)) {
     throw new TypeError('npm pack --json returned an invalid pack entry; expected one object.');
   }
   return entry;

--- a/scripts/run-packed-tests.mjs
+++ b/scripts/run-packed-tests.mjs
@@ -40,16 +40,19 @@ if (buildExitCode !== 0) process.exit(buildExitCode);
 
 const packDirectory = await mkdtemp(join(tmpdir(), 'agent-bundle-shared-pack-'));
 try {
+  // [shared-pack key, packages/ directory, npm package name]; the pack entry
+  // is selected by npm name so a workspace-aware `npm pack --json` that lists
+  // sibling packages still yields the intended tarball.
   await Promise.all([
-    ['agent-bundle', 'agent-bundle'],
-    ['create-agent-bundle', 'create-agent-bundle'],
-    ['runtime', 'rsc-runtime'],
-  ].map(async ([packageName, directory]) => {
+    ['agent-bundle', 'agent-bundle', 'agent-bundle'],
+    ['create-agent-bundle', 'create-agent-bundle', 'create-agent-bundle'],
+    ['runtime', 'rsc-runtime', '@agent-bundle/runtime'],
+  ].map(async ([packageName, directory, npmName]) => {
     const { stdout } = await execFile('npm', ['pack', '--json', '--pack-destination', packDirectory], {
       cwd: join(repositoryRoot, 'packages', directory),
       env: { ...environment, NODE_ENV: 'production' },
     });
-    const packOutput = packOutputFromJson(stdout);
+    const packOutput = packOutputFromJson(stdout, npmName);
     await writeFile(
       join(packDirectory, `${packageName}.json`),
       `${JSON.stringify({ packOutput, tarball: join(packDirectory, packOutput.filename) })}\n`,


### PR DESCRIPTION
## Summary

Three test-isolation fixes, each fixed at source (no retries, no padding, no longer timeouts):

1. **`native-claude-contract.test.ts`** — every enabled `runNativeClaudeSmoke` now receives an isolated `homeDirectory` (`withIsolatedHome`, mkdtemp + cleanup). Five tests previously ran with `environment: {}` / no `homeDirectory`, so `resolveClaudeNormalHome` fell back to `os.homedir()` and digested the developer's real `~/.claude` (2.1 GB / 7,479 files on this machine) before and after every stubbed run. The "fails closed when the candidate plugin…" case runs three smokes (six digests) and timed out at 5 s wherever the `claude` CLI is installed.
2. **`event-ipc.test.ts`** — the three contender-race tests (`does not unlink a concurrent winner…`, `serializes concurrent reclamation…`, `excludes a second orphan-claim remover…`) now attach the settlement handler to the losing server promise the moment it is created (`settleContender`). Root cause: the loser rejects `Event runtime endpoint already has a live server.` as soon as the winner listens (≤ 10 ms retry loop), while the test only reached its `await secondServer` after the winner had fully resolved (listen + chmod + stat + Effect layer plumbing). On a loaded machine the rejection landed first and surfaced as an *unhandled*, file-level failure (`"fullName": ""`, stack in `claimEndpoint`) — the exact signature seen in prior `pnpm test:unit` runs under concurrent lanes. Endpoint ids are `crypto.randomUUID()` so there is no cross-run socket-path collision to isolate; the shared `/tmp` was only the load source. A copy of the file with a forced 200 ms gap between winner resolution and the loser `await` reproduced the failure deterministically before the fix and passed after it.
3. **`npm pack --json` entry selection** — `packOutputFromJson` (`src/build/pack-inventory.ts` + the `scripts/npm-pack-json.mjs` mirror) accepts a `packageName` and selects the entry by npm name instead of by position; without a name it still requires exactly one entry. `scripts/run-packed-tests.mjs`, `scripts/audit-packed-release.mjs`, `tests/support/shared-pack.ts`, `tests/support/packed-native-smoke.ts`, `packed-consumer.test.ts`, and `cli.test.ts` pass `agent-bundle` / `@agent-bundle/runtime` / `create-agent-bundle`, so a workspace-aware pack that lists sibling packages still resolves the intended tarball. Unit coverage added in `prepack.test.ts` (array + package-keyed shapes, name-less npm 12 objects, 0/2 match errors).

## Evidence

Machine: `claude` on PATH (`/home/zack/.local/bin/claude`), other lanes running tests concurrently.

| Item | Before | After |
|---|---|---|
| native-claude-contract | 1 failed: `fails closed…` → `test timed out in 5000ms`; file wall 16.5 s | 17 passed / 1 skipped, tests 681 ms, file wall 1.8 s; **10/10** loop runs green (wall 1.82–2.07 s each) |
| event-ipc | prior `test:unit` logs: file-level `EventRuntimeTransportError: Event runtime endpoint already has a live server.` with `"fullName": ""` (5 separate runs on record); deterministic repro via 200 ms gap copy → same signature | 200 ms-gap copy passes; **10/10** sequential loop green; two concurrent runs of the file both green (16/16 each); 8 concurrent runs green |
| packed-native-smoke | `pnpm build && pnpm test:packed:native` on this machine: 6 passed / 1 skipped (35.8 s) — the 4-entry `npm pack --json` output did not reproduce with npm 12.0.2 here, so the fix is by construction + unit-tested | 6 passed / 1 skipped (27.4 s); **10/10** `pnpm test:packed:native` loop green (wall 23.7–28.0 s each, opt-in test skipped, Claude plugin proof passing); `prepack.test.ts` 10/10 incl. new name-selection test |

The isolated "fails closed…" case alone now runs in 179 ms (`-t` filtered run) versus the former 5 s timeout.

Gates: `pnpm typecheck` ✅ (6.8 s), `pnpm lint` ✅ (0 errors / 0 warnings, 1161 files), `pnpm test:unit` ✅ 204 files, 3003 passed / 5 skipped / 0 failed (44.8 s).

## Test plan

- `pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/native-claude-contract.test.ts` (with `claude` installed) — < 2 s, green.
- Launch `packages/agent-bundle/tests/event-ipc.test.ts` twice in parallel — both green.
- `pnpm build && pnpm test:packed:native` — reaches harness setup, opt-in test skipped, Claude plugin proof passes.
- `AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest --config rstest.integration.config.ts packages/agent-bundle/tests/prepack.test.ts` — green.

## Review status

- CI: all required checks green on head `c511d01cd6bbabed1bf96df3db21af27b7a90239` (Changeset present, Dependency review, Docs site, Examples check, Host install proofs, RSC runtime micro-eval, Release gates, Verify (Node 24), pkg.pr.new preview).
- `chatgpt-codex-connector`: three requests (automatic on open at 16:51Z, `@codex review` at 16:52Z and 17:11Z) all answered "You have reached your Codex usage limits for code reviews". No review threads were opened.
- Last codex-reviewed SHA: none. Unreviewed SHAs: `93bd86ea7` (fix), `c511d01cd` (changeset PR reference; head). Merged on CI green per the standing rule; a follow-up PR will answer any threads codex raises later.
