### PR TITLE
chore(examples): use built-in framework surface over hand-rolled setup

### DIFF
--- a/examples/audiobook-curator/package.json
+++ b/examples/audiobook-curator/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@agent-bundle/runtime": "workspace:*",
-    "@modelcontextprotocol/server": "2.0.0",
     "react": "19.2.8",
     "zod": "4.5.4"
   },

--- a/examples/rsc-agent-runtime/src/dev/generation-materializer.ts
+++ b/examples/rsc-agent-runtime/src/dev/generation-materializer.ts
@@ -18,7 +18,7 @@ import type {
 } from '../runtime/contracts.js';
 import type { DevRuntimePreparedProject } from '../../../../packages/agent-bundle/src/dev/runtime-provider.ts';
 import type { DevRuntimeMcpServerDescriptor } from '../../../../packages/agent-bundle/src/dev/runtime-protocol.ts';
-import type { JsonObject, JsonValue } from '../../../../packages/agent-bundle/src/dev/types.ts';
+import type { JsonObject, JsonValue } from 'agent-bundle';
 import type {
   RuntimeGenerationActivationGuard,
   RuntimeGenerationAsset,

--- a/examples/rsc-agent-runtime/src/dev/provider.ts
+++ b/examples/rsc-agent-runtime/src/dev/provider.ts
@@ -1,6 +1,9 @@
-import type { DevRuntimeProvider, DevRuntimeStartContext } from '../../../../packages/agent-bundle/src/dev/runtime-provider.ts';
+import type { DevRuntimeProvider } from 'agent-bundle/api';
 
 import { RsbuildRuntimeSession } from './rsbuild-runtime-session.js';
+
+/** The start context the public provider contract hands `start`; the framework exports only the provider type itself. */
+type DevRuntimeStartContext = Parameters<DevRuntimeProvider['start']>[0];
 
 export const createDevRuntimeProvider = (): DevRuntimeProvider => Object.freeze({
   descriptor: Object.freeze({

--- a/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
+++ b/examples/rsc-agent-runtime/src/dev/rsbuild-runtime-session.ts
@@ -84,7 +84,7 @@ import {
   type DevRuntimeSurface,
   type RuntimeVector,
 } from '../../../../packages/agent-bundle/src/dev/runtime-protocol.ts';
-import type { JsonObject, JsonValue } from '../../../../packages/agent-bundle/src/dev/types.ts';
+import type { JsonObject, JsonValue } from 'agent-bundle';
 
 const descriptor: DevRuntimeDescriptor = Object.freeze({
   environmentVariables: Object.freeze([]),

--- a/examples/rsc-agent-runtime/src/dev/serialize-inspection.ts
+++ b/examples/rsc-agent-runtime/src/dev/serialize-inspection.ts
@@ -5,7 +5,7 @@ import type {
   DevRuntimeTraceSpan,
   DevRuntimeTreeNode,
 } from '../../../../packages/agent-bundle/src/dev/runtime-protocol.ts';
-import type { JsonObject, JsonValue } from '../../../../packages/agent-bundle/src/dev/types.ts';
+import type { JsonObject, JsonValue } from 'agent-bundle';
 
 const inspectionStartedAt = '1970-01-01T00:00:00.000Z';
 const flightPreviewBytes = 32 * 1024;

--- a/examples/rsc-agent-runtime/src/runtime/contracts.ts
+++ b/examples/rsc-agent-runtime/src/runtime/contracts.ts
@@ -3,7 +3,7 @@ import type {
   DevRuntimeInspectionEnvelope,
   DevRuntimeMcpServerDescriptor,
 } from '../../../../packages/agent-bundle/src/dev/runtime-protocol.ts';
-import type { JsonObject } from '../../../../packages/agent-bundle/src/dev/types.ts';
+import type { JsonObject } from 'agent-bundle';
 
 export interface EditEvent {
   eventId: string;

--- a/examples/worktree-proximity/README.md
+++ b/examples/worktree-proximity/README.md
@@ -40,7 +40,7 @@ The application has four planes:
 - **Providers** — `git-worktree` derives repository, branch, commit, common
   Git directory, and linked-worktree identity without throwing for expected
   degradation. `agent-topology` reports that its snapshot is unavailable
-  before request mounting.
+  because providers receive no request identity or state handle.
 - **Events** — canonical shared-runtime routes observe actors, bind worktrees,
   record or clear intent, detect conflicts, render current-actor context, and
   publish or admit notices.
@@ -59,29 +59,53 @@ same driver. The application never opens a second store from Git identity
 data; `gitWorktree.commonDir` remains identity evidence only.
 
 The issue sketch places a snapshot at `providers.agentTopology.snapshot`, but
-providers execute before request state is mounted, so this provider reports
-an honest unavailable result and routes read snapshots from
-`(await agent()).state.read()` instead.
+a provider factory receives only `{ invocation, signal }` — no request
+identity, no `lineage`, and no mounted `state` handle
+([agent-bundle#459](https://github.com/scriptedalchemy/agent-bundle/issues/459)) —
+so this provider reports an honest unavailable result and routes read
+snapshots from `(await agent()).state.read()` instead.
 
 `worktree()` in `src/api.ts` is the issue-mandated custom Promise API over the
-provider value. A `useWorktree()` React-hook variant is recorded unavailable:
-the framework exposes no client-hook contract for provider values.
+provider value. `useWorktree()` is the hook-shaped variant for Server
+Components and synchronous helpers: it reads the same request handle through
+the runtime's `useAgent()`, so it follows the identical lease rules and throws
+the runtime's `outside-invocation` error outside a request.
 
 ## Actor identity and provenance
 
-Every identity claim records whether it came from a native envelope or was
-derived:
+Every identity claim records where it came from. `native` is read from the
+host envelope (or a `request.lineage` the runtime resolved natively),
+`registry` and `inferred` are the runtime lineage registry's own resolutions,
+and `derived` is this application's fallback:
 
-- `session/start` observes `session:<session_id>` as the root actor.
-- `agent/start` requires native `agent_id` and `session_id`, records the child,
-  and records its parent session provenance as native.
-- Tool envelopes contain no `agent_id`. A tool event first resolves an active
-  actor already bound to the event worktree. Without an earlier binding it
-  uses the explicit derived identity `worktree:<root>` and records that
-  provenance; it never upgrades the derived identity to native.
-- `agent/start` without native identity records an `edgeRefused` event and
-  renders that parent identity is unavailable. It refuses to fabricate a
-  topology edge.
+- `session/start` observes `session:<root>` as the root actor, where the root
+  is `(await agent()).lineage.root` when the runtime resolved a lineage and the
+  native `session_id` otherwise.
+- `agent/start` records the child and its parent from `request.lineage`
+  (`subagent.id`, `parent`, `resolution`) when the runtime placed the start
+  below the root — which needs the spawning `Agent`/`Task` `tool/before` to
+  have passed through the same shared runtime — and from the native `agent_id`
+  + `session_id` pair otherwise.
+- Claude and Codex put the subagent's `agent_id` on every one of its hook
+  payloads; Cursor gives the child a fresh `conversation_id` that only the
+  runtime registry can bind to its `subagentStart`. A tool or stop event
+  therefore resolves its actor in order of evidence: the child named by
+  `request.lineage` (depth above zero), then the native `agent_id`, then the
+  active actor already bound to the event worktree, and finally the explicit
+  derived identity `worktree:<root>`. A carried child the topology has not
+  seen is observed and bound with the provenance the evidence carried; a
+  derived identity is never upgraded. A root-level tool envelope (lineage
+  depth zero) resolves through the worktree binding, so intent stays
+  attributed per worktree.
+- `agent/start` without either lineage or native identity records an
+  `edgeRefused` event and renders that parent identity is unavailable. It
+  refuses to fabricate a topology edge.
+
+`request.lineage` covers the request's own parent, root, depth, and subagent
+record. Siblings, children, and other roots are not exposed
+([#457](https://github.com/scriptedalchemy/agent-bundle/issues/457)), so this
+application keeps its own topology state for the whole-tree view the
+coordinator status reports.
 
 Unsupported worktree, actor, parent, state, and delivery conditions are
 rendered as unavailable instead of being replaced with invented evidence.
@@ -98,11 +122,15 @@ Notice admission runs once per event invocation in the render scope.
 Generated event principals in v1 mount host, session, and workspace identity,
 but not actor identity. Proximity notices therefore target the recipient
 worktree through `recipient.workspace.root`, while their content and dedupe
-keys continue to name the target actor. Actor-directed delivery remains future
-work tied to actor-principal mounting in the #99/#233 lineage.
+keys continue to name the target actor. Lineage-addressed delivery
+(`recipient.conversation` / `recipient.root` matched against
+`request.lineage`) is tracked in
+[agent-bundle#458](https://github.com/scriptedalchemy/agent-bundle/issues/458).
 `(await agent()).notices.read()` exposes only deliveries attempted for the
-current invocation. The coordinator status therefore reports topology facts
-only and does not claim a whole-ledger pending count.
+current invocation; publisher-scoped visibility is
+[#460](https://github.com/scriptedalchemy/agent-bundle/issues/460). The
+coordinator status therefore reports topology facts only and does not claim a
+whole-ledger pending count.
 
 ## Evidence boundary
 

--- a/examples/worktree-proximity/src/api.ts
+++ b/examples/worktree-proximity/src/api.ts
@@ -1,4 +1,4 @@
-import { agent } from '@agent-bundle/runtime';
+import { agent, useAgent } from '@agent-bundle/runtime';
 import { z } from 'zod';
 
 export const WorktreeProviderValueSchema = z.discriminatedUnion('state', [
@@ -24,8 +24,7 @@ export const WorktreeProviderValueSchema = z.discriminatedUnion('state', [
 export type WorktreeProviderValue = z.output<typeof WorktreeProviderValueSchema>;
 export type AvailableWorktree = Extract<WorktreeProviderValue, { state: 'available' }>;
 
-export const worktree = async (): Promise<WorktreeProviderValue> => {
-  const candidate = (await agent()).providers.gitWorktree;
+const parseWorktree = (candidate: unknown): WorktreeProviderValue => {
   const parsed = WorktreeProviderValueSchema.safeParse(candidate);
   return parsed.success
     ? parsed.data
@@ -34,3 +33,16 @@ export const worktree = async (): Promise<WorktreeProviderValue> => {
         state: 'unavailable',
       };
 };
+
+/** The Promise-shaped accessor over the mounted `git-worktree` provider value. */
+export const worktree = async (): Promise<WorktreeProviderValue> =>
+  parseWorktree((await agent()).providers.gitWorktree);
+
+/**
+ * The hook-shaped variant, for Server Components and synchronous helpers
+ * that cannot `await`. It reads the identical request handle through the
+ * runtime's `useAgent()`, so every lease rule holds unchanged: outside a
+ * request it throws the runtime's `outside-invocation` error.
+ */
+export const useWorktree = (): WorktreeProviderValue =>
+  parseWorktree(useAgent().providers.gitWorktree);

--- a/examples/worktree-proximity/src/event-support.ts
+++ b/examples/worktree-proximity/src/event-support.ts
@@ -1,11 +1,14 @@
-import type {
-  AgentDocumentNode,
-  AgentNoticeDelivery,
+import {
+  agent,
+  type AgentDocumentNode,
+  type AgentLineage,
+  type AgentNoticeDelivery,
+  type Observed,
 } from '@agent-bundle/runtime';
 
 import type { AvailableWorktree } from './api.js';
 import type { TopologyAccess } from './coordination.js';
-import type { TopologyState } from './state.js';
+import type { IdentityProvenance, TopologyState } from './state.js';
 
 export interface EventIdentity {
   readonly idempotencyKey: string;
@@ -19,8 +22,50 @@ export interface ExtractedIntent {
 
 export interface ResolvedActor {
   readonly id: string;
-  readonly source: 'derived' | 'native';
+  readonly source: IdentityProvenance;
 }
+
+/** A child actor plus the conversation that spawned it, as one envelope names them. */
+export interface CarriedChild extends ResolvedActor {
+  readonly parentSessionId: string;
+}
+
+/** The conversation lineage the runtime resolved for the current request. */
+export const requestLineage = async (): Promise<Observed<AgentLineage>> => (await agent()).lineage;
+
+/**
+ * The subagent a request speaks for, when the runtime's `request.lineage`
+ * places it below the root. The runtime resolves the same shape on every
+ * host, so the route never has to know that Claude and Codex spell the child
+ * `agent_id` while Cursor gives it a fresh `conversation_id`. A root request
+ * (depth 0) is deliberately not a child; the root actor is observed at
+ * `session/start`.
+ */
+export const childFromLineage = (lineage: Observed<AgentLineage>): CarriedChild | undefined => {
+  if (lineage.state !== 'available' || lineage.value.depth === 0) return undefined;
+  return {
+    id: lineage.value.subagent?.id ?? lineage.value.conversation,
+    parentSessionId: lineage.value.parent ?? lineage.value.root,
+    source: lineage.value.resolution,
+  };
+};
+
+/**
+ * The child actor one envelope carries: the runtime lineage first, then the
+ * host's own `agent_id` (Claude and Codex put the subagent's id on every one
+ * of its hook payloads) with the root `session_id` as its parent. `undefined`
+ * means the envelope names no subagent.
+ */
+export const carriedChild = async (
+  native: Readonly<Record<string, unknown>>,
+): Promise<CarriedChild | undefined> => {
+  const fromLineage = childFromLineage(await requestLineage());
+  if (fromLineage !== undefined) return fromLineage;
+  const agentId = nativeString(native, 'agent_id');
+  const sessionId = nativeString(native, 'session_id');
+  if (agentId === undefined || sessionId === undefined) return undefined;
+  return { id: agentId, parentSessionId: sessionId, source: 'native' };
+};
 
 export const nativeString = (
   native: Readonly<Record<string, unknown>>,
@@ -66,12 +111,45 @@ export const extractIntent = (
   };
 };
 
+/**
+ * The actor a tool or stop envelope belongs to, in order of evidence: the
+ * child the envelope itself names (runtime lineage, then native `agent_id`),
+ * the active actor already bound to the event worktree, and finally the
+ * explicit derived identity `worktree:<root>`. A carried child the topology
+ * has not seen yet (its `agent/start` was missed) is observed and bound with
+ * the provenance the evidence carried; a derived actor is never upgraded.
+ */
 export const actorForWorktree = async (
   topology: TopologyAccess,
   worktree: AvailableWorktree,
   canonical: EventIdentity,
+  native: Readonly<Record<string, unknown>> = {},
 ): Promise<{ readonly actor: ResolvedActor; readonly snapshot: TopologyState }> => {
   const before = await topology.read();
+  const carried = await carriedChild(native);
+  if (carried !== undefined) {
+    const known = before.state.actors.find((actor) => actor.id === carried.id);
+    if (known !== undefined) {
+      return { actor: { id: known.id, source: known.provenance.id }, snapshot: before.state };
+    }
+    await topology.dispatch('actorObserved', {
+      id: carried.id,
+      kind: 'child',
+      parentSessionId: carried.parentSessionId,
+      provenance: { id: carried.source, parentSessionId: carried.source },
+      status: 'active',
+    }, {
+      idempotencyKey: `${canonical.idempotencyKey}:carried-actor`,
+    });
+    const boundResult = await topology.dispatch('actorBound', {
+      actorId: carried.id,
+      provenance: 'native',
+      worktreeRoot: worktree.root,
+    }, {
+      idempotencyKey: `${canonical.idempotencyKey}:carried-worktree`,
+    });
+    return { actor: { id: carried.id, source: carried.source }, snapshot: boundResult.state };
+  }
   const bound = before.state.actors.find(
     (actor) => actor.status === 'active' && actor.worktreeRoot === worktree.root && actor.kind === 'child',
   ) ?? before.state.actors.find(

--- a/examples/worktree-proximity/src/events/agent/start.tsx
+++ b/examples/worktree-proximity/src/events/agent/start.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { worktree } from '../../api.js';
 import { withNotices, withTopology } from '../../coordination.js';
-import { deliveryContexts, nativeString } from '../../event-support.js';
+import { carriedChild, deliveryContexts, nativeString } from '../../event-support.js';
 
 export const config = {
   runtime: 'shared',
@@ -24,10 +24,13 @@ export default async function AgentStart({
     );
   }
 
-  const agentId = nativeString(native, 'agent_id');
-  const sessionId = nativeString(native, 'session_id');
-  if (agentId === undefined || sessionId === undefined) {
-    const refusal = agentId === undefined
+  // The runtime's `request.lineage` names the child and its parent when the
+  // registry resolved this start; the native `agent_id` + root `session_id`
+  // pair is the fallback. Neither present is a refusal, never a guess.
+  const child = await carriedChild(native);
+  if (child === undefined) {
+    const sessionId = nativeString(native, 'session_id');
+    const refusal = nativeString(native, 'agent_id') === undefined
       ? 'agent/start omitted native agent_id; refused to fabricate a topology edge'
       : 'agent/start omitted native session_id; refused to fabricate a topology edge';
     const topologyResult = await withTopology(async (topology) => {
@@ -58,19 +61,19 @@ export default async function AgentStart({
 
   const topologyResult = await withTopology(async (topology) => {
     await topology.dispatch('actorObserved', {
-      id: agentId,
+      id: child.id,
       kind: 'child',
-      parentSessionId: sessionId,
+      parentSessionId: child.parentSessionId,
       provenance: {
-        id: 'native',
-        parentSessionId: 'native',
+        id: child.source,
+        parentSessionId: child.source,
       },
       status: 'active',
     }, {
       idempotencyKey: `${canonical.idempotencyKey}:actor`,
     });
     await topology.dispatch('actorBound', {
-      actorId: agentId,
+      actorId: child.id,
       provenance: 'native',
       worktreeRoot: currentWorktree.root,
     }, {

--- a/examples/worktree-proximity/src/events/session/start.tsx
+++ b/examples/worktree-proximity/src/events/session/start.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { worktree } from '../../api.js';
 import { withNotices, withTopology } from '../../coordination.js';
-import { deliveryContexts, nativeString } from '../../event-support.js';
+import { deliveryContexts, nativeString, requestLineage } from '../../event-support.js';
 
 export const config = {
   runtime: 'shared',
@@ -23,8 +23,16 @@ export default async function SessionStart({
       </Agent.Result>
     );
   }
-  const sessionId = nativeString(native, 'session_id');
-  if (sessionId === undefined) {
+  // The runtime's lineage names the root conversation on every host; the
+  // native `session_id` is the fallback when no lineage was resolved.
+  const lineage = await requestLineage();
+  const root = lineage.state === 'available'
+    ? { id: lineage.value.root, source: lineage.value.resolution }
+    : (() => {
+        const sessionId = nativeString(native, 'session_id');
+        return sessionId === undefined ? undefined : { id: sessionId, source: 'native' as const };
+      })();
+  if (root === undefined) {
     return (
       <Agent.Result>
         <Agent.Context>Root actor unavailable: session/start omitted native session_id.</Agent.Context>
@@ -32,12 +40,12 @@ export default async function SessionStart({
     );
   }
 
-  const actorId = `session:${sessionId}`;
+  const actorId = `session:${root.id}`;
   const topologyResult = await withTopology(async (topology) => {
     await topology.dispatch('actorObserved', {
       id: actorId,
       kind: 'root',
-      provenance: { id: 'native' },
+      provenance: { id: root.source },
       status: 'active',
     }, {
       idempotencyKey: `${canonical.idempotencyKey}:actor`,

--- a/examples/worktree-proximity/src/events/stop.tsx
+++ b/examples/worktree-proximity/src/events/stop.tsx
@@ -6,8 +6,8 @@ import { worktree } from '../api.js';
 import { withNotices, withTopology } from '../coordination.js';
 import {
   actorForWorktree,
+  carriedChild,
   deliveryContexts,
-  nativeString,
   type ResolvedActor,
 } from '../event-support.js';
 
@@ -28,11 +28,13 @@ export default async function Stop({
       </Agent.Result>
     );
   }
-  const nativeActorId = nativeString(native, 'agent_id');
+  // A stop names its own actor through the runtime lineage or the native
+  // `agent_id`; only an anonymous stop falls back to the worktree binding.
+  const carried = await carriedChild(native);
   const topologyResult = await withTopology(async (topology): Promise<ResolvedActor> => {
-    const resolved = nativeActorId === undefined
+    const resolved: ResolvedActor = carried === undefined
       ? (await actorForWorktree(topology, currentWorktree, canonical)).actor
-      : { id: nativeActorId, source: 'native' as const };
+      : { id: carried.id, source: carried.source };
     await topology.dispatch('actorStopped', {
       actorId: resolved.id,
       observedAt: canonical.observedAt,

--- a/examples/worktree-proximity/src/events/tool/after.tsx
+++ b/examples/worktree-proximity/src/events/tool/after.tsx
@@ -13,6 +13,7 @@ export const config = {
 
 export default async function AfterTool({
   canonical,
+  native,
 }: AgentEventRouteProps) {
   const currentWorktree = await worktree();
   if (currentWorktree.state === 'unavailable') {
@@ -23,7 +24,7 @@ export default async function AfterTool({
     );
   }
   const topologyResult = await withTopology(async (topology) => {
-    const resolved = await actorForWorktree(topology, currentWorktree, canonical);
+    const resolved = await actorForWorktree(topology, currentWorktree, canonical, native);
     await topology.dispatch('intentRecorded', {
       actorId: resolved.actor.id,
       dependencies: [],

--- a/examples/worktree-proximity/src/events/tool/before.tsx
+++ b/examples/worktree-proximity/src/events/tool/before.tsx
@@ -30,7 +30,7 @@ export default async function BeforeTool({
   }
   const intent = extractIntent(native);
   const topologyResult = await withTopology(async (topology) => {
-    const { actor } = await actorForWorktree(topology, currentWorktree, canonical);
+    const { actor } = await actorForWorktree(topology, currentWorktree, canonical, native);
     const committed = await topology.dispatch('intentRecorded', {
       actorId: actor.id,
       dependencies: [...intent.dependencies],

--- a/examples/worktree-proximity/src/providers/agent-topology.ts
+++ b/examples/worktree-proximity/src/providers/agent-topology.ts
@@ -3,10 +3,20 @@ export interface AgentTopologyProviderValue {
   readonly state: 'unavailable';
 }
 
+/**
+ * The issue sketch places a topology snapshot at
+ * `providers.agentTopology.snapshot`. A conventional provider factory still
+ * receives only `{ invocation, signal }` — no request identity, no
+ * `lineage`, and no mounted `state`/`notices` handles (agent-bundle#459) —
+ * so it cannot derive that view. Routes read the topology from
+ * `(await agent()).state` and their own place in the conversation tree from
+ * `(await agent()).lineage` instead; this provider reports the gap honestly
+ * rather than opening a second store.
+ */
 export default function agentTopologyProvider(): AgentTopologyProviderValue {
   return {
     reason:
-      'Topology snapshots are available only from the mounted request state handle; providers execute before that handle is mounted.',
+      'Topology snapshots are available only from the mounted request state handle; providers receive no request identity, lineage, or state handle (agent-bundle#459).',
     state: 'unavailable',
   };
 }

--- a/examples/worktree-proximity/src/state.ts
+++ b/examples/worktree-proximity/src/state.ts
@@ -2,7 +2,15 @@ import { defineState } from '@agent-bundle/runtime/state';
 import { z } from 'zod';
 
 const nonEmpty = z.string().trim().min(1);
-const provenance = z.enum(['native', 'derived']);
+/**
+ * Where an identity claim came from: `native` is read straight from the host
+ * envelope (or a `request.lineage` the runtime resolved natively), `registry`
+ * and `inferred` are the runtime lineage registry's own resolutions, and
+ * `derived` is this application's fallback (`worktree:<root>`).
+ */
+const provenance = z.enum(['native', 'registry', 'inferred', 'derived']);
+
+export type IdentityProvenance = z.output<typeof provenance>;
 
 export const ActorSchema = z
   .object({

--- a/examples/worktree-proximity/tests/route-unit/routes.test.ts
+++ b/examples/worktree-proximity/tests/route-unit/routes.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
-import { available } from '@agent-bundle/runtime';
+import { available, type AgentLineage, type Observed } from '@agent-bundle/runtime';
 import {
   createGeneratedRuntimeState,
   type GeneratedRuntimeState,
@@ -66,6 +66,7 @@ const renderEventInput = async (
   id: string,
   worktreeRoot: string,
   actorId?: string,
+  lineage?: Observed<AgentLineage>,
 ) => {
   const bindings = await runtimeState.requestBindings();
   try {
@@ -77,6 +78,7 @@ const renderEventInput = async (
           id: `invocation:${id}`,
           startedAt: `2026-09-01T20:01:${String(sequence).padStart(2, '0')}.000Z`,
         },
+        ...(lineage === undefined ? {} : { lineage }),
         noticeLedger: bindings.noticeLedger,
         providers: { gitWorktree: provider(worktreeRoot) },
         session: available({ sessionId: 'root-session' }, 'native'),
@@ -97,13 +99,25 @@ const renderEvent = (
   id: string,
   worktreeRoot: string,
   actorId?: string,
+  lineage?: Observed<AgentLineage>,
 ) => renderEventInput(
   route,
   eventInput(event, native, id),
   id,
   worktreeRoot,
   actorId,
+  lineage,
 );
+
+/** A runtime-registry lineage placing `id` one level below `root-session`. */
+const childLineage = (id: string): Observed<AgentLineage> => available({
+  conversation: id,
+  depth: 1,
+  parent: 'root-session',
+  resolution: 'registry',
+  root: 'root-session',
+  subagent: { id },
+}, 'derived');
 
 const bindActors = async (): Promise<void> => {
   await renderEvent(
@@ -335,6 +349,80 @@ describe('worktree proximity journeys', () => {
           reason: 'agent/start omitted native agent_id; refused to fabricate a topology edge',
         }),
       ]);
+    } finally {
+      await bindings.close();
+    }
+  });
+
+  it('records the child and its parent from request.lineage when the envelope carries no agent_id', async () => {
+    await bindActors();
+    const rendered = await renderEvent(
+      'event:agent/start',
+      'agent/start',
+      {
+        agent_type: 'implementation',
+        cwd: worktrees.b,
+        hook_event_name: 'SubagentStart',
+        session_id: 'root-session',
+      },
+      'agent-c:start',
+      worktrees.b,
+      undefined,
+      childLineage('agent-c'),
+    );
+
+    expectDocument(rendered).toHaveStatus('success').toHaveNodeKinds(['result']);
+
+    const bindings = await runtimeState.requestBindings();
+    try {
+      const snapshot = await bindings.state.read();
+      expect(snapshot.state.refusals).toEqual([]);
+      expect(snapshot.state.actors).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'agent-c',
+          kind: 'child',
+          parentSessionId: 'root-session',
+          provenance: expect.objectContaining({ id: 'registry', parentSessionId: 'registry' }),
+          worktreeRoot: worktrees.b,
+        }),
+      ]));
+    } finally {
+      await bindings.close();
+    }
+  });
+
+  it('attributes a tool envelope to the lineage child ahead of the worktree binding', async () => {
+    await bindActors();
+    const rendered = await renderEvent(
+      'event:tool/before',
+      'tool/before',
+      {
+        cwd: worktrees.a,
+        hook_event_name: 'PreToolUse',
+        session_id: 'root-session',
+        tool_input: { file_path: 'src/shared.ts' },
+        tool_name: 'Edit',
+      },
+      'intent:c',
+      worktrees.a,
+      undefined,
+      childLineage('agent-c'),
+    );
+
+    expectDocument(rendered).toHaveStatus('success');
+    expect(rendered.document.value).toEqual({ outcome: 'continue' });
+
+    const bindings = await runtimeState.requestBindings();
+    try {
+      const snapshot = await bindings.state.read();
+      expect(snapshot.state.actors).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'agent-c',
+          provenance: expect.objectContaining({ id: 'registry', parentSessionId: 'registry' }),
+          worktreeRoot: worktrees.a,
+        }),
+      ]));
+      expect(snapshot.state.activities.map((activity) => activity.actorId)).toEqual(['agent-c']);
     } finally {
       await bindings.close();
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@agent-bundle/runtime':
         specifier: workspace:*
         version: link:../../packages/rsc-runtime
-      '@modelcontextprotocol/server':
-        specifier: 2.0.0
-        version: 2.0.0
       react:
         specifier: 19.2.8
         version: 19.2.8


### PR DESCRIPTION
Fixes #51, #52 and #54 (daemon side; the client-side `MAKEFLAGS` transport item in #54 is handled separately).

## #51 — kill honoured while parked; batch, ETA and settlement hardening
- `processJob` now races the job's kill signal against the load gate + `admission.withPermits(1)`. A kill on a job parked at the gate or on the permit settles it `killed` (`killed while queued`) immediately via the existing `finishKilledBeforeRun` path, releases any heavy claim, and no longer blocks the rest of its lane. A kill that lands after `claimStart` is left to the executor (the race arm parks instead of interrupting an admitted run).
- `foldBatch` skips candidates whose state is not `queued`; `processLaneJob` re-checks state before the batch window sleep and before folding, so a kill-requested head neither waits for nor leads a batch.
- Queue ETA uses `remainingEstimateMs` (clamped at 0) and counts a head parked at the gate (new `Lane.head`, set from take to settlement). The existing assertion in `daemon-broker.test.ts` that encoded the negative-cancel bug (`waitEtaMs === 0`) now expects the queued job's estimate.
- `settleJob` isolates every step after `claimSettlement` (`markFinished`, metrics, `notifyWaiters`, `completeExit`, `settleAttachments`) with `settlementStep` (log + continue on defect). `settleAttachments` and `finishAttachment` apply the same per-step isolation.

## #52 — attachment registration races
- `replayThenGoLive` takes the replay snapshot and clears `pendingLive` in one `Effect.sync`, so a chunk emitted between registration and replay is delivered once.
- `completeAttachRegistration` re-checks `leader.attachments.get(ticket) === attachment` in a sync frame before any ledger write and returns early if the leader settled / the attachment was killed or released in the window. `updateRunning` / `updateAttached` carry `AND status NOT IN (<terminal>)` and record a transition only when a row changed.
- Early follower release from the stdout pump (`releaseSatisfiedAttachments`) is guarded: a ledger/metric defect is logged instead of surfacing as `pump-failed` and terminating cargo.
- `mergeStderr` is part of identity/coverage attach compatibility for raw-output leaders (`channelsCompatible`); demux runs never merge so the flag is irrelevant there. Batch folding is documented as unchanged (folded followers receive the composite's channels as produced).

## #54 — jobserver vs `CARGO_BUILD_JOBS`
- New `isSharedJobserverArmed()`; `cargoExecEnv` injects `CARGO_BUILD_JOBS` only when the FIFO is **not** armed, so an armed daemon lets `sharedJobserverDelta` inject `MAKEFLAGS` and cargo joins the shared budget. Caller `-j` / `CARGO_BUILD_JOBS` still win.
- README: parallelism paragraph, capability row and `CARGO_HAULER_JOBS_GRANT` env row state the precedence; `DaemonConfigShape.jobsGrant` doc updated.

## Tests (each written failing first, then fixed)
- `tests/daemon-races.test.ts` (new, in-process broker over the fake cargo via the shared `tests/broker-fixture.ts`, extracted from `daemon-async.test.ts`):
  - kill of a job parked on the permit settles `killed` within the await budget while the holder keeps running
  - kill-requested pending job is not folded into a batch (leader chosen via a rider so the doomed job is the fold candidate)
  - settlement completes (exit callback fires, directory entry cleared, successor runs alone) when `markFinished` dies
  - late attacher receives each of 40 replayed ticks exactly once with `markAttached` delayed 400 ms
  - follower whose `markAttached` is held until after the leader settled stays `done`
  - early follower release with a dying `markFinished` leaves the leader `done` (not `pump failed`) and still delivers the follower's exit
  - identity attach on `cargo test` requires equal `mergeStderr`
- `tests/daemon-ledger.test.ts`: late `markAttached`/`markRunning` never reopen a `done` row or add transitions.
- `tests/daemon-jobs-grant.test.ts` (new): `cargoExecEnv` matrix + a daemon spawn asserting `CARGO_BUILD_JOBS` unset and `MAKEFLAGS` carrying `--jobserver-auth=fifo:<stateDir>/jobserver.fifo`.

## Gate
`pnpm check` green locally: validate, build, typecheck, Effect diagnostics (pre-existing suggestions only), rstest 637 passed / 0 failed, route-unit 32 passed / 0 failed.

## Review status
_(filled in per AGENTS.md once the automated review runs)_
