### PR TITLE
chore(deps): ignore TypeScript major updates until TypeDoc and twoslash support TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # typescript@7.0.x is a native compiler: import('typescript') is only
+      # { version, versionMajorMinor }. website/rspress.config.ts,
+      # @rspress/plugin-twoslash@2.0.21 (peer ^6.0.3 -> twoslash@0.3.9 peer
+      # ^5.5.0 || ^6.0.0), and typedoc@0.28.20 (peer 5.0.x–6.0.x;
+      # TypeStrong/typedoc#3098 targets TS 7.1) all need the JS compiler API
+      # and crash on 7.0.2. Root tsc is already 7.0.2; website stays on
+      # 6.0.3. Drop this ignore when TypeDoc and twoslash support TS 7.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     # `/` covers .github/workflows/*; the composite actions under
     # .github/actions/* (where pnpm/setup lives) are separate directories.


### PR DESCRIPTION
## Summary
- Dependabot #606 tried to bump website `typescript` 6.0.3 → 7.0.2. Root `tsc` is already 7.0.2; the remaining pin is the docsite, which imports the TypeScript JS compiler API.
- No released TypeDoc or twoslash can run on `typescript@7.0.2` (`import('typescript')` is only `{ version, versionMajorMinor }`). This ignore stops further major bumps until those tools support TS 7 (TypeDoc is targeting 7.1: TypeStrong/typedoc#3098).
- Tracking: #612. #606 closed in favor of this ignore.

## Test plan
- [x] Ignore applies only to `version-update:semver-major` for `typescript` (6.x and 7.x patches still allowed)
- [ ] CI green (yaml-only; `skip-changeset`)

## Self-review
- Reviewer: change-risk-reviewer (`gpt-5.6-sol-medium`)
- Findings: none
- Disposition: approve after required CI is green. Ignore is scoped to semver-major only; `skip-changeset` is appropriate for a Dependabot config change.