### PR TITLE
chore(examples): drop stray host-test probe note; add mcp-app typecheck and make it pass --strict

### DIFF
--- a/examples/host-test/probe-note.txt
+++ b/examples/host-test/probe-note.txt
@@ -1,1 +1,0 @@
-host-test

--- a/examples/mcp-app/README.md
+++ b/examples/mcp-app/README.md
@@ -73,6 +73,7 @@ from the example package:
 cd examples/mcp-app
 pnpm validate
 pnpm build
+pnpm typecheck
 pnpm exec agent-bundle eval --case status-is-healthy --trials 1
 pnpm dev
 ```
@@ -95,6 +96,7 @@ variants, by default. Launch environment precedence is manifest env, then
 `--env-file <path>` to replace the conventional files, `--no-env` to skip
 them, and `--plugin-root <path>` only for a copied-artifact rehearsal.
 
-Use `pnpm check` for validation and build without opening the Workbench. The
+Use `pnpm check` for validation, build, and typecheck without opening the
+Workbench. The
 deterministic portable eval and fixture check read only checked-in data and
 require no native Claude/Codex login or API key.

--- a/examples/mcp-app/package.json
+++ b/examples/mcp-app/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "agent-bundle build",
-    "check": "pnpm validate && pnpm build",
+    "check": "pnpm validate && pnpm build && pnpm typecheck",
     "dev": "agent-bundle dev",
     "test:browser-app": "rstest --config rstest.browser-app.config.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "validate": "agent-bundle validate"
   },
   "devDependencies": {

--- a/examples/mcp-app/src/compiler-status-contract.ts
+++ b/examples/mcp-app/src/compiler-status-contract.ts
@@ -17,14 +17,19 @@ export const isHealthyCompilerFixture = (value: unknown): boolean => {
     || value.service !== healthyCompilerStatus.service
     || value.status !== healthyCompilerStatus.status
     || value.summary !== healthyCompilerStatus.summary
-    || !Array.isArray(value.checks)
-    || value.checks.length !== healthyCompilerStatus.checks.length
   ) {
     return false;
   }
 
+  // Bind the property once: a narrowing on `value.checks` does not survive
+  // into the `every` callback, so the guard and the indexing share one binding.
+  const checks: unknown = value.checks;
+  if (!Array.isArray(checks) || checks.length !== healthyCompilerStatus.checks.length) {
+    return false;
+  }
+
   return healthyCompilerStatus.checks.every((expected, index) => {
-    const received = value.checks[index];
+    const received: unknown = checks[index];
     return isRecord(received)
       && received.label === expected.label
       && received.status === expected.status;

--- a/examples/mcp-app/tests/browser-app/status-panel.browser.test.ts
+++ b/examples/mcp-app/tests/browser-app/status-panel.browser.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, it } from '@rstest/core';
 
-import { mountBrowserApp, type MountedBrowserApp } from 'agent-bundle/test/browser';
+import { mountBrowserApp, type MountBrowserAppOptions, type MountedBrowserApp } from 'agent-bundle/test/browser';
+
+type BindingOperations = MountBrowserAppOptions['operations'];
+type ToolCallResult = Awaited<ReturnType<BindingOperations['callTool']>>;
 
 const statusResult = Object.freeze({
   content: Object.freeze([Object.freeze({
@@ -33,10 +36,10 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 2_000): Promise<voi
 };
 
 const operations = (options: {
-  readonly callTool?: () => Promise<unknown>;
+  readonly callTool?: () => Promise<ToolCallResult>;
   readonly calls?: string[];
   readonly reads?: string[];
-} = {}) => ({
+} = {}): BindingOperations => ({
   callTool: async (_bindingId: string, request: { readonly name: string }) => {
     options.calls?.push(request.name);
     return options.callTool?.() ?? statusResult;

--- a/examples/mcp-app/tsconfig.json
+++ b/examples/mcp-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "agent-bundle.config.ts",
+    "evals/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "views/**/*.ts"
+  ]
+}

--- a/website/docs/en/examples/mcp-app.mdx
+++ b/website/docs/en/examples/mcp-app.mdx
@@ -84,10 +84,11 @@ After the repository-level `pnpm build`:
 cd examples/mcp-app
 pnpm validate
 pnpm build
+pnpm typecheck
 pnpm exec agent-bundle eval --case status-is-healthy --trials 1
 ```
 
-`pnpm check` is the validation-and-build pair without the Workbench.
+`pnpm check` runs validation, build, and typecheck without the Workbench.
 
 ## Running the server on stdio
 

--- a/website/docs/zh/examples/mcp-app.mdx
+++ b/website/docs/zh/examples/mcp-app.mdx
@@ -74,10 +74,11 @@ description: 'MCP App 示例：把一条服务就绪度工作流表达为生成�
 cd examples/mcp-app
 pnpm validate
 pnpm build
+pnpm typecheck
 pnpm exec agent-bundle eval --case status-is-healthy --trials 1
 ```
 
-`pnpm check` 是不打开 Workbench 的“校验加构建”这一对。
+`pnpm check` 在不打开 Workbench 的情况下依次运行校验、构建和类型检查。
 
 ## 在 stdio 上运行服务器
 


### PR DESCRIPTION
Follow-up cleanup from #471 (examples only; no publishable package touched).

| Change | Files | Why |
|---|---|---|
| Delete stray `probe-note.txt` | `examples/host-test/probe-note.txt` | Left over from a lineage probe; not referenced by the README, the docs page, or any test. |
| Add `typecheck` script to `mcp-app` | `examples/mcp-app/package.json`, `examples/mcp-app/tsconfig.json` (new) | Every other example defines `"typecheck": "tsc -p tsconfig.json --noEmit"` and runs it from `check`; mcp-app was the only one without a tsconfig or typecheck. Same `extends`/`jsx` shape as the siblings, `include` adds `evals/**` and `views/**` because this example has both. `check` now runs validate → build → typecheck. |
| `src/compiler-status-contract.ts:27` — TS18046 `'value.checks' is of type 'unknown'` | `examples/mcp-app/src/compiler-status-contract.ts` | The `Array.isArray(value.checks)` narrowing on a `Record<string, unknown>` property did not survive into the `every` callback. Bind `checks` once, guard it, index the binding. Runtime behavior unchanged. |
| Browser test typed against the public helper | `examples/mcp-app/tests/browser-app/status-panel.browser.test.ts` | Surfaced by the new typecheck: the `operations()` stub returned `Promise<unknown>` from `callTool`, which `MountBrowserAppOptions['operations']` rejects. Typed via `MountBrowserAppOptions` (public `agent-bundle/test/browser` export) so it stays in step with the helper. |
| Docs/README mention the new step | `examples/mcp-app/README.md`, `website/docs/{en,zh}/examples/mcp-app.mdx` | `pnpm check` description and the non-interactive command list now include `pnpm typecheck`. |

## Verification

- `examples/mcp-app`: `pnpm typecheck` clean; `pnpm check` (validate + build + typecheck) passes; `pnpm test:browser-app` 4/4; `agent-bundle eval --case status-is-healthy --trials 1` 1 passed.
- Repo: `packages/agent-bundle/tests/examples-contract.test.ts` + `examples-check-script.test.ts` — 6 passed, 0 failed.
- Root `pnpm typecheck` and `pnpm lint` clean (0 errors, 1151 files).
- `pnpm docs:site:build` passes (dead-link + language parity) for the two `mcp-app.mdx` edits.

## Changeset

None: only `examples/*` and `website/` (private, ignored by the changeset config), as in #471.

## Review status

Merged under the maintainer's relaxation for the `Release gates` / `release-audit.test.ts` failure (npm advisories endpoint, red on `main`, being removed in #487) if that is the only red check.
