### PR TITLE
fix(web): preserve literal launch arguments

### DIFF
--- a/.changeset/preserve-dev-web-launch-arguments.md
+++ b/.changeset/preserve-dev-web-launch-arguments.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Preserve literal stdio arguments when `agent-bundle dev` selects `/web` launches with AB8023 (#635)

--- a/packages/agent-bundle/src/dev/web-host-launch-selection.ts
+++ b/packages/agent-bundle/src/dev/web-host-launch-selection.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { isAbsolute, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import type { TargetRegistry } from '../adapters/registry.ts';
 import { digest } from '../core/digest.ts';
@@ -64,18 +64,11 @@ interface LaunchCandidate {
   readonly target: string;
 }
 
-const normalizedStdioArgument = (
+const normalizedStdioEntry = (
   value: string,
   artifactRoot: string,
   cwd: string,
 ): string => {
-  if (
-    !isAbsolute(value) &&
-    !value.startsWith('./') &&
-    !value.startsWith('../') &&
-    !value.includes('/') &&
-    !value.includes('\\')
-  ) return value;
   const resolved = resolve(cwd, value);
   return isInsideOrEqual(artifactRoot, resolved) ? resolved : value;
 };
@@ -137,10 +130,12 @@ const launchIdentityOf = async (
       const cwd = resolved.cwd === undefined
         ? artifactRoot
         : assertInside(artifactRoot, resolve(artifactRoot, resolved.cwd));
+      const [entry, ...args] = resolved.args;
       return digest({
-        args: resolved.args.map((argument) => normalizedStdioArgument(argument, artifactRoot, cwd)),
+        args,
         command: resolved.command,
         cwd,
+        entry: entry === undefined ? null : normalizedStdioEntry(entry, artifactRoot, cwd),
         env: resolved.env ?? {},
         kind: 'stdio',
       });

--- a/packages/agent-bundle/tests/web-host-launch-selection.test.ts
+++ b/packages/agent-bundle/tests/web-host-launch-selection.test.ts
@@ -115,6 +115,22 @@ describe('selectWebLaunch', () => {
     expect(selection.sharedTargets).toEqual(['claude', 'portable']);
   });
 
+  it('preserves path-looking literal arguments after the executable entry', async () => {
+    const root = await artifactRoot();
+    await writeManifest(root, '.mcp.json', {
+      status: claudeServer({
+        args: ['${CLAUDE_PLUGIN_ROOT}/mcp/mcp-status.mjs', '--label', './team/red'],
+      }),
+    });
+    await writeManifest(root, 'mcp.json', {
+      status: emittedPortableServer({
+        args: ['mcp/mcp-status.mjs', '--label', join(root, 'team', 'red')],
+      }),
+    });
+    const error = await failure(root, { declaredTargets: ['claude', 'portable'] });
+    expect(error.code).toBe('launch-ambiguous');
+  });
+
   it('keeps an emitted portable entry distinct when it resolves to another artifact path', async () => {
     const root = await artifactRoot();
     await writeManifest(root, '.mcp.json', { status: claudeServer() });


### PR DESCRIPTION
## Summary

- Give the internal stdio launch descriptor a typed `entry` field and normalize only that known artifact reference.
- Preserve every trailing argument byte-for-byte, including path-looking literal values such as `./team/red`.
- Keep `/web` selection ambiguous with `AB8023` when projections differ in literal arguments.

Follow-up to #633. The typed `entry` field records which reference is an artifact path now; no filesystem-existence or slash heuristic remains.

## Tests

- TDD red: equal entries with `--label ./team/red` versus `--label /artifact/team/red` incorrectly selected one shared launch before the fix.
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` — 4,124 passed, 6 skipped
- focused web-host/web-launch/MCP-session suite — 69 passed

## Deslop

GPT-5.6 Sol, 0 edits — the two-file behavior diff was read in full against `origin/main`; no redundant comments, exception-driven control flow, casts, or copied helpers remain.

## Self-review

Reviewer: `claude-fable-5-1-thinking-high` (`change-risk-reviewer`) over exact `18964e116` vs `origin/main` (`2c28363ce`).

No concrete merge risks found. The review verified that compiler lowering places the executable entry at `args[0]`, only that typed `entry` is normalized, trailing arguments remain byte-exact, portable-relative and host-absolute entries stay equivalent, distinct entries and path-looking literals remain `AB8023`, and the digest shape is in-memory only.

Residual observations and dispositions:

1. A non-path `args[0]` in a command-shaped user server would still be interpreted as the entry — **dismissed**: every compiler-lowered server in scope places its generated or prebuilt executable entry at `args[0]`; arbitrary command shapes are not this selector contract.
2. Codex may resolve trailing `./` arguments before identity — **dismissed**: pre-existing adapter behavior mirrors the bytes the Codex launch path executes and is outside this correction.
3. An additional positive identical-literal test could be added — **dismissed**: existing shared-launch and trailing-argument identity tests cover equality, while the new negative test directly proves the shipped false-equivalence regression.

