### PR TITLE
docs(website): fit home artifact tree column

### DIFF
--- a/.changeset/public-capability-table-types.md
+++ b/.changeset/public-capability-table-types.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': patch
+---
+
+Export the `CapabilityRow` and `HostCapabilityTable` capability-table types. (#626)

--- a/packages/agent-bundle/src/adapters/capability-state.ts
+++ b/packages/agent-bundle/src/adapters/capability-state.ts
@@ -1,6 +1,7 @@
 import { CapabilityStateError, unknownCapabilityStateError } from '../core/capabilities.ts';
 import type { CapabilityEvidence, CapabilityState } from '../core/capabilities.ts';
 import { featureCapabilityName } from '../core/components.ts';
+import type { JsonObject } from '../core/strict-json.ts';
 import {
   NOTICE_DELIVERY_ROUTES,
   NOTICE_SENSITIVITIES,
@@ -42,6 +43,24 @@ export const unavailableCapability = (reason: string): CapabilityState => Object
   reason,
   state: 'unavailable',
 });
+
+/** A row from a pinned host capability table. */
+export interface CapabilityRow {
+  readonly availability?: Readonly<Record<string, { readonly reason?: string; readonly state?: string }>>;
+  readonly evidence?: readonly string[];
+  readonly nativeEvent?: string;
+  readonly payload?: JsonObject;
+  readonly reason?: string;
+  readonly state?: string;
+}
+
+/** A loaded pinned host capability table and its source identity. */
+export interface HostCapabilityTable {
+  readonly data: JsonObject;
+  readonly fileName: string;
+  readonly host: string;
+  readonly version: string;
+}
 
 export interface EventRouteCapabilityTableEntry {
   readonly nativeEvent?: string;
@@ -90,8 +109,7 @@ export const supportedEventRouteNamesFrom = (
 ));
 
 /** A pinned capability-table row: JSON imports widen the state literal, so unknown states fail closed. */
-export interface CapabilityTableRow {
-  readonly reason?: string;
+export interface CapabilityTableRow extends CapabilityRow {
   readonly state: string;
 }
 

--- a/packages/agent-bundle/src/index.ts
+++ b/packages/agent-bundle/src/index.ts
@@ -191,6 +191,7 @@ export type AgentBundleConfig = CoreAgentBundleConfig
   & PortableConfigExtension;
 
 export type { PortableAuthorConfig, PortableManifestConfig } from './adapters/portable.ts';
+export type { CapabilityRow, HostCapabilityTable } from './adapters/capability-state.ts';
 
 // The config hook handler contract (#488): the payload a `hooks.<event>.handler`
 // receives and the result the generated wrapper admits, per canonical event.

--- a/website/docs/en/index.mdx
+++ b/website/docs/en/index.mdx
@@ -119,32 +119,32 @@ declaration, because a handler has to be bound to an event.
 ```text title="artifact/"
 artifact/
 ├── .claude-plugin/
-│   ├── plugin.json                  # Claude Code manifest
+│   ├── plugin.json
 │   └── marketplace.json
 ├── .codex-plugin/
-│   ├── plugin.json                  # Codex manifest
-│   ├── hooks.json                   # Codex hook document
-│   └── mcp.json                     # Codex MCP document
-├── .agents/plugins/marketplace.json # Codex marketplace
-├── .mcp.json                        # Claude Code MCP document
-├── plugin.json                      # portable (Agent Plugins) manifest
-├── mcp.json                         # portable MCP document
+│   ├── plugin.json
+│   ├── hooks.json
+│   └── mcp.json
+├── .agents/plugins/marketplace.json
+├── .mcp.json
+├── plugin.json
+├── mcp.json
 ├── hooks/
-│   ├── hooks.json                   # Claude Code hook document
-│   ├── session-start-….claude.mjs   # one wrapper per host the hook reaches
+│   ├── hooks.json
+│   ├── session-start-….claude.mjs
 │   ├── session-start-….codex.mjs
 │   └── hooks-flight.mjs
 ├── mcp/
-│   ├── mcp-status-….mjs             # compiled once, shared by every host
+│   ├── mcp-status-….mjs
 │   └── mcp-status-…-flight.mjs
 ├── scripts/check-service.mjs
 ├── skills/release-review/
 │   ├── SKILL.md
 │   └── references/policy.md
-├── INSTALL.md                       # one section per selected host
-├── install.mjs                      # installer for portable and Cursor
-├── agent-bundle.manifest.json       # every emitted file with its SHA-256
-└── agent-bundle.hooks.json          # hook index over the selected hosts
+├── INSTALL.md
+├── install.mjs
+├── agent-bundle.manifest.json
+└── agent-bundle.hooks.json
 ```
 
 Every selected host reads this one directory as its plugin root: Claude Code finds

--- a/website/docs/zh/index.mdx
+++ b/website/docs/zh/index.mdx
@@ -116,32 +116,32 @@ Skill、MCP 服务器与脚本都按约定被发现。只有钩子需要声明�
 ```text title="artifact/"
 artifact/
 ├── .claude-plugin/
-│   ├── plugin.json                  # Claude Code 清单
+│   ├── plugin.json
 │   └── marketplace.json
 ├── .codex-plugin/
-│   ├── plugin.json                  # Codex 清单
-│   ├── hooks.json                   # Codex 钩子文档
-│   └── mcp.json                     # Codex MCP 文档
-├── .agents/plugins/marketplace.json # Codex marketplace
-├── .mcp.json                        # Claude Code MCP 文档
-├── plugin.json                      # portable（Agent Plugins）清单
-├── mcp.json                         # portable MCP 文档
+│   ├── plugin.json
+│   ├── hooks.json
+│   └── mcp.json
+├── .agents/plugins/marketplace.json
+├── .mcp.json
+├── plugin.json
+├── mcp.json
 ├── hooks/
-│   ├── hooks.json                   # Claude Code 钩子文档
-│   ├── session-start-….claude.mjs   # 钩子到达的每个宿主各一个包装脚本
+│   ├── hooks.json
+│   ├── session-start-….claude.mjs
 │   ├── session-start-….codex.mjs
 │   └── hooks-flight.mjs
 ├── mcp/
-│   ├── mcp-status-….mjs             # 只编译一次，所有宿主共用
+│   ├── mcp-status-….mjs
 │   └── mcp-status-…-flight.mjs
 ├── scripts/check-service.mjs
 ├── skills/release-review/
 │   ├── SKILL.md
 │   └── references/policy.md
-├── INSTALL.md                       # 每个所选宿主一节
-├── install.mjs                      # portable 与 Cursor 的安装器
-├── agent-bundle.manifest.json       # 每个输出文件及其 SHA-256
-└── agent-bundle.hooks.json          # 覆盖所选宿主的钩子索引
+├── INSTALL.md
+├── install.mjs
+├── agent-bundle.manifest.json
+└── agent-bundle.hooks.json
 ```
 
 每个所选宿主都把这同一个目录当作自己的插件根目录来读取：Claude Code 找到 `.claude-plugin/`、

--- a/website/plugins/generated-reference.ts
+++ b/website/plugins/generated-reference.ts
@@ -1,6 +1,11 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { RspressPlugin } from '@rspress/core';
+import type {
+  CapabilityRow,
+  HostCapabilityTable,
+} from '../../packages/agent-bundle/src/adapters/capability-state.ts';
+import type { JsonObject, JsonValue } from '../../packages/agent-bundle/src/core/strict-json.ts';
 
 /**
  * Build-time reference pages rendered from repository sources of truth:
@@ -14,26 +19,6 @@ import type { RspressPlugin } from '@rspress/core';
  * pages take part in sidebar metadata, dead-link checks, search, and the LLM
  * artifacts exactly like authored pages, while never being committed.
  */
-
-type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
-type JsonObject = { [key: string]: JsonValue };
-
-interface CapabilityRow {
-  readonly state?: string;
-  readonly reason?: string;
-  readonly nativeEvent?: string;
-  readonly evidence?: readonly string[];
-  readonly availability?: Readonly<Record<string, { readonly state?: string; readonly reason?: string }>>;
-  /** Canonical payload field → host key (or `{ nativeKey, decode }`), on supported event-route rows. */
-  readonly payload?: JsonObject;
-}
-
-interface HostCapabilityTable {
-  readonly fileName: string;
-  readonly host: string;
-  readonly version: string;
-  readonly data: JsonObject;
-}
 
 export interface GeneratedReferenceLocale {
   /** Locale key, such as `en` or `zh`. */
@@ -79,7 +64,7 @@ const mcpPathTokenFields = (host: JsonObject): JsonObject => {
     return {};
   }
   const groups = asObject(substitution.fields);
-  const derived: JsonObject = {};
+  const derived: Record<string, JsonValue> = {};
   for (const group of ['mcpStdio', 'mcpRemote']) {
     const fields = groups[group];
     if (Array.isArray(fields)) {


### PR DESCRIPTION
## Summary

- remove trailing artifact-tree comments that overflow the 484 px home-page comparison column, in both English and Chinese
- export `CapabilityRow` and `HostCapabilityTable` from `agent-bundle` and reuse their owning source definitions in the generated-reference plugin
- add one patch changeset for the public type exports

Closes #617

## Verification

- `pnpm docs:site:build`
- `pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit`
- Playwright, built site, 1440×900:
  - before: artifact fence `scrollWidth 679`, `clientWidth 484`
  - after (en): `scrollWidth 484`, `clientWidth 484`
  - after (zh): `scrollWidth 484`, `clientWidth 484`

## Item 2

Done. The deferred types describe the pinned capability-table contract and now have one owner in `src/adapters/capability-state.ts`; the package root publicly exports them, and the website plugin imports them instead of maintaining copies. The website imports the owning source module because its typecheck runs before package `dist` exists, matching the docs build's existing source-compilation model.

## Deslop

Deslop: GPT-5.6 Sol, 0 edits. The complete diff against `origin/main` had no restating comments, defensive branches, casts, or unrelated helpers to remove.

## Self-review

Reviewer: Claude Fable 5.1 Thinking High (`change-risk-reviewer`), pass 1.

No blocking or medium findings. Dispositions for low-severity notes:

- Changeset `(#626)`: confirmed by this PR number; retain.
- Website typecheck includes package source transitively: accepted, consistent with the existing TypeDoc/source build and required because docs build before `dist`.
- `HostCapabilityTable` has no in-package runtime consumer: accepted intentionally; it is a public description of the pinned table consumed by repository tooling.
- `CapabilityRow.payload` overlaps the narrower event-route row: no change; the public row models heterogeneous capability JSON while the event-route type enforces its runtime subset.
- Removed comments carried details: no change; surrounding prose already explains per-host wrappers, shared entries, installation instructions, manifests, and host hook indexing, while the issue explicitly selected dropping trailing comments.


Reviewer: Claude Fable 5.1 Thinking High (`change-risk-reviewer`), pass 2.

No blocking findings; merge-ready. Dispositions for remaining non-blocking notes:

- Bare `CapabilityRow.payload` TypeDoc: no change; the public type intentionally models heterogeneous capability JSON, while `EventRouteCapabilityTableEntry` documents the narrower canonical payload mapping.
- Three removed fence annotations: no change; the home prose and linked distribution documentation own those details, and #617 explicitly permits dropping trailing comments to retain the comparison layout.
- No persistent 484 px regression assertion: no change in this small content fix; the required built-site Playwright acceptance was run in both locales, and broader authored-fence overflow coverage remains separate test-infrastructure scope.
