### PR TITLE
docs(agents): make the pull-request review rule neutral about who reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,11 +72,9 @@
   the PR description under a "Self-review" section (reviewer model, findings,
   disposition), run the reviewer once more after fixes, then merge on green
   CI.
-- Never solicit external reviews: no `@codex review` comments, no waiting for
-  the connector, no unreviewed-SHA bookkeeping. Review comments that arrive
-  on their own (Codex or human) are still addressed — fix in the same PR or
-  reply with a precise reason — and re-checked after each push until none
-  remain.
+- CI green first. Address every review thread, whoever opened it — fix it in
+  the same PR or reply with a precise reason — and re-check for new threads
+  after each push until none remain. Only then merge.
 - PRs are squash-merged. Review threads left on an already-merged PR must
   still be answered, in a follow-up PR.
 


### PR DESCRIPTION
## Summary

`AGENTS.md` › Pull requests: remove the "Never solicit external reviews: no `@codex review` comments, no waiting for the connector, no unreviewed-SHA bookkeeping" bullet (landed via #449, which itself replaced the #433 `@codex review` / reviewer-quota-fallback rules). The repository guidance now carries no instruction about soliciting Codex reviews in either direction.

What stays: CI green first; address every review thread, whoever opened it, and re-check after each push until none remain; squash-merge; threads left on a merged PR are answered in a follow-up PR. The local self-review bullet is untouched.

Checked for the same review-process text and found none elsewhere: `.cursor/rules/**` (absent), `.changeset/README.md`, hand-written `docs/**`, `website/docs/{en,zh}/**` (excluding generated `api/**`). `packages/agent-bundle/src/adapters/capabilities/codex-*.json` describes Codex as a host target and is out of scope.

Docs-only, root file; no publishable package changes, so the `Changeset present` check does not require a changeset.