### PR TITLE
test(mcp-probe): order the settle-fence test on the probe's connect instead of a 20 ms sleep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,20 +63,20 @@
 
 ## Pull requests
 
-- Every PR: CI green first, then wait for the automated reviewer
-  (`chatgpt-codex-connector`) to finish. It does not re-review on its own
-  after a rebase or force-push: after every push, post an `@codex review` PR
-  comment if no fresh review appears within a few minutes, and confirm its
-  summary comment cites the current head SHA before merging.
-- Reviewer quota fallback: if the connector answers "usage limits reached", or
-  no review arrives within about ten minutes of two `@codex review` requests,
-  record the last-reviewed and unreviewed head SHAs in the PR body's "Review
-  status" section and merge on green CI. Re-request the review once credits
-  return; a thread it opens on an already-merged PR is answered in a
-  follow-up PR like any other.
-- Address every review thread — fix it in the same PR or reply with a precise
-  reason — and reply on every thread. After each push, re-check for new
-  threads and repeat until there are none. Only then merge.
+- Every PR gets a self-review before merge: spawn a local reviewer subagent
+  (`change-risk-reviewer` if available, else `generalPurpose`; prefer a
+  different model from the author's, e.g. `gpt-5.6-sol-high`) with the repo
+  path and the PR number or branch, asking for concrete merge risks only —
+  bugs, breaking changes, missed tests, doc or changeset gaps — against the
+  current diff vs `origin/main`. Fix or explicitly dismiss every finding in
+  the PR description under a "Self-review" section (reviewer model, findings,
+  disposition), run the reviewer once more after fixes, then merge on green
+  CI.
+- Never solicit external reviews: no `@codex review` comments, no waiting for
+  the connector, no unreviewed-SHA bookkeeping. Review comments that arrive
+  on their own (Codex or human) are still addressed — fix in the same PR or
+  reply with a precise reason — and re-checked after each push until none
+  remain.
 - PRs are squash-merged. Review threads left on an already-merged PR must
   still be answered, in a follow-up PR.
 

--- a/packages/agent-bundle/tests/mcp-probe-service.test.ts
+++ b/packages/agent-bundle/tests/mcp-probe-service.test.ts
@@ -709,6 +709,10 @@ it('settle() fences in-flight probes, not only already-registered teardowns (#39
   const connectReleased = new Promise<void>((resolvePromise) => {
     releaseConnect = resolvePromise;
   });
+  let connectReached!: () => void;
+  const connectStarted = new Promise<void>((resolvePromise) => {
+    connectReached = resolvePromise;
+  });
   try {
     const service = serviceFor(root, {
       createClient: () => client({
@@ -716,6 +720,7 @@ it('settle() fences in-flight probes, not only already-registered teardowns (#39
           // A probe that is still connecting when shutdown begins: its
           // teardown is not registered yet, so a fence over teardowns alone
           // would resolve immediately.
+          connectReached();
           await connectReleased;
         },
       }),
@@ -732,13 +737,16 @@ it('settle() fences in-flight probes, not only already-registered teardowns (#39
 
     const probe = service.probe({ host: 'claude', serverName: 'timeline' });
     void probe.then(() => { events.push('report-returned'); });
-    // Let the probe reach its (blocked) connect before shutdown starts.
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+    // Wait for the probe to reach its (blocked) connect before shutdown
+    // starts: plugin data exists by then, and the teardown is not registered.
+    await connectStarted;
     await expect(readFile(join(pluginData!, 'proof.txt'), 'utf8')).resolves.toBe('present');
 
     let settled = false;
     const settle = service.settle().then(() => { settled = true; });
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+    // A fence over registered teardowns alone would resolve within the
+    // current macrotask; draining one is enough to observe that regression.
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
     expect(settled).toBe(false);
 
     releaseConnect();


### PR DESCRIPTION
## Summary

Two changes:

1. **Test determinism** (`packages/agent-bundle/tests/mcp-probe-service.test.ts`) — see below.
2. **AGENTS.md "Pull requests"** — replaces the `@codex review` re-request / head-SHA-confirmation / quota-fallback rules with the maintainer's new process: a local reviewer subagent self-review before merge, findings fixed or dismissed in a "Self-review" PR section, organic review comments still addressed, external reviews never solicited.

### Test fix

`pnpm check:local-ci` on `origin/main` @ `10a98a0fb` (final sweep, load average 50–75) failed exactly one test, on the Node 22.19 verify leg:

```
packages/agent-bundle/tests/mcp-probe-service.test.ts
  settle() fences in-flight probes, not only already-registered teardowns (#397 review)
  AssertionError: promise rejected "Error: ENOENT: no such file or directory, … proof.txt" instead of resolving   (line 737)
```

Root cause: the test slept 20 ms "to let the probe reach its (blocked) connect" and then read the plugin-data file that `createPluginData` writes *before* `connect`. Under load the probe had not reached `createPluginData` inside 20 ms, so `pluginData` was still the previous value and the read hit `ENOENT`. A second 50 ms sleep guarded the "settle must not resolve early" assertion the same way.

Fix at source (test only, no product change): the stubbed `connect` resolves a `connectStarted` deferred the moment it is entered, and the test awaits that instead of the sleep — plugin data provably exists at that point and the teardown is provably not registered yet. The early-resolution check drains one macrotask (`setImmediate`) instead of sleeping 50 ms: a fence that only covered registered teardowns resolves within the current macrotask, so the regression is still observed, with no wall-clock budget left in the test.

## Evidence

- Failure: `.worktrees/local-ci/logs/verify-node22/07-test-unit.log` from the sweep run (3015/3021, one failed test; Node 24 and 26 verify legs and the gates leg were green on the same commit).
- After the fix: the file run 20× in a loop at load average 66–77 → **20/20 green** (`/tmp/final-sweep/probe-loop-*.log`).
- Pre-fix reproduction on unmodified `main` under the same load is recorded in the sweep report (10-run loop).

## Test plan

- [x] `pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/mcp-probe-service.test.ts` ×20 under load
- [ ] CI Verify

## Self-review

- Reviewer: `change-risk-reviewer` subagent, model `gpt-5.6-sol-high`, on head `f3dfd3d4b` vs `origin/main`, asked for concrete merge risks only.
- Findings (all verified against source, none actionable):
  1. `mcp-probe-service.ts:428,590` — `createPluginData` and the `proof.txt` write complete before `connect()` is called on the same probe, so the awaited read cannot `ENOENT`. Disposition: confirms the fix; no change.
  2. `mcp-probe-service.test.ts:745-750` — a teardown-only `settle()` resolves through microtasks before `setImmediate` fires, so the regression is still caught. Disposition: confirms the guard; no change.
  3. `mcp-probe-service.ts:558-590` — one probe calls `connect()` exactly once; never reaching it fails/times out rather than false-greening. Disposition: no change.
  4. `AGENTS.md:66-80` — repo-wide search found no remaining instruction to post `@codex review` or record unreviewed SHAs. Disposition: no change.
  5. `.changeset/README.md:24-27`, `.changeset/config.json:6` — `tests/**` and root guidance are exempt; no changeset required (the "Changeset present" check passed without a label). Disposition: no change.
- Verdict: no blockers; no fixes were needed, so no second pass was required.
- No organic review comments have arrived on this PR.
