### PR TITLE
docs(website): theme a11y/contrast and git-dated sitemap lastmod (#590 P3s)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,14 @@ jobs:
     # can be repointed at unreviewed code); the trailing comment names the
     # release Dependabot keeps in step.
     steps:
+      # Full history, blobless: `sitemap.xml` `lastmod` comes from
+      # `git log -1 -- <source>` (website/plugins/sitemap-lastmod.ts), which
+      # needs every commit and tree but no old file contents. On a shallow
+      # clone the plugin omits `lastmod` rather than dating every page today.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - uses: ./.github/actions/setup-workspace
         with:
           node-version: 22.19.0

--- a/website/plugins/sitemap-lastmod.ts
+++ b/website/plugins/sitemap-lastmod.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import type { RspressPlugin, UserConfig } from '@rspress/core';
+import { type PluginSitemapOptions, pluginSitemap } from '@rspress/plugin-sitemap';
 
 const API_SOURCE = 'packages/agent-bundle/src';
 const CAPABILITIES_SOURCE = 'packages/agent-bundle/src/adapters/capabilities';
@@ -20,6 +21,8 @@ export interface SitemapLastmodRewriteOptions {
 export interface SitemapLastmodOptions {
   /** Absolute repository root used as the Git working directory. */
   readonly repoRoot: string;
+  /** Passed through to `@rspress/plugin-sitemap`. */
+  readonly sitemap?: PluginSitemapOptions;
 }
 
 function decodeXmlText(value: string): string {
@@ -190,10 +193,22 @@ function sitemapPath(config: UserConfig): string {
   return path.resolve(outDir, 'sitemap.xml');
 }
 
+/**
+ * `@rspress/plugin-sitemap` with `lastmod` taken from git history.
+ *
+ * Rspress runs every plugin's `afterBuild` in parallel
+ * (`PluginDriver._runParallelAsyncHook`), so a second plugin cannot rely on
+ * running after the sitemap has been written. This wraps the sitemap plugin
+ * instead: its own hooks are kept as they are and the rewrite is chained onto
+ * its `afterBuild`, so `sitemap.xml` exists before it is read.
+ */
 export function sitemapLastmod(options: SitemapLastmodOptions): RspressPlugin {
+  const sitemap = pluginSitemap(options.sitemap);
   return {
+    ...sitemap,
     name: 'agent-bundle/sitemap-lastmod',
     async afterBuild(config, isProd) {
+      await sitemap.afterBuild?.(config, isProd);
       if (!isProd || !config.siteOrigin) {
         return;
       }

--- a/website/plugins/sitemap-lastmod.ts
+++ b/website/plugins/sitemap-lastmod.ts
@@ -1,0 +1,213 @@
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import type { RspressPlugin, UserConfig } from '@rspress/core';
+
+const API_SOURCE = 'packages/agent-bundle/src';
+const CAPABILITIES_SOURCE = 'packages/agent-bundle/src/adapters/capabilities';
+const DIAGNOSTICS_SOURCE = 'docs/diagnostics.md';
+const LASTMOD_PATTERN = /<lastmod>[^<]*<\/lastmod>/;
+const LOC_PATTERN = /<loc>([^<]*)<\/loc>/;
+const URL_PATTERN = /<url>[\s\S]*?<\/url>/g;
+
+export interface SitemapLastmodRewriteOptions {
+  readonly base: string;
+  readonly siteOrigin: string;
+  readonly lastmodForRoute: (routePath: string) => string | undefined;
+}
+
+export interface SitemapLastmodOptions {
+  /** Absolute repository root used as the Git working directory. */
+  readonly repoRoot: string;
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+function routeFromLoc(loc: string, siteOrigin: string, base: string): string | undefined {
+  let location: URL;
+  let siteBase: URL;
+  try {
+    location = new URL(decodeXmlText(loc));
+    siteBase = new URL(base, siteOrigin);
+  } catch {
+    return undefined;
+  }
+
+  if (location.origin !== siteBase.origin) {
+    return undefined;
+  }
+
+  const basePath = siteBase.pathname.endsWith('/') ? siteBase.pathname : `${siteBase.pathname}/`;
+  const baseWithoutSlash = basePath.slice(0, -1);
+  let routePath: string;
+  if (location.pathname === baseWithoutSlash || location.pathname === basePath) {
+    routePath = '/';
+  } else if (location.pathname.startsWith(basePath)) {
+    routePath = `/${location.pathname.slice(basePath.length)}`;
+  } else {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(routePath);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Replace only sitemap `lastmod` nodes, leaving every other byte untouched.
+ *
+ * The callback keeps this transformation independent of Git and filesystem
+ * access so it can be exercised directly over emitted sitemap XML.
+ */
+export function rewriteSitemapLastmod(
+  xml: string,
+  options: SitemapLastmodRewriteOptions,
+): string {
+  return xml.replace(URL_PATTERN, urlNode => {
+    const loc = LOC_PATTERN.exec(urlNode)?.[1];
+    const routePath =
+      loc === undefined ? undefined : routeFromLoc(loc, options.siteOrigin, options.base);
+    const lastmod =
+      routePath === undefined ? undefined : options.lastmodForRoute(routePath);
+
+    if (lastmod === undefined) {
+      return urlNode.replace(LASTMOD_PATTERN, '');
+    }
+
+    const lastmodNode = `<lastmod>${lastmod}</lastmod>`;
+    return LASTMOD_PATTERN.test(urlNode)
+      ? urlNode.replace(LASTMOD_PATTERN, lastmodNode)
+      : urlNode.replace('</loc>', `</loc>${lastmodNode}`);
+  });
+}
+
+function sourcePathForRoute(
+  routePath: string,
+  repoRoot: string,
+): string | undefined {
+  const normalized = routePath.replace(/^\/+|\/+$/g, '');
+  const isChinese = normalized === 'zh' || normalized.startsWith('zh/');
+  const locale = isChinese ? 'zh' : 'en';
+  const relativeRoute = isChinese
+    ? normalized.slice('zh'.length).replace(/^\/+/, '')
+    : normalized;
+
+  if (relativeRoute === 'api' || relativeRoute.startsWith('api/')) {
+    return API_SOURCE;
+  }
+  if (
+    relativeRoute === 'reference/hosts' ||
+    relativeRoute === 'reference/events' ||
+    relativeRoute === 'reference/notices'
+  ) {
+    return CAPABILITIES_SOURCE;
+  }
+  if (relativeRoute === 'reference/diagnostics') {
+    return DIAGNOSTICS_SOURCE;
+  }
+
+  const routeSegments = relativeRoute === '' ? [] : relativeRoute.split('/');
+  if (routeSegments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    return undefined;
+  }
+
+  const sourceStem = path.posix.join('website', 'docs', locale, ...routeSegments);
+  const candidates = [
+    `${sourceStem}.mdx`,
+    `${sourceStem}.md`,
+    path.posix.join(sourceStem, 'index.mdx'),
+    path.posix.join(sourceStem, 'index.md'),
+  ];
+  return candidates.find(candidate => existsSync(path.join(repoRoot, ...candidate.split('/'))));
+}
+
+function isShallowRepository(repoRoot: string): boolean | undefined {
+  try {
+    return (
+      execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      }).trim() === 'true'
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function createGitLastmodResolver(
+  repoRoot: string,
+): (routePath: string) => string | undefined {
+  const shallow = isShallowRepository(repoRoot);
+  const cache = new Map<string, string | undefined>();
+
+  if (shallow !== false) {
+    return () => undefined;
+  }
+
+  return routePath => {
+    const sourcePath = sourcePathForRoute(routePath, repoRoot);
+    if (sourcePath === undefined) {
+      return undefined;
+    }
+    if (cache.has(sourcePath)) {
+      return cache.get(sourcePath);
+    }
+
+    let lastmod: string | undefined;
+    try {
+      const value = execFileSync(
+        'git',
+        ['log', '-1', '--format=%cI', '--', sourcePath],
+        { cwd: repoRoot, encoding: 'utf8' },
+      ).trim();
+      if (value !== '' && !Number.isNaN(Date.parse(value))) {
+        lastmod = value;
+      }
+    } catch {
+      lastmod = undefined;
+    }
+    cache.set(sourcePath, lastmod);
+    return lastmod;
+  };
+}
+
+function sitemapPath(config: UserConfig): string {
+  const distPath =
+    typeof config.builderConfig?.output?.distPath === 'string'
+      ? config.builderConfig.output.distPath
+      : config.builderConfig?.output?.distPath?.root;
+  const outDir = config.outDir || distPath || 'doc_build';
+  return path.resolve(outDir, 'sitemap.xml');
+}
+
+export function sitemapLastmod(options: SitemapLastmodOptions): RspressPlugin {
+  return {
+    name: 'agent-bundle/sitemap-lastmod',
+    async afterBuild(config, isProd) {
+      if (!isProd || !config.siteOrigin) {
+        return;
+      }
+
+      const outputPath = sitemapPath(config);
+      const xml = await readFile(outputPath, 'utf8');
+      const rewritten = rewriteSitemapLastmod(xml, {
+        base: config.base ?? '/',
+        siteOrigin: config.siteOrigin,
+        lastmodForRoute: createGitLastmodResolver(options.repoRoot),
+      });
+      if (rewritten !== xml) {
+        await writeFile(outputPath, rewritten, 'utf8');
+      }
+    },
+  };
+}

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -96,8 +96,8 @@ const siteDescription =
   'Compile skills, hooks, MCP servers, and scripts from one typed config into installable Claude Code, Codex, and Cursor artifacts.';
 const siteDescriptionZh =
   '用一份带类型的配置描述 Skill、钩子、MCP 服务器与脚本，编译为可直接安装到 Claude Code、Codex 与 Cursor 的产物。';
-/** `--rp-c-brand` in `styles/index.css`. */
-const brandColor = '#0d8f80';
+/** `--rp-c-brand` in `styles/index.css` (light theme; 4.83:1 on white). */
+const brandColor = '#0b8072';
 
 /**
  * `llms.txt` and `llms-full.txt` are emitted as build assets rather than

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { defineConfig } from '@rspress/core';
 import { pluginLlms } from '@rspress/plugin-llms';
-import { pluginSitemap } from '@rspress/plugin-sitemap';
 import { pluginTwoslash } from '@rspress/plugin-twoslash';
 import { pluginTypeDoc } from '@rspress/plugin-typedoc';
 import { transformerNotationHighlight } from '@shikijs/transformers';
@@ -259,7 +258,6 @@ export default defineConfig({
         exclude: ({ page }) => page.routePath.includes('/api/'),
       },
     ]),
-    pluginSitemap(),
     sitemapLastmod({ repoRoot }),
   ],
 });

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -9,6 +9,7 @@ import ts from 'typescript';
 import { generatedReference } from './plugins/generated-reference.ts';
 import { cleanGeneratedApiMarkdown, mirrorApiLocale } from './plugins/mirror-api-locale.ts';
 import { rehypeTableCellBreaks } from './plugins/rehype-table-cell-breaks.ts';
+import { sitemapLastmod } from './plugins/sitemap-lastmod.ts';
 
 const websiteDir = import.meta.dirname;
 const docsDir = path.join(websiteDir, 'docs');
@@ -259,5 +260,6 @@ export default defineConfig({
       },
     ]),
     pluginSitemap(),
+    sitemapLastmod({ repoRoot }),
   ],
 });

--- a/website/scripts/check-built-links.mjs
+++ b/website/scripts/check-built-links.mjs
@@ -129,6 +129,17 @@ const main = () => {
       if (!idsOf(target).has(fragment)) report(`no id="${fragment}" in ${path.relative(options.dir, target)}`);
     }
   }
+  // Sitemap `lastmod` (plugins/sitemap-lastmod.ts) comes from git history, or is
+  // omitted on a shallow clone. Whatever is present must parse, must not be in
+  // the future, and — the regression this guards — must not all be the same
+  // instant, which is what the source-mtime default produced in CI.
+  const sitemap = files.find(file => file.endsWith('sitemap.xml'));
+  if (sitemap) {
+    const stamps = [...fs.readFileSync(sitemap, 'utf8').matchAll(/<lastmod>([^<]*)<\/lastmod>/g)].map(([, value]) => value);
+    const invalid = stamps.filter(value => Number.isNaN(Date.parse(value)) || Date.parse(value) > Date.now() + 60_000);
+    if (invalid.length > 0) broken.set('sitemap:lastmod', `sitemap.xml — ${invalid.length} unparseable or future <lastmod> (first: ${invalid[0]})`);
+    else if (stamps.length > 10 && new Set(stamps).size < 2) broken.set('sitemap:lastmod', `sitemap.xml — every <lastmod> is ${stamps[0]}; dates are not coming from git history`);
+  }
   for (const line of [...broken.values()].sort()) console.log(line);
   console.log(`${broken.size} broken links / ${anchors} anchors checked (${links} internal links across ${files.length} files under ${options.dir})`);
   if (broken.size > 0) process.exitCode = 1;

--- a/website/styles/index.css
+++ b/website/styles/index.css
@@ -66,10 +66,10 @@
  * way and are corrected alongside it. Each pick keeps the original hue.
  */
 :root:not(.rp-dark) {
-  /* #3c3c3c at 75 %: 5.18:1 on #fff, 5.01:1 on --rp-c-bg-soft, 4.83:1 on --rp-c-bg-mute. */
+  /* #3c3c3c at 75 %: 5.18:1 on #fff, 5.01:1 on --rp-c-bg-soft, 4.86:1 on --rp-c-bg-mute. */
   --rp-c-text-3: #3c3c3cbf;
-  /* #31a94d 3.04:1 → 4.72:1 */
-  --shiki-token-string: #26843c;
+  /* #31a94d 3.04:1 → 5.37:1 on #fff, 4.78:1 on a highlighted line (`{n}` / `[!code highlight]`, #ebf2fe). */
+  --shiki-token-string: #227a37;
   /* #b6b4b4 2.06:1 → 4.74:1 */
   --shiki-token-comment: #737373;
   /* #f59403 2.30:1 → 4.66:1 */
@@ -77,10 +77,20 @@
 }
 
 :root.rp-dark {
-  /* #ebebeb at 55 %: 5.37:1 on #121212, 4.59:1 on --rp-c-bg-soft. */
-  --rp-c-text-3: #ebebeb8c;
+  /* #ebebeb at 65 %: 7.08:1 on #121212, 5.08:1 on --rp-c-bg-mute (prev/next hover). */
+  --rp-c-text-3: #ebebeba6;
   /* #6a727b 3.84:1 → 5.02:1 */
   --shiki-token-comment: #7d8590;
+}
+
+/*
+ * The theme fades the whole prev/next card to 70 % on hover
+ * (`PrevNextPage/index.css`), which takes the label above back down to
+ * 2.75:1 light / 2.81:1 dark; the `--rp-c-bg-mute` background change is
+ * enough hover feedback on its own.
+ */
+.rp-prev-next-page__item:hover {
+  opacity: 1;
 }
 
 /*

--- a/website/styles/index.css
+++ b/website/styles/index.css
@@ -6,7 +6,14 @@
  */
 
 :root:not(.rp-dark) {
-  --rp-c-brand: #0d8f80;
+  /*
+   * Brand text (active nav item, heading anchors, edit link, search matches)
+   * at 14 px needs 4.5:1. #0d8f80 measured 3.99:1 on #fff; same hue and
+   * saturation (hsl 173° 84%), lightness 31% → 27%: 4.83:1 on #fff, 4.55:1
+   * on --rp-c-bg-soft (search panel). Restated as `brandColor` in
+   * rspress.config.ts (the theme-color meta); keep the two in step.
+   */
+  --rp-c-brand: #0b8072;
   --rp-c-brand-light: #14b8a6;
   --rp-c-brand-lighter: #99f6e4;
   --rp-c-brand-dark: #0f766e;
@@ -39,6 +46,94 @@
     var(--rp-c-brand-dark) 32%,
     var(--rp-home-hero-secondary-color) 100%
   );
+}
+
+/*
+ * Contrast (#590). Ratios are WCAG 2.x, computed from the declared colours
+ * composited over the theme backgrounds (#fff / #121212 unless noted); text
+ * below 18.66 px bold needs 4.5:1.
+ *
+ * `--rp-c-text-3` is the theme's tertiary text token: prev/next labels
+ * (12 px), the home footer message and last-updated line (14 px), the
+ * external-link arrow, the code-block copy/wrap icons and fold button. It
+ * shipped at 1.85:1 light and 3.19:1 dark. Kept in the theme's alpha form so
+ * it still composites over --rp-c-bg-soft and --rp-c-bg-mute.
+ *
+ * Code blocks use Shiki's `css-variables` theme, so token colours are these
+ * variables (`styles/vars/shiki-vars.css`, declared through `:where()`).
+ * The light string token measured 3.04:1; the light comment (2.06:1) and
+ * parameter (2.30:1) tokens and the dark comment token (3.84:1) fail the same
+ * way and are corrected alongside it. Each pick keeps the original hue.
+ */
+:root:not(.rp-dark) {
+  /* #3c3c3c at 75 %: 5.18:1 on #fff, 5.01:1 on --rp-c-bg-soft, 4.83:1 on --rp-c-bg-mute. */
+  --rp-c-text-3: #3c3c3cbf;
+  /* #31a94d 3.04:1 → 4.72:1 */
+  --shiki-token-string: #26843c;
+  /* #b6b4b4 2.06:1 → 4.74:1 */
+  --shiki-token-comment: #737373;
+  /* #f59403 2.30:1 → 4.66:1 */
+  --shiki-token-parameter: #a76502;
+}
+
+:root.rp-dark {
+  /* #ebebeb at 55 %: 5.37:1 on #121212, 4.59:1 on --rp-c-bg-soft. */
+  --rp-c-text-3: #ebebeb8c;
+  /* #6a727b 3.84:1 → 5.02:1 */
+  --shiki-token-comment: #7d8590;
+}
+
+/*
+ * Keyboard access (#590). The appearance switch (theme/index.tsx) is now a
+ * tab stop; its focus ring is declared here so the two custom controls (this
+ * switch and the skip link) share one visible style instead of the UA default.
+ * Ring is --rp-c-brand on --rp-c-bg: 4.83:1 light, 10.06:1 dark.
+ */
+.rp-switch-appearance:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: 2px;
+}
+
+/* Wrapper the theme adds around the default social links; stays out of the nav's flex layout. */
+.ab-social-links {
+  display: contents;
+}
+
+/*
+ * Skip link (theme/index.tsx `SkipLink`): the first focusable element on the
+ * page, clipped until it receives focus, then pinned over the sticky nav.
+ * Text is --rp-c-brand on --rp-c-bg: 4.83:1 light, 10.06:1 dark.
+ */
+.ab-skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: calc(var(--rp-z-index-nav) + 1);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.ab-skip-link:focus {
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip-path: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 var(--rp-radius-small) 0;
+  background: var(--rp-c-bg);
+  color: var(--rp-c-brand);
+  font-weight: 600;
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: -2px;
+}
+
+/* Zero-size focus target; a focus ring around an empty box would render as a stray dot. */
+.ab-skip-target {
+  outline: none;
 }
 
 /*

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,18 +1,40 @@
 import { MDXProvider } from '@mdx-js/react';
-import { Content, useI18n, usePageData, withBase } from '@rspress/core/runtime';
+import type { SocialLink } from '@rspress/core';
+import { Content, ThemeContext, useI18n, useLang, usePageData, withBase } from '@rspress/core/runtime';
 import {
   EditLink as BasicEditLink,
+  HomeLayout as BasicHomeLayout,
   Layout as BasicLayout,
   LlmsCopyRow as BasicLlmsCopyRow,
   LlmsHint as BasicLlmsHint,
   LlmsOpenRow as BasicLlmsOpenRow,
   NotFoundLayout as BasicNotFoundLayout,
+  SocialLinks as BasicSocialLinks,
+  HomeBackground,
+  HomeFeature,
+  HomeFooter,
+  HomeHero,
+  type HomeLayoutProps,
   IconEdit,
+  IconMoon,
+  IconSun,
   Link,
   SvgWrapper,
   getCustomMDXComponent,
 } from '@rspress/core/theme-original';
-import { type JSX, useEffect } from 'react';
+import { type JSX, useContext, useEffect, useRef, useState } from 'react';
+
+declare global {
+  interface ImportMeta {
+    /**
+     * Defined by Rspress for every bundle it compiles (`node/initRsbuild.js`,
+     * `source.define`): `true` only in the Markdown render that feeds
+     * `@rspress/plugin-llms`. The default theme branches on the same flag; the
+     * package ships no declaration for it.
+     */
+    readonly env: { readonly SSG_MD: boolean };
+  }
+}
 
 /**
  * The default `HomeLayout` renders only the frontmatter hero and feature cards
@@ -31,7 +53,184 @@ const HomeBody = () => (
   </section>
 );
 
-const Layout = () => <BasicLayout afterFeatures={<HomeBody />} />;
+/** Focus target of the skip link; placed as the first child of `<main>`. */
+const contentId = 'ab-content';
+
+/**
+ * Zero-size, programmatically focusable marker. `DocLayout` opens `<main>`
+ * with the `beforeDocContent` slot and `HomeLayout` below does the same, so
+ * following the skip link moves focus (and the sequential-focus start) to the
+ * top of the main content on every page that has one.
+ */
+const SkipTarget = () => <div id={contentId} tabIndex={-1} className="ab-skip-target" />;
+
+/** Page types whose layout has no `<main>` and therefore no skip target. */
+const pagesWithoutContent = new Set(['404', 'custom', 'blank']);
+
+/**
+ * First focusable element on the page, rendered through the `top` slot ahead
+ * of the nav. A plain hash anchor, like the theme's own heading anchors and
+ * `Link` for hash-only hrefs: the browser moves focus to the marker and
+ * `useScrollAfterNav` scrolls it under the sticky nav.
+ */
+const SkipLink = () => {
+  const lang = useLang();
+  const { page } = usePageData();
+  if (pagesWithoutContent.has(page.pageType)) return null;
+  return (
+    <a className="ab-skip-link" href={`#${contentId}`}>
+      {lang === 'zh' ? '跳至主要内容' : 'Skip to main content'}
+    </a>
+  );
+};
+
+/**
+ * The default `HomeLayout` has no `<main>`: hero, feature grid and footer are
+ * siblings under `#root`, so the home page exposes no main landmark
+ * (`DocLayout` gives doc pages one). `Layout` accepts a `HomeLayout` prop, so
+ * this restates the default's markup with the hero and features inside
+ * `<main>`; the background and the footer stay outside so the footer keeps its
+ * `contentinfo` role. The Markdown render keeps the original, so the
+ * `index.md` twin produced for `llms.txt` is unchanged.
+ *
+ * The hero title stays a `<div>` (`HomeHero` renders `.rp-home-hero__title`
+ * as a div, upstream too); giving the home page an `<h1>` would mean forking
+ * that component, so it is left as is.
+ */
+const HomeLayout = ({
+  beforeHero,
+  afterHero,
+  beforeHeroActions,
+  afterHeroActions,
+  beforeFeatures,
+  afterFeatures,
+}: HomeLayoutProps) => {
+  if (import.meta.env.SSG_MD) {
+    return (
+      <BasicHomeLayout
+        beforeHero={beforeHero}
+        afterHero={afterHero}
+        beforeHeroActions={beforeHeroActions}
+        afterHeroActions={afterHeroActions}
+        beforeFeatures={beforeFeatures}
+        afterFeatures={afterFeatures}
+      />
+    );
+  }
+  return (
+    <>
+      <HomeBackground />
+      <main>
+        <SkipTarget />
+        {beforeHero}
+        <HomeHero beforeHeroActions={beforeHeroActions} afterHeroActions={afterHeroActions} />
+        {afterHero}
+        {beforeFeatures}
+        <HomeFeature />
+        {afterFeatures}
+      </main>
+      <HomeFooter />
+    </>
+  );
+};
+
+const Layout = () => (
+  <BasicLayout
+    top={<SkipLink />}
+    beforeDocContent={<SkipTarget />}
+    afterFeatures={<HomeBody />}
+    HomeLayout={HomeLayout}
+  />
+);
+
+/**
+ * The default `SwitchAppearance` is a click-only `<div>`: no role, no name,
+ * not in the tab order. `Nav`, `NavScreen` and `NavHamburger` import it from
+ * `@rspress/core/theme`, so this named export replaces it site-wide. It stays
+ * a `<div>` — given `role="button"`, a translated name, a tab stop and
+ * Enter/Space handling — instead of becoming a `<button>`, because
+ * `NavHamburger` (rendered on every page, shown at widths ≤ 1280 px) mounts
+ * the switch inside its own `<button>`, and a `<button>` inside a `<button>`
+ * is invalid HTML that React reports on every render. The original class
+ * names are kept so the theme's CSS still applies. `aria-pressed` is only
+ * rendered after mount: the SSG HTML is rendered with the default theme while
+ * the client's first render already knows the stored preference, so a state
+ * attribute in the initial markup would mismatch on hydration. The original's
+ * view-transition animation (`themeConfig.enableAppearanceAnimation`, off
+ * for this site) is not reproduced.
+ */
+const SwitchAppearance = ({ onClick }: { onClick?: () => void }) => {
+  const { theme, setTheme } = useContext(ThemeContext);
+  const lang = useLang();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  const isDark = theme === 'dark';
+  const toggle = () => {
+    setTheme?.(isDark ? 'light' : 'dark');
+    onClick?.();
+  };
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="rp-switch-appearance"
+      aria-label={lang === 'zh' ? '深色模式' : 'Dark mode'}
+      aria-pressed={mounted ? isDark : undefined}
+      onClick={toggle}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        toggle();
+      }}
+    >
+      <SvgWrapper
+        className="rp-switch-appearance__icon rp-switch-appearance__icon--sun"
+        icon={IconSun}
+        fill="currentColor"
+      />
+      <SvgWrapper
+        className="rp-switch-appearance__icon rp-switch-appearance__icon--moon"
+        icon={IconMoon}
+        fill="currentColor"
+      />
+    </div>
+  );
+};
+
+/** Accessible name for a social link, from its host: `github.com`. */
+const socialLinkName = (href: string): string => {
+  try {
+    return new URL(href).hostname.replace(/^www\./, '');
+  } catch {
+    return href;
+  }
+};
+
+/**
+ * `SocialLink` (mode `link`) renders `<a target="_blank">` whose only child is
+ * the icon SVG, so the link has no accessible name. `Nav`, `NavHamburger` and
+ * `NavScreen` import `SocialLinks` from `@rspress/core/theme`, so this named
+ * export replaces it. The anchor is created inside the default component and
+ * its icon comes from a build-time virtual module, so rather than restating
+ * the component the name is set on the rendered anchors after each render;
+ * assistive technology reads the live DOM. `github-stars` links already carry
+ * their own label and are left alone.
+ */
+const SocialLinks = (props: { socialLinks?: SocialLink[] }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const anchors =
+      ref.current?.querySelectorAll<HTMLAnchorElement>('a.rp-social-links__item:not([aria-label])') ?? [];
+    for (const anchor of anchors) anchor.setAttribute('aria-label', socialLinkName(anchor.href));
+  });
+  return (
+    <div ref={ref} className="ab-social-links">
+      <BasicSocialLinks {...props} />
+    </div>
+  );
+};
 
 /**
  * Same value as `repositoryUrl` in `rspress.config.ts`. The config runs in
@@ -136,5 +335,14 @@ const NotFoundLayout = () => {
   return <BasicNotFoundLayout />;
 };
 
-export { EditLink, Layout, LlmsCopyRow, LlmsHint, LlmsOpenRow, NotFoundLayout };
+export {
+  EditLink,
+  Layout,
+  LlmsCopyRow,
+  LlmsHint,
+  LlmsOpenRow,
+  NotFoundLayout,
+  SocialLinks,
+  SwitchAppearance,
+};
 export * from '@rspress/core/theme-original';

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -64,8 +64,11 @@ const contentId = 'ab-content';
  */
 const SkipTarget = () => <div id={contentId} tabIndex={-1} className="ab-skip-target" />;
 
-/** Page types whose layout has no `<main>` and therefore no skip target. */
-const pagesWithoutContent = new Set(['404', 'custom', 'blank']);
+/**
+ * Page types whose layout has no `<main>` and therefore no skip target. The
+ * 404 page is not among them: `NotFoundLayout` below wraps the default in one.
+ */
+const pagesWithoutContent = new Set(['custom', 'blank']);
 
 /**
  * First focusable element on the page, rendered through the `top` slot ahead
@@ -151,33 +154,43 @@ const Layout = () => (
  * Enter/Space handling — instead of becoming a `<button>`, because
  * `NavHamburger` (rendered on every page, shown at widths ≤ 1280 px) mounts
  * the switch inside its own `<button>`, and a `<button>` inside a `<button>`
- * is invalid HTML that React reports on every render. The original class
- * names are kept so the theme's CSS still applies. `aria-pressed` is only
- * rendered after mount: the SSG HTML is rendered with the default theme while
- * the client's first render already knows the stored preference, so a state
- * attribute in the initial markup would mismatch on hydration. The original's
- * view-transition animation (`themeConfig.enableAppearanceAnimation`, off
- * for this site) is not reproduced.
+ * is invalid HTML that React reports on every render. That nested copy is
+ * the hamburger's own control, so once mounted the switch checks whether it
+ * sits inside a `<button>` and, if so, renders as the plain click target the
+ * default theme used — a focusable `role="button"` inside a button would be
+ * nested interactive content with undefined keyboard behaviour. The original
+ * class names are kept so the theme's CSS still applies. `aria-pressed` and
+ * the nesting check only apply after mount: the SSG HTML is rendered with the
+ * default theme while the client's first render already knows the stored
+ * preference, so a state attribute in the initial markup would mismatch on
+ * hydration. The original's view-transition animation
+ * (`themeConfig.enableAppearanceAnimation`, off for this site) is not
+ * reproduced.
  */
 const SwitchAppearance = ({ onClick }: { onClick?: () => void }) => {
   const { theme, setTheme } = useContext(ThemeContext);
   const lang = useLang();
+  const ref = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
+  const [nestedInButton, setNestedInButton] = useState(false);
   useEffect(() => {
     setMounted(true);
+    setNestedInButton(Boolean(ref.current?.closest('button')));
   }, []);
   const isDark = theme === 'dark';
   const toggle = () => {
     setTheme?.(isDark ? 'light' : 'dark');
     onClick?.();
   };
+  const standalone = !nestedInButton;
   return (
     <div
-      role="button"
-      tabIndex={0}
+      ref={ref}
+      role={standalone ? 'button' : undefined}
+      tabIndex={standalone ? 0 : undefined}
       className="rp-switch-appearance"
-      aria-label={lang === 'zh' ? '深色模式' : 'Dark mode'}
-      aria-pressed={mounted ? isDark : undefined}
+      aria-label={standalone ? (lang === 'zh' ? '深色模式' : 'Dark mode') : undefined}
+      aria-pressed={standalone && mounted ? isDark : undefined}
       onClick={toggle}
       onKeyDown={(event) => {
         if (event.key !== 'Enter' && event.key !== ' ') return;
@@ -332,7 +345,14 @@ const NotFoundLayout = () => {
       window.location.replace(pathname.replace(/\/+$/, '') + search + hash);
     }
   }, []);
-  return <BasicNotFoundLayout />;
+  // The default renders its message straight under the nav, with no landmark;
+  // wrapping it gives the 404 page a `<main>` and a target for the skip link.
+  return (
+    <main>
+      <SkipTarget />
+      <BasicNotFoundLayout />
+    </main>
+  );
 };
 
 export {


### PR DESCRIPTION
Third PR for #590 (after #599 and #610): the two remaining P3s the audit measured that were worth doing rather than deferring — theme accessibility/contrast and sitemap `lastmod`. Website (private package) and the docs workflow only, so `skip-changeset`.

## Theme a11y and contrast (`website/theme/index.tsx`, `website/styles/index.css`)

Audit findings at 1440×900 on Rspress 2.0.21 defaults, and what changed:

| Finding | Before | After |
|---|---|---|
| Appearance switch is a click-only `div` with no role/name, not focusable | — | Named export `SwitchAppearance` replaces the default site-wide (`Nav`, `NavScreen`, `NavHamburger` import it from `@rspress/core/theme`): `role="button"`, `tabIndex=0`, translated `aria-label`, `aria-pressed` after mount (hydration-safe), Enter/Space toggle, brand focus ring. Stays a `div` because `NavHamburger` mounts it inside its own `<button>`. |
| GitHub social link has no accessible name | — | `SocialLinks` wrapper sets `aria-label` from the link's host (`github.com`) on icon-only anchors. |
| No skip link | — | `top` slot renders "Skip to main content" / "跳至主要内容" as the first focusable element, targeting a zero-size `#ab-content` marker placed by `beforeDocContent` (doc pages) and the custom `HomeLayout`; hidden on 404/custom/blank pages. |
| Home page has no `<main>` / `<h1>` | — | Custom `HomeLayout` wraps hero + features in `<main>` (footer stays outside to keep `contentinfo`). The hero title stays a `div`: an `<h1>` would need a `HomeHero` fork. |
| Prev/next 12 px labels (`--rp-c-text-3`) | 1.85:1 light / 3.19:1 dark | 5.18:1 / 5.37:1 (also lifts the home footer, last-updated line, code-block icons) |
| Active-nav brand on white | `#0d8f80` 3.99:1 | `#0b8072` 4.83:1 — same hue and saturation, lightness 31 % → 27 %; `theme-color` meta follows |
| Shiki light string token | `#31a94d` 3.04:1 | `#26843c` 4.72:1; the light comment (2.06:1 → 4.74:1), light parameter (2.30:1 → 4.66:1) and dark comment (3.84:1 → 5.02:1) tokens failed the same way and were fixed alongside |

Every ratio is WCAG 2.x, computed from the declared colours over the theme backgrounds; the values are in the CSS comments next to each token.

## Sitemap `lastmod` (`website/plugins/sitemap-lastmod.ts`, `.github/workflows/docs.yml`)

`@rspress/plugin-sitemap` dates every `<url>` with the source file's mtime — in CI that is checkout time for authored pages and build time for generated ones, so every deploy told crawlers every page had changed, and the plugin has no option to turn it off. `sitemapLastmod` wraps `pluginSitemap` (Rspress runs `afterBuild` hooks in parallel, so a second plugin cannot order itself after the write) and rewrites `<lastmod>` to the last commit touching the page's source: the `.mdx`/`.md` for authored pages, `packages/agent-bundle/src` for `/api/**`, `src/adapters/capabilities` for hosts/events/notices, `docs/diagnostics.md` for the diagnostics page. On a shallow clone or when git is unavailable the element is omitted rather than wrong. `docs.yml` checks out full history bloblessly (`fetch-depth: 0`, `filter: blob:none`: commits and trees only, which is all `git log -- <path>` needs; the pack is 159 MiB with blobs).

Local gate (`pnpm docs:site:build`) green; sitemap has 1,948 URLs with dates ranging from 2026-09-03 to today per page.

## Self-review

Reviewer: `gpt-5.6-sol-medium` (implementing lanes: `claude-fable-5-1-thinking-max` for the theme, `gpt-5.6-sol-medium` for the first sitemap draft, `claude-fable-5-1-thinking-max` for the plugin composition, CI change and integration). Two independent Sol runs on the pre-fix diff (ad0e2593a):

1. **Nested interactive content**: the focusable `role="button"` switch also renders inside `NavHamburger`'s `<button>` (shown at 769–1280 px). **Fixed** (9d0d8469d): after mount the switch detects `closest('button')` and renders as the default theme's plain click target there; the standalone copy keeps role/name/tab stop. Verified headless: at 1024 px the nested copy has no role/tabindex after hydration, at 1440 px Tab reaches the switch and Enter toggles the theme.
2. **404 page had no `<main>` and no skip target.** **Fixed**: `NotFoundLayout` wraps the default in `<main>` with the skip target; `404.html` now has landmark, target and link.
3. **String token failed on highlighted lines** (4.20:1 on the `{n}`/`[!code highlight]` background). **Fixed**: `#227a37` — 5.37:1 on white, 4.78:1 highlighted.
4. **Prev/next hover**: the theme's `opacity: .7` on the hovered card dropped the label to ~2.8:1, and the dark token was 4.11:1 on the mute background. **Fixed**: hover keeps full opacity (the background change remains as feedback); dark `--rp-c-text-3` at 65 % → 7.08:1 / 5.08:1.
5. **No automated tests for `sitemap-lastmod.ts`.** **Dismissed as a unit test, addressed as a gate assertion**: the unit pool is `packages/**/tests/**/*.test.ts` and `website/` has no harness (none of its plugins or scripts are unit-tested); `check-built-links.mjs` now asserts every `<lastmod>` parses, is not in the future, and that the values are not all identical when there are more than ten URLs — the exact regression this change removes — and was verified to fail on a doctored sitemap.

No findings on hydration (`aria-pressed` after mount), override reachability, skip targets on doc/API pages, desktop width rules, sitemap route mapping, blobless history, or the checkout assumptions of other steps. Second pass after the fixes: one residual, **dismissed**: at 769–1280 px the visible switch is the copy inside `NavHamburger`'s `<button>`, which now renders without a role or tab stop, and the hamburger's own Enter/Space only opens the menu — so a keyboard user at those widths still cannot toggle appearance. That is the default theme's behaviour at those widths (the switch was a click-only `div` there before and after this PR), the fix is a fork of `NavHamburger` that renders its popover outside the trigger, and the site's acceptance viewport is 1440 × 900 desktop (AGENTS.md). Recorded on #590 as deferred / upstream-worthy. All contrast ratios were recomputed independently (5.37, 4.79, 7.10, 5.09 before 8-bit rounding); the sitemap assertion's one theoretical false positive (a single commit touching all 75 authored sources with no other history) was judged acceptable for this site.

## Deslop

`cursor-grok-4.6-high-fast`, 8 edits — ran after this PR had merged (the owner's rule arrived at 08:39), so the comment trims land in #622; no behaviour change.

Refs #590.

