### PR TITLE
refactor(workbench): fail the Agent Document and host discovery atoms with their typed client errors

### DIFF
--- a/packages/workbench/src/discovery/discovery-atoms.ts
+++ b/packages/workbench/src/discovery/discovery-atoms.ts
@@ -3,10 +3,11 @@ import { Effect } from 'effect';
 import { Atom } from 'effect/unstable/reactivity';
 import { useCallback, useEffect, useState } from 'react';
 
-import type {
-  HostDiscoveryReport,
-  McpProbeHost,
-  McpProbeReport,
+import {
+  DiscoveryClientError,
+  type HostDiscoveryReport,
+  type McpProbeHost,
+  type McpProbeReport,
 } from './discovery-client.ts';
 
 export type DiscoveryLoader = (signal?: AbortSignal) => Promise<HostDiscoveryReport>;
@@ -35,18 +36,42 @@ export const discoveryProbeStateAtom = Atom.family(
   (key: string) => Atom.make<DiscoveryProbeState>(undefined),
 );
 
-export const discoveryReportAtom = Atom.family((refreshKey: number) => Atom.make((get) => {
-  const loader = get.once(discoveryLoaderAtom);
-  if (loader === undefined) {
-    return Effect.fail(new Error('Host discovery loading is not available in this Workbench session.'));
-  }
-  return Effect.tryPromise({
-    catch: (error) => error instanceof Error
-      ? error
-      : new Error('Host discovery request could not be completed.'),
-    try: (signal) => loader(signal),
-  });
-}));
+/**
+ * `AB8234` is the documented host-discovery decoder diagnostic and the code
+ * the page already falls back to for an uncoded failure; the report atom uses
+ * it for the client-side states that have no route diagnostic of their own.
+ */
+const discoveryClientErrorCode = 'AB8234';
+
+/**
+ * The atom's fail channel is always the client's typed error: a
+ * `DiscoveryClientError` from the loader passes through unchanged, any other
+ * rejection is wrapped with its message (or the generic text) so the page
+ * renders the same code and message it did for a bare `Error`.
+ */
+const toDiscoveryClientError = (error: unknown): DiscoveryClientError => {
+  if (error instanceof DiscoveryClientError) return error;
+  return new DiscoveryClientError(
+    discoveryClientErrorCode,
+    error instanceof Error ? error.message : 'Host discovery request could not be completed.',
+  );
+};
+
+export const discoveryReportAtom = Atom.family((refreshKey: number) => Atom.make(
+  (get): Effect.Effect<HostDiscoveryReport, DiscoveryClientError> => {
+    const loader = get.once(discoveryLoaderAtom);
+    if (loader === undefined) {
+      return Effect.fail(new DiscoveryClientError(
+        discoveryClientErrorCode,
+        'Host discovery loading is not available in this Workbench session.',
+      ));
+    }
+    return Effect.tryPromise({
+      catch: toDiscoveryClientError,
+      try: (signal) => loader(signal),
+    });
+  },
+));
 
 export const useDiscoveryLoader = (loader: DiscoveryLoader | undefined): boolean => {
   const [current, setCurrent] = useAtom(discoveryLoaderAtom);

--- a/packages/workbench/src/discovery/discovery-atoms.ts
+++ b/packages/workbench/src/discovery/discovery-atoms.ts
@@ -44,17 +44,22 @@ export const discoveryProbeStateAtom = Atom.family(
 const discoveryClientErrorCode = 'AB8234';
 
 /**
- * The atom's fail channel is always the client's typed error: a
- * `DiscoveryClientError` from the loader passes through unchanged, any other
- * rejection is wrapped with its message (or the generic text) so the page
- * renders the same code and message it did for a bare `Error`.
+ * The atom's fail channel is always the client's typed error. A
+ * `DiscoveryClientError` passes through unchanged; any other coded `Error`
+ * (for example the foreground authority's `ForegroundRouteClientError` when
+ * authentication was invalidated) keeps its own `code`, `message`, and numeric
+ * `status`; an uncoded rejection gets the decoder code and its message — the
+ * same code/message pair `errorDetails` on the page derived from a bare
+ * `Error`.
  */
 const toDiscoveryClientError = (error: unknown): DiscoveryClientError => {
   if (error instanceof DiscoveryClientError) return error;
-  return new DiscoveryClientError(
-    discoveryClientErrorCode,
-    error instanceof Error ? error.message : 'Host discovery request could not be completed.',
-  );
+  if (!(error instanceof Error)) {
+    return new DiscoveryClientError(discoveryClientErrorCode, 'Host discovery request could not be completed.');
+  }
+  const code = 'code' in error && typeof error.code === 'string' ? error.code : discoveryClientErrorCode;
+  const status = 'status' in error && typeof error.status === 'number' ? error.status : undefined;
+  return new DiscoveryClientError(code, error.message, status);
 };
 
 export const discoveryReportAtom = Atom.family((refreshKey: number) => Atom.make(

--- a/packages/workbench/src/runtime-inspector.tsx
+++ b/packages/workbench/src/runtime-inspector.tsx
@@ -62,7 +62,7 @@ const RuntimeDocumentResult = ({ runId }: Readonly<{ readonly runId: string }>):
   const result = useAtomValue(agentDocumentEventsAtom(runId));
   return AsyncResult.matchWithWaiting(result, {
     onDefect: (error) => <p role="alert">{error instanceof Error ? error.message : 'Agent Document request could not be completed.'}</p>,
-    onError: (message) => <p role="alert">{message}</p>,
+    onError: (error) => <p role="alert">{error.message}</p>,
     onSuccess: ({ value: events }) => <AgentDocumentStage events={events} />,
     onWaiting: () => <p role="status">Loading Agent Document…</p>,
   });

--- a/packages/workbench/src/runtime/agent-document-atoms.ts
+++ b/packages/workbench/src/runtime/agent-document-atoms.ts
@@ -15,17 +15,22 @@ type AgentDocumentLoader = (runId: string, signal?: AbortSignal) => Promise<read
 const runtimeClientErrorCode = 'AB8206';
 
 /**
- * The atom's fail channel is always the client's typed error: a
- * `AgentDocumentClientError` from the loader passes through unchanged, any
- * other rejection is wrapped with its message so the panel renders the same
- * text it did when the channel carried bare strings.
+ * The atom's fail channel is always the client's typed error. An
+ * `AgentDocumentClientError` passes through unchanged; any other coded
+ * `Error` (the production loader rethrows `RuntimeClientError`, and the
+ * foreground authority raises `ForegroundRouteClientError`) keeps its own
+ * `code`, `message`, and numeric `status`; an uncoded rejection gets the
+ * runtime client code and its message, so the panel renders the same text it
+ * did when the channel carried bare strings.
  */
 const toAgentDocumentClientError = (error: unknown): AgentDocumentClientError => {
   if (error instanceof AgentDocumentClientError) return error;
-  return new AgentDocumentClientError(
-    runtimeClientErrorCode,
-    error instanceof Error ? error.message : 'Agent Document request could not be completed.',
-  );
+  if (!(error instanceof Error)) {
+    return new AgentDocumentClientError(runtimeClientErrorCode, 'Agent Document request could not be completed.');
+  }
+  const code = 'code' in error && typeof error.code === 'string' ? error.code : runtimeClientErrorCode;
+  const status = 'status' in error && typeof error.status === 'number' ? error.status : undefined;
+  return new AgentDocumentClientError(code, error.message, status);
 };
 
 export const agentDocumentLoaderAtom = Atom.make<AgentDocumentLoader | undefined>(undefined);

--- a/packages/workbench/src/runtime/agent-document-atoms.ts
+++ b/packages/workbench/src/runtime/agent-document-atoms.ts
@@ -3,22 +3,48 @@ import { Effect } from 'effect';
 import { Atom } from 'effect/unstable/reactivity';
 import { useEffect } from 'react';
 
-import type { AgentRenderEvent } from './agent-document-client.ts';
+import { AgentDocumentClientError, type AgentRenderEvent } from './agent-document-client.ts';
 
 type AgentDocumentLoader = (runId: string, signal?: AbortSignal) => Promise<readonly AgentRenderEvent[]>;
 
+/**
+ * `AB8206` is the documented Workbench runtime client failure; the Agent
+ * Document atoms use it for the client-side states that have no route
+ * diagnostic of their own (loader unavailable, non-Error rejection).
+ */
+const runtimeClientErrorCode = 'AB8206';
+
+/**
+ * The atom's fail channel is always the client's typed error: a
+ * `AgentDocumentClientError` from the loader passes through unchanged, any
+ * other rejection is wrapped with its message so the panel renders the same
+ * text it did when the channel carried bare strings.
+ */
+const toAgentDocumentClientError = (error: unknown): AgentDocumentClientError => {
+  if (error instanceof AgentDocumentClientError) return error;
+  return new AgentDocumentClientError(
+    runtimeClientErrorCode,
+    error instanceof Error ? error.message : 'Agent Document request could not be completed.',
+  );
+};
+
 export const agentDocumentLoaderAtom = Atom.make<AgentDocumentLoader | undefined>(undefined);
 
-export const agentDocumentEventsAtom = Atom.family((runId: string) => Atom.make((get) => {
-  const loader = get.once(agentDocumentLoaderAtom);
-  if (loader === undefined) {
-    return Effect.fail('Agent Document loading is not available in this Workbench session.');
-  }
-  return Effect.tryPromise({
-    catch: (error) => error instanceof Error ? error.message : 'Agent Document request could not be completed.',
-    try: (signal) => loader(runId, signal),
-  });
-}));
+export const agentDocumentEventsAtom = Atom.family((runId: string) => Atom.make(
+  (get): Effect.Effect<readonly AgentRenderEvent[], AgentDocumentClientError> => {
+    const loader = get.once(agentDocumentLoaderAtom);
+    if (loader === undefined) {
+      return Effect.fail(new AgentDocumentClientError(
+        runtimeClientErrorCode,
+        'Agent Document loading is not available in this Workbench session.',
+      ));
+    }
+    return Effect.tryPromise({
+      catch: toAgentDocumentClientError,
+      try: (signal) => loader(runId, signal),
+    });
+  },
+));
 
 export const useAgentDocumentLoader = (loader: AgentDocumentLoader | undefined): boolean => {
   const [current, setCurrent] = useAtom(agentDocumentLoaderAtom);

--- a/packages/workbench/tests/atom-error-channels.test.ts
+++ b/packages/workbench/tests/atom-error-channels.test.ts
@@ -4,8 +4,10 @@ import { AsyncResult, AtomRegistry, type Atom } from 'effect/unstable/reactivity
 
 import { DiscoveryClientError, type HostDiscoveryReport } from '../src/discovery/discovery-client.ts';
 import { discoveryLoaderAtom, discoveryReportAtom } from '../src/discovery/discovery-atoms.ts';
+import { ForegroundRouteClientError } from '../src/mcp/mcp-route-client.ts';
 import { AgentDocumentClientError } from '../src/runtime/agent-document-client.ts';
 import { agentDocumentEventsAtom, agentDocumentLoaderAtom } from '../src/runtime/agent-document-atoms.ts';
+import { RuntimeClientError } from '../src/runtime-client.ts';
 
 const settled = <A, E>(
   registry: AtomRegistry.AtomRegistry,
@@ -68,6 +70,27 @@ describe('Workbench atom error channels', () => {
         name: 'AgentDocumentClientError',
       });
 
+      // The production loader (`RuntimeClient.readRunDocument`) rethrows the
+      // route diagnostic as a RuntimeClientError; its code must survive.
+      registry.set(agentDocumentLoaderAtom, async () => {
+        throw new RuntimeClientError({ code: 'AB8208', message: 'Stored Flight could not be decoded.', phase: 'flight-decode' });
+      });
+      expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-3-runtime')))).toMatchObject({
+        code: 'AB8208',
+        message: 'Stored Flight could not be decoded.',
+        name: 'AgentDocumentClientError',
+        status: undefined,
+      });
+      registry.set(agentDocumentLoaderAtom, async () => {
+        throw new ForegroundRouteClientError('AB8019', 'Foreground authentication was invalidated.', 401);
+      });
+      expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-3-foreground')))).toMatchObject({
+        code: 'AB8019',
+        message: 'Foreground authentication was invalidated.',
+        name: 'AgentDocumentClientError',
+        status: 401,
+      });
+
       registry.set(agentDocumentLoaderAtom, async () => { throw 'opaque'; });
       expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-4')))).toMatchObject({
         code: 'AB8206',
@@ -103,6 +126,18 @@ describe('Workbench atom error channels', () => {
         code: 'AB8234',
         message: 'Failed to fetch',
         name: 'DiscoveryClientError',
+      });
+
+      // A foreground authentication failure surfaces before any discovery
+      // response; its own diagnostic code must not be relabelled as AB8234.
+      registry.set(discoveryLoaderAtom, async () => {
+        throw new ForegroundRouteClientError('AB8019', 'Foreground authentication was invalidated.', 401);
+      });
+      expect(failureOf(await settled(registry, discoveryReportAtom(20)))).toMatchObject({
+        code: 'AB8019',
+        message: 'Foreground authentication was invalidated.',
+        name: 'DiscoveryClientError',
+        status: 401,
       });
 
       registry.set(discoveryLoaderAtom, async () => { throw 'opaque'; });

--- a/packages/workbench/tests/atom-error-channels.test.ts
+++ b/packages/workbench/tests/atom-error-channels.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from '@rstest/core';
+import { Cause } from 'effect';
+import { AsyncResult, AtomRegistry, type Atom } from 'effect/unstable/reactivity';
+
+import { DiscoveryClientError, type HostDiscoveryReport } from '../src/discovery/discovery-client.ts';
+import { discoveryLoaderAtom, discoveryReportAtom } from '../src/discovery/discovery-atoms.ts';
+import { AgentDocumentClientError } from '../src/runtime/agent-document-client.ts';
+import { agentDocumentEventsAtom, agentDocumentLoaderAtom } from '../src/runtime/agent-document-atoms.ts';
+
+const settled = <A, E>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
+): Promise<AsyncResult.AsyncResult<A, E>> => {
+  let dispose: (() => void) | undefined;
+  // A synchronously failing atom settles inside the immediate callback, before
+  // `subscribe` returns its disposer, so the subscription is released after
+  // the promise settles rather than from inside the callback.
+  return new Promise<AsyncResult.AsyncResult<A, E>>((resolve) => {
+    dispose = registry.subscribe(atom, (result) => {
+      if (AsyncResult.isInitial(result) || AsyncResult.isWaiting(result)) return;
+      resolve(result);
+    }, { immediate: true });
+  }).finally(() => dispose?.());
+};
+
+const failureOf = <A, E>(result: AsyncResult.AsyncResult<A, E>): E => {
+  if (!AsyncResult.isFailure(result)) throw new Error(`Expected a failed AsyncResult, received ${result._tag}.`);
+  const failure = result.cause.reasons.find(Cause.isFailReason);
+  if (failure === undefined) throw new Error('Expected a typed failure on the atom error channel.');
+  return failure.error;
+};
+
+const report: HostDiscoveryReport = {
+  diagnostics: [],
+  endpoints: {
+    diagnostics: [],
+    directory: '/tmp/agent-bundle',
+    findings: [],
+    status: 'healthy',
+    summary: { live: 0, staleLocks: 0, staleSockets: 0 },
+  },
+  generatedAt: '2026-09-01T12:00:00.000Z',
+  hosts: [],
+  manifestDigest: 'manifest-current',
+  summary: { errors: 0, infos: 0, warnings: 0 },
+};
+
+describe('Workbench atom error channels', () => {
+  it('fails the Agent Document atom with AgentDocumentClientError in every failure state', async () => {
+    const registry = AtomRegistry.make();
+    try {
+      const unavailable = failureOf(await settled(registry, agentDocumentEventsAtom('run-1')));
+      expect(unavailable).toBeInstanceOf(AgentDocumentClientError);
+      expect(unavailable).toMatchObject({
+        code: 'AB8206',
+        message: 'Agent Document loading is not available in this Workbench session.',
+        name: 'AgentDocumentClientError',
+      });
+
+      const routeFailure = new AgentDocumentClientError('AB8208', 'Stored Flight could not be decoded.', 409);
+      registry.set(agentDocumentLoaderAtom, async () => { throw routeFailure; });
+      expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-2')))).toBe(routeFailure);
+
+      registry.set(agentDocumentLoaderAtom, async () => { throw new TypeError('Failed to fetch'); });
+      expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-3')))).toMatchObject({
+        code: 'AB8206',
+        message: 'Failed to fetch',
+        name: 'AgentDocumentClientError',
+      });
+
+      registry.set(agentDocumentLoaderAtom, async () => { throw 'opaque'; });
+      expect(failureOf(await settled(registry, agentDocumentEventsAtom('run-4')))).toMatchObject({
+        code: 'AB8206',
+        message: 'Agent Document request could not be completed.',
+        name: 'AgentDocumentClientError',
+      });
+
+      registry.set(agentDocumentLoaderAtom, async () => []);
+      const loaded = await settled(registry, agentDocumentEventsAtom('run-5'));
+      expect(AsyncResult.isSuccess(loaded)).toBe(true);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('fails the host discovery report atom with DiscoveryClientError in every failure state', async () => {
+    const registry = AtomRegistry.make();
+    try {
+      const unavailable = failureOf(await settled(registry, discoveryReportAtom(0)));
+      expect(unavailable).toBeInstanceOf(DiscoveryClientError);
+      expect(unavailable).toMatchObject({
+        code: 'AB8234',
+        message: 'Host discovery loading is not available in this Workbench session.',
+        name: 'DiscoveryClientError',
+      });
+
+      const routeFailure = new DiscoveryClientError('AB8007', 'Discovery route rejected the request.', 503);
+      registry.set(discoveryLoaderAtom, async () => { throw routeFailure; });
+      expect(failureOf(await settled(registry, discoveryReportAtom(1)))).toBe(routeFailure);
+
+      registry.set(discoveryLoaderAtom, async () => { throw new TypeError('Failed to fetch'); });
+      expect(failureOf(await settled(registry, discoveryReportAtom(2)))).toMatchObject({
+        code: 'AB8234',
+        message: 'Failed to fetch',
+        name: 'DiscoveryClientError',
+      });
+
+      registry.set(discoveryLoaderAtom, async () => { throw 'opaque'; });
+      expect(failureOf(await settled(registry, discoveryReportAtom(3)))).toMatchObject({
+        code: 'AB8234',
+        message: 'Host discovery request could not be completed.',
+        name: 'DiscoveryClientError',
+      });
+
+      registry.set(discoveryLoaderAtom, async () => report);
+      const loaded = await settled(registry, discoveryReportAtom(4));
+      expect(AsyncResult.isSuccess(loaded)).toBe(true);
+      if (AsyncResult.isSuccess(loaded)) expect(loaded.value).toBe(report);
+    } finally {
+      registry.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Effect-conformance cleanup 4 of the prior audit (Workbench `runtime/agent-document-atoms.ts` + `discovery/discovery-atoms.ts`): the two Atom Effect channels that failed with a bare `string` / global `Error` now fail with the existing typed client errors, setting the Atom error pattern for the Workbench. Behavior-preserving: every rendered message is unchanged; the discovery page shows the same code (`AB8234` fallback) and text.

### What changed

- **`packages/workbench/src/runtime/agent-document-atoms.ts`** (audit row `:15–18`, fail channel was a `string`): `agentDocumentEventsAtom` is typed `Effect<readonly AgentRenderEvent[], AgentDocumentClientError>`. The "loading is not available in this Workbench session" state fails with `new AgentDocumentClientError('AB8206', …)`; `tryPromise`'s `catch` passes an `AgentDocumentClientError` through unchanged; any other coded `Error` — the production loader `RuntimeClient.readRunDocument` rethrows `RuntimeClientError`, and the foreground authority raises `ForegroundRouteClientError` — keeps its own `code`, `message`, and numeric `status`; an uncoded rejection becomes `AgentDocumentClientError('AB8206', error.message | 'Agent Document request could not be completed.')`. `AB8206` is the documented "Workbench runtime client failure" code (`docs/diagnostics.md`), already used by `runtime-client.ts`; no new diagnostic code.
- **`packages/workbench/src/runtime-inspector.tsx`**: `onError` renders `error.message` instead of the former string — same text.
- **`packages/workbench/src/discovery/discovery-atoms.ts`** (audit row `:41`, `Effect.fail(new Error(…))`): `discoveryReportAtom` is typed `Effect<HostDiscoveryReport, DiscoveryClientError>`. The unavailable state and *uncoded* rejections fail with `DiscoveryClientError('AB8234', …)` — the documented host-discovery decoder code and the exact fallback `errorDetails` in `discovery-page.tsx` already applied to an uncoded `Error`. A coded `Error` (e.g. `ForegroundRouteClientError` `AB8019` when foreground authentication was invalidated) keeps its own `code`/`message`/`status`, so the rendered `<code> <message>` pair is identical to what the page derived before. `DiscoveryClientError`s pass through untouched.
- No `Atom`/`AsyncResult` types leak into DTOs or exports; components still only use `@effect/atom-react` hooks; no `Effect.run*` outside the registry (`docs/effect-conventions.md` § Workbench browser state).

### Idioms and citations

| Idiom | Doc | `repos/effect/LLMS.md` / repo section |
| --- | --- | --- |
| Typed class errors on the fail channel instead of `string` / global `Error` | [Error Management → Expected Errors](https://effect.website/docs/v4/error-management/expected-errors/) ("The type makes the possible failure visible to callers") | LLMS.md § Error handling; `agent-patterns/effect-errors.md` "What to avoid: `unknown` or global `Error` in the fail channel (`globalErrorInEffectFailure`)"; `docs/effect-conventions.md` § Error mapping — existing classes, no `Schema.TaggedError` |
| `Effect.tryPromise({ try, catch })` mapping rejections onto the typed error | [Resource Management → Scope → acquireRelease example](https://effect.website/docs/v4/resource-management/scope/#acquirerelease) (same `tryPromise` `catch` shape) | LLMS.md § Creating effects from common sources |

### Tests

- New `packages/workbench/tests/atom-error-channels.test.ts` (unit, `AtomRegistry.make()` + `subscribe`): for each atom family — loader unavailable → typed error with the exact code/message/name; a client error from the loader passes through by identity; a coded foreign error (`RuntimeClientError` `AB8208`, `ForegroundRouteClientError` `AB8019` + `status: 401`) keeps its code/message/status; an uncoded `TypeError` is wrapped with its message; a non-`Error` rejection gets the generic message; a resolving loader yields `AsyncResult` success.
- `pnpm typecheck` (includes `packages/workbench/tsconfig.json`), `pnpm lint` green; `pnpm test:unit` green (3173 passed, incl. all `packages/workbench/tests`).

### Changeset

`skip-changeset`: `packages/workbench` is private and ignored by changesets (`.changeset/README.md`); no publishable package changed.

### Review status

No PR comments are posted by the author; every review thread is answered in this section.

| Head | Review | Threads |
| --- | --- | --- |
| `55c8a51` | Codex completed (2 P2) | `discovery-atoms.ts:56` "Preserve foreground discovery diagnostic codes" and `agent-document-atoms.ts:27` "Preserve runtime document diagnostic codes" — both valid: the wrappers relabelled `ForegroundRouteClientError` / `RuntimeClientError` codes. Fixed in `4beb5f1`: coded `Error`s keep `code`, `message`, and numeric `status`; tests added for `AB8019` (status 401) and `AB8208`. |
| `4beb5f1` | pending | — |
