### PR TITLE
refactor(build): align Rsbuild integration with official plugin patterns

### DIFF
--- a/.changeset/build-official-plugin-patterns.md
+++ b/.changeset/build-official-plugin-patterns.md
@@ -2,4 +2,4 @@
 'agent-bundle': patch
 ---
 
-Register the package build's `__filename`/`__dirname` ESM shim through Rsbuild's `processAssets` plugin hook instead of a hand-rolled Rspack plugin class inside `tools.rspack`, matching how Rsbuild's own asset plugins hang post-build rewrites. The emitted `dist/**` is byte-identical; no artifact, config key, or CLI output changes. (#PR)
+Register the package build's `__filename`/`__dirname` ESM shim through Rsbuild's `processAssets` plugin hook instead of a hand-rolled Rspack plugin class inside `tools.rspack`, matching how Rsbuild's own asset plugins hang post-build rewrites. The emitted `dist/**` is byte-identical; no artifact, config key, or CLI output changes. (#510)

--- a/.changeset/build-official-plugin-patterns.md
+++ b/.changeset/build-official-plugin-patterns.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': patch
+---
+
+Register the package build's `__filename`/`__dirname` ESM shim through Rsbuild's `processAssets` plugin hook instead of a hand-rolled Rspack plugin class inside `tools.rspack`, matching how Rsbuild's own asset plugins hang post-build rewrites. The emitted `dist/**` is byte-identical; no artifact, config key, or CLI output changes. (#PR)

--- a/.changeset/build-official-plugin-patterns.md
+++ b/.changeset/build-official-plugin-patterns.md
@@ -1,5 +1,0 @@
----
-'agent-bundle': patch
----
-
-Register the package build's `__filename`/`__dirname` ESM shim through Rsbuild's `processAssets` plugin hook instead of a hand-rolled Rspack plugin class inside `tools.rspack`, matching how Rsbuild's own asset plugins hang post-build rewrites. The emitted `dist/**` is byte-identical; no artifact, config key, or CLI output changes. (#510)

--- a/packages/agent-bundle/rslib.config.ts
+++ b/packages/agent-bundle/rslib.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 
-import { defineConfig, type Rspack, type rspack as RspackInstance } from '@rslib/core';
+import { defineConfig, type RsbuildPlugin } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 import packageManifest from './package.json' with { type: 'json' };
 
@@ -14,23 +14,22 @@ const esmNodeGlobalsShim = [
 /**
  * Prepends the `__filename`/`__dirname` shim to every emitted ESM chunk that
  * still references those CommonJS globals (the bundled TypeScript parser's
- * eager `getNodeSystem()`); every other chunk is left untouched.
+ * eager `getNodeSystem()`); every other chunk is left untouched. Registered
+ * through Rsbuild's `processAssets` hook (the `additions` stage), the way
+ * Rsbuild's own `rsbuild:inline-chunk` and `rsbuild:appIcon` plugins hang
+ * asset rewrites, so no Rspack plugin class or compiler tap is needed.
  */
-const esmNodeGlobalsPlugin = (rspack: typeof RspackInstance): Rspack.RspackPluginInstance => ({
-  apply(compiler: Rspack.Compiler) {
-    compiler.hooks.thisCompilation.tap('agent-bundle:esm-node-globals', (compilation: Rspack.Compilation) => {
-      compilation.hooks.processAssets.tap({
-        name: 'agent-bundle:esm-node-globals',
-        stage: rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
-      }, (assets: Rspack.Assets) => {
-        for (const [name, asset] of Object.entries(assets)) {
-          if (!name.endsWith('.js') || !/\b__(?:filename|dirname)\b/u.test(asset.source().toString())) continue;
-          compilation.updateAsset(name, new rspack.sources.ConcatSource(esmNodeGlobalsShim, asset));
-        }
-      });
+const esmNodeGlobalsPlugin: RsbuildPlugin = {
+  name: 'agent-bundle:esm-node-globals',
+  setup(api) {
+    api.processAssets({ stage: 'additions' }, ({ assets, compilation, sources }) => {
+      for (const [name, asset] of Object.entries(assets)) {
+        if (!name.endsWith('.js') || !/\b__(?:filename|dirname)\b/u.test(asset.source().toString())) continue;
+        compilation.updateAsset(name, new sources.ConcatSource(esmNodeGlobalsShim, asset));
+      }
     });
   },
-});
+};
 
 /**
  * Rslib enables Rspack's persistent build cache by default and keys its
@@ -65,24 +64,27 @@ export default defineConfig({
   ...(buildCacheDirectory === undefined || buildCacheDirectory.length === 0
     ? {}
     : { performance: { buildCache: { cacheDirectory: buildCacheDirectory } } }),
-  // Suggestions stay informational; errors and warnings block publishing.
-  plugins: [pluginPublint({ throwOn: 'warning' })],
+  plugins: [
+    // Suggestions stay informational; errors and warnings block publishing.
+    pluginPublint({ throwOn: 'warning' }),
+    // The bundled TypeScript 5 parser's eager `getNodeSystem()` reads the
+    // CommonJS `__filename`/`__dirname` globals, which the ESM output does
+    // not define and which Rspack's `node-module` rewrite (disabled below)
+    // leaves untouched inside that module. The chunk that carries them gets
+    // a module-scoped shim derived from its own `import.meta.url`
+    // (`process.getBuiltinModule` is Node >= 22.3).
+    esmNodeGlobalsPlugin,
+  ],
   root: import.meta.dirname,
   tools: {
     // The TypeScript 5 parser is bundled (a devDependency, #381) so consumers
     // never receive its `tsc` bin beside their own TypeScript.
-    rspack: (config, { rspack }) => {
+    rspack: (config) => {
       // Its `sys.tryEnableSourceMapsForHost` requires `source-map-support`
       // inside a try/catch for the tsc CLI only; the static route-config
       // extractor never reaches it.
       config.ignoreWarnings = [...(config.ignoreWarnings ?? []), /Can't resolve 'source-map-support'/u];
-      // Its eager `getNodeSystem()` reads the CommonJS `__filename`/`__dirname`
-      // globals, which the ESM output does not define and which Rspack's
-      // `node-module` rewrite leaves untouched inside that module. The chunk
-      // that carries them gets a module-scoped shim derived from its own
-      // `import.meta.url` (`process.getBuiltinModule` is Node >= 22.3).
       config.node = { ...(typeof config.node === 'object' ? config.node : {}), __dirname: false, __filename: false };
-      config.plugins = [...(config.plugins ?? []), esmNodeGlobalsPlugin(rspack)];
     },
   },
   source: {


### PR DESCRIPTION
Source-reading pass over the official/community plugins evaluated in #509 (`rsbuild-plugin-publint`, `rsbuild-plugin-arethetypeswrong`, `@rsbuild/plugin-type-check`, `@rsbuild/plugin-check-syntax`, `rsbuild-plugin-source-build`, `@rsbuild/plugin-react`, `rsbuild-plugin-virtual-module`) plus Rsbuild core's built-in plugins, looking for patterns that make an existing path in `packages/agent-bundle/src/build/**` or the two package `rslib.config.ts` files shorter or clearer with identical output. Scope kept to that; no new abstraction, plugin layer, or option. Each change below is one commit-sized item the maintainer can judge separately.

## Changes

| # | Path | Before → after (code lines, comments excluded) | Pattern borrowed from | Behavior |
| --- | --- | --- | --- | --- |
| 1 | `packages/agent-bundle/rslib.config.ts` — the `__filename`/`__dirname` ESM shim | 17 → 15; nesting 5 → 3 levels; drops the `Rspack`/`rspack` type imports and the engine parameter | `api.processAssets({ stage: 'additions' }, ({ assets, compilation, sources }) => …)` — how Rsbuild's built-in `rsbuild:inline-chunk` and `rsbuild:appIcon` plugins hang asset rewrites, instead of a hand-written Rspack plugin class (`apply → thisCompilation.tap → processAssets.tap({ stage: PROCESS_ASSETS_STAGE_ADDITIONS })`) appended via `tools.rspack`. Rsbuild's implementation of the hook is the same `thisCompilation` + `processAssets.tapPromise({ stage })` tap. | `dist/**` byte-identical (warm and cold cache): `diff -rq` before/after clean; `dist/1178.js` still carries the shim. |

That is the only change that met the bar. `pluginPublint` was already registered the official way, and both `composeEntryLibConfig` and `composeMcpAppsRsbuildConfig` already use `@rsbuild/plugin-react`.

## Considered and left alone (with the reason)

- **Post-build checks onto `onAfterBuild` / `afterEmit`** (`assertNoResidualReservedImports`, `assertSelfContainedViews`; publint/attw use `api.onAfterBuild`, check-syntax uses `compiler.hooks.afterEmit` over `compilation.getAssets()`): the framework's checks deliberately read the *published on-disk bytes* after `rslib.build()` resolves and after `close()`, and wrapping them in a plugin would be a new plugin layer, not a shorter path.
- **Logging through `@rsbuild/core`'s `logger`** (publint/attw/type-check pattern): `src/build/**` prints nothing itself — every failure is a thrown `Error`/`DiagnosticError` that the CLI's diagnostics layer renders, and builds run at `logLevel: 'silent'`/`'error'`. Nothing to move.
- **Option validation**: the official plugins validate nothing beyond TypeScript types; the framework's `tools` shape checks (AB4720–4723) live in `config/validate.ts`, outside this scope, and are the diagnostics the docs promise.
- **`pluginReact({ fastRefresh: false })`** in `rslib.ts`: the plugin only enables refresh in dev mode, so the option is redundant for `build()`, but the file is owned by #503 right now (see below) and the explicit `false` documents intent.
- **Multi-environment handling**: `composeMcpAppsRsbuildConfig` already uses one Rsbuild instance with one environment per view, the shape type-check's `checkedTsconfig`-per-environment logic assumes.

## For the `xref-build-orchestration` worker (#503 touches `rslib.ts`; not edited here)

1. `virtualModulesPluginConstructor` is duplicated verbatim in `src/build/rslib.ts` (Rslib's engine) and `src/build/mcp-apps.ts` (workspace `@rsbuild/core`), differing only in the message text. One helper taking `(rspack, engineName, purpose)` would drop ~10 lines; both call sites keep their own engine object, so the dual-engine rule holds.
2. `enforceInvariants` in `rslib.ts` grows a `DefinePlugin` and a `VirtualModulesPlugin` through `config.plugins = [...(config.plugins ?? []), …]` twice; a single append at the end of the mutator is one statement.

## Verification

- `pnpm typecheck`, `pnpm lint`: clean.
- `packages/agent-bundle/dist` before vs after: `diff -rq` reports no differences, with the default warm Rspack cache and with a fresh `AGENT_BUNDLE_RSLIB_CACHE_DIRECTORY`.
- `artifact/**` for `examples/audiobook-curator` and `examples/host-test`: unchanged by construction — no `src/build/**` file changes in this PR and the package `dist` they build with is byte-identical.

## Review status

Codex reviewed `5a3cb01` (PR opened). One thread, addressed in-branch rather than by reply (this PR posts no comments):

- `.changeset/build-official-plugin-patterns.md` — "implementation-only summary": agreed; there is no user-facing change to describe (byte-identical `dist/**`, no command, export, or config key). The changeset is removed and the PR carries the `skip-changeset` label, the AGENTS.md escape hatch for genuinely no-op changes.

Last Codex-reviewed head: `5a3cb01`. Unreviewed heads (no re-review arrived after the pushes; this PR posts no comments): the changeset-number commit, the rebase over #507, and the changeset removal — current head `76877346d`. Merged on green CI per the AGENTS.md fallback; any thread opened afterwards is answered in a follow-up PR.
