### PR TITLE
docs(agents): record the protected-main merge policy (no --admin bypass)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,9 @@
   after each push until none remain. Only then merge.
 - PRs are squash-merged. Review threads left on an already-merged PR must
   still be answered, in a follow-up PR.
+- `main` is protected: PRs land only with every required check green and
+  the branch up to date with `main` (`gh pr update-branch`, then
+  `gh pr merge --squash --auto`); never bypass with `--admin`.
 
 ## Vendored repos
 


### PR DESCRIPTION
## Summary

One bullet under "Pull requests" in `AGENTS.md`: `main` is protected (required checks green + branch up to date, land with `gh pr merge --squash --auto`), never bypass with `--admin`.

Follow-up to #536. Also serves as the proof run for the new protection: this PR is merged with `gh pr merge --squash --auto` and must wait for the required checks before landing. Docs-only (`AGENTS.md` is not on the docs site); `skip-changeset`.
