### PR TITLE
refactor(effect): name the lift's rejection channel; fold boundary settlements without an unknown failure

### DIFF
--- a/packages/agent-bundle/src/effect/lift.ts
+++ b/packages/agent-bundle/src/effect/lift.ts
@@ -1,15 +1,38 @@
 import { Effect } from 'effect';
 
 /**
- * Lifts for the dev seam's existing Promise/sync helpers. Both keep the
- * thrown/rejected value untouched in the error channel — the dev seam's
+ * Lifts for the dev seam's existing Promise/sync helpers (Stage 3). Both keep
+ * the thrown/rejected value untouched in the error channel — the dev seam's
  * typed contracts are plain `Error` subclasses that must cross
  * `src/effect/boundary.ts` identity-preserved, and several call sites
  * re-raise non-Error values (for example an `AbortSignal.reason`) verbatim.
+ *
+ * A bare `Effect.tryPromise(fn)` would wrap every rejection in
+ * `Cause.UnknownError`; these helpers are the only sanctioned way to lift a
+ * leaf helper (`docs/effect-conventions.md` § Stage 3 "Hurt / gotchas").
  */
 
-export const liftPromise = <A>(evaluate: () => PromiseLike<A>): Effect.Effect<A, unknown> =>
-  Effect.tryPromise({ catch: (error) => error, try: evaluate });
+/**
+ * The raw value a lifted helper threw or rejected with. It is `unknown` by
+ * contract — the lift is an identity, not a normalizer — so callers narrow it
+ * where they know the helper's failure contract (`instanceof`, `isErrno`,
+ * `Effect.mapError` into a typed dev error) instead of assuming a shape. The
+ * boundary maps whatever reaches it: typed dev errors and `Error`s rethrow
+ * as-is, other values are wrapped, interruption becomes `AbortError`.
+ */
+export type LiftedRejection = unknown;
 
-export const liftTry = <A>(evaluate: () => A): Effect.Effect<A, unknown> =>
-  Effect.try({ catch: (error) => error, try: evaluate });
+/**
+ * Lift a Promise-returning leaf helper. `evaluate` receives Effect's
+ * interruption `AbortSignal` (aborted when the fiber is interrupted), so a
+ * cancellable API can be passed the signal directly; thunks that ignore it
+ * keep working unchanged.
+ */
+export const liftPromise = <A>(
+  evaluate: (signal: AbortSignal) => PromiseLike<A>,
+): Effect.Effect<A, LiftedRejection> =>
+  Effect.tryPromise({ catch: (error): LiftedRejection => error, try: evaluate });
+
+/** Lift a synchronous leaf helper; a throw becomes a typed failure carrying the thrown value. */
+export const liftTry = <A>(evaluate: () => A): Effect.Effect<A, LiftedRejection> =>
+  Effect.try({ catch: (error): LiftedRejection => error, try: evaluate });

--- a/packages/agent-bundle/tests/effect-boundary.test.ts
+++ b/packages/agent-bundle/tests/effect-boundary.test.ts
@@ -18,6 +18,7 @@ import {
   runSync,
   toDevError,
 } from '../src/effect/boundary.ts';
+import { liftPromise, liftTry } from '../src/effect/lift.ts';
 import * as rootApi from '../src/index.ts';
 
 describe('effect boundary (agent-bundle dev seam)', () => {
@@ -88,5 +89,43 @@ describe('effect boundary (agent-bundle dev seam)', () => {
     });
     await expect(Promise.race([pending, hung])).rejects.toSatisfy(isAbortError);
     await expect(runPromise(abortToInterrupt(controller.signal))).rejects.toSatisfy(isAbortError);
+  });
+});
+
+describe('effect lifts (src/effect/lift.ts)', () => {
+  it('keeps the rejected or thrown value identity-preserved on the fail channel', async () => {
+    const typed = new EpochStoreError('EPOCH_NOT_FOUND', 'Epoch "e1" does not exist.');
+    const reason = { code: 'ECUSTOM', message: 'not an Error' };
+    const rejected = await runPromiseExit(liftPromise(() => Promise.reject(typed)));
+    expect(Exit.isFailure(rejected) && Cause.squash(rejected.cause)).toBe(typed);
+    const rawReason = await runPromiseExit(liftPromise(() => Promise.reject(reason)));
+    expect(Exit.isFailure(rawReason) && Cause.squash(rawReason.cause)).toBe(reason);
+    const thrown = await runPromiseExit(liftTry((): never => { throw typed; }));
+    expect(Exit.isFailure(thrown) && Cause.squash(thrown.cause)).toBe(typed);
+    expect(runSync(liftTry(() => 7))).toBe(7);
+    // The Promise edge rethrows typed errors as-is and wraps non-Error values,
+    // exactly per the boundary's mapping table — the lift itself never
+    // normalizes, so a caller that must re-raise a raw reason reads the Exit.
+    await expect(runPromise(liftPromise(() => Promise.reject(typed)))).rejects.toBe(typed);
+    await expect(runPromise(liftPromise(() => Promise.reject(reason)))).rejects.toEqual(new Error(String(reason)));
+  });
+
+  it('hands the lifted helper an AbortSignal that aborts when the fiber is interrupted', async () => {
+    const host = new AbortController();
+    let observed: AbortSignal | undefined;
+    const pending = runPromise(
+      liftPromise((signal) => {
+        observed = signal;
+        return new Promise<never>((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      }),
+      { signal: host.signal },
+    );
+    await Promise.resolve();
+    expect(observed?.aborted).toBe(false);
+    host.abort();
+    await expect(pending).rejects.toSatisfy(isAbortError);
+    expect(observed?.aborted).toBe(true);
   });
 });

--- a/packages/rsc-runtime/src/reconciler.ts
+++ b/packages/rsc-runtime/src/reconciler.ts
@@ -285,18 +285,23 @@ type SettledBoundary = {
   readonly ok: boolean;
 };
 
+/**
+ * Waits for the first pending boundary to settle either way. The rejection
+ * reason is data, not a failure to normalize: React rejects a boundary with a
+ * `{ message, digest }` object that `renderErrorFrom` reads, so mapping it
+ * through `toRuntimeError` would erase the digest. Both settlements are folded
+ * inside the promise, which therefore cannot reject and never puts an
+ * `unknown` on the Effect error channel.
+ */
 const waitSettledBoundary = (
   pending: readonly PendingBoundary[],
-): Effect.Effect<SettledBoundary, Error> =>
+): Effect.Effect<SettledBoundary> =>
   Effect.raceAll(
     pending.map((boundary) =>
-      Effect.tryPromise({
-        catch: (error) => error,
-        try: () => Promise.resolve(boundary.thenable),
-      }).pipe(
-        Effect.map(() => ({ boundary, ok: true as const })),
-        Effect.catch((error) => Effect.succeed({ boundary, error, ok: false as const })),
-      ),
+      Effect.promise((): Promise<SettledBoundary> => Promise.resolve(boundary.thenable).then(
+        () => ({ boundary, ok: true as const }),
+        (error: unknown) => ({ boundary, error, ok: false as const }),
+      )),
     ),
   );
 


### PR DESCRIPTION
## Summary

The two "small ones" from the Effect-conformance audit: the reconciler's momentary `unknown` on the fail channel, and the dev seam's identity lift inferring bare `unknown` at every call site. Behavior-preserving: no runtime path changes; every `liftPromise`/`liftTry` call site (82) type-checks unchanged.

### What changed

**`packages/rsc-runtime/src/reconciler.ts:288–300`** (audit row `:293–295`, `Effect.tryPromise({ catch: (error) => error })` → `unknownInEffectCatch`). The audit suggested `catch: toRuntimeError`; that would be a behavior change: a boundary's rejection reason is *data* that `renderErrorFrom` (`:130`) reads — React rejects a boundary thenable with a `{ message, digest }` object, and `toRuntimeError` would turn a non-`Error` object into `new Error('[object Object]')` and lose the digest-derived `code`. Instead `waitSettledBoundary` folds both settlements inside the promise (`Effect.promise(() => thenable.then(ok, (error) => ({ boundary, error, ok: false })))`), so the Effect can never fail and nothing `unknown` ever sits on the error channel — the reason travels as a field of `SettledBoundary`, as before. Return type narrows from `Effect<SettledBoundary, Error>` to `Effect<SettledBoundary>`.

**`packages/agent-bundle/src/effect/lift.ts`** (audit row `:11–15`). The audit proposed typing `E` as `CodedError | DiagnosticError | unknown`; that union collapses to `unknown` and any narrower union would be unsound — the lift is an identity by contract (typed dev errors *and* raw `AbortSignal.reason` values must cross the boundary untouched). So:
- `export type LiftedRejection = unknown` names the channel: hovers and signatures now read `Effect<A, LiftedRejection>` with the doc explaining it is the raw thrown/rejected value that callers narrow (`instanceof`, `isErrno`, `Effect.mapError` into a typed dev error) rather than a shape to assume, and how the boundary maps whatever reaches it.
- `liftPromise`'s `evaluate` is now `(signal: AbortSignal) => PromiseLike<A>` — rc.112's own `Effect.tryPromise` contract (`Effect.ts:969–973`): the signal aborts when the fiber is interrupted, so a cancellable Promise API can take it directly. Zero-arg thunks are unchanged.
- Module doc records why a bare `Effect.tryPromise(fn)` is not used (it wraps rejections in `Cause.UnknownError`).

### Idioms and citations

| Idiom | Doc | `repos/effect/LLMS.md` / repo section |
| --- | --- | --- |
| No `unknown` / global `Error` on the fail channel; a value that is data stays in the success channel | [Error Management → Two Types of Errors](https://effect.website/docs/v4/error-management/two-error-types/), [Expected Errors](https://effect.website/docs/v4/error-management/expected-errors/) | `agent-patterns/effect-errors.md` "What to avoid: `unknown` or global `Error` in the fail channel (`unknownInEffectCatch`)" |
| `Effect.promise` for a promise that cannot reject; `tryPromise`'s `try(signal)` for interruption-aware lifts | [Resource Management → Scope → acquireRelease example](https://effect.website/docs/v4/resource-management/scope/#acquirerelease) (`Effect.promise` release), rc.112 `Effect.promise` / `tryPromise` signatures | LLMS.md § Creating effects from common sources; `docs/effect-conventions.md` Stage 3 "Hurt": "Bare `Effect.tryPromise(fn)` wraps rejections in `Cause.UnknownError`; always route through `src/effect/lift.ts`" |

### Tests

- New in `packages/agent-bundle/tests/effect-boundary.test.ts` (`effect lifts`): rejected typed errors and raw non-`Error` reasons are identity-preserved on the fail channel (`Exit` + `Cause.squash`), thrown values likewise via `liftTry`; the Promise edge rethrows typed errors as-is and wraps a non-`Error` per the mapping table; the lifted helper receives an `AbortSignal` that is not aborted while running and aborts when the host signal interrupts the fiber (`AbortError` at the edge).
- Reconciler: the existing dispatcher boundary-error tests (`emits a represented boundary error and still completes siblings`, `emits a replace or error for every boundary that settled before resnapshot`) cover the fold; all 55 dispatcher/boundary tests green.
- `pnpm typecheck`, `pnpm lint` green; `pnpm test:unit` green (3186 passed).

### Changeset

`skip-changeset`: type-level and internal-structure only; no Promise-side value, message, or export changes.

### Review status

No PR comments are posted by the author; every review thread is answered in this section.

| Head | Review | Threads |
| --- | --- | --- |
| `a9e5459` | Codex completed, no findings | — |
