### PR TITLE
fix(docs): isolate TypeScript compiler API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,17 +12,6 @@ updates:
       rspress:
         patterns:
           - '@rspress/*'
-    ignore:
-      # typescript@7.0.x is a native compiler: import('typescript') is only
-      # { version, versionMajorMinor }. website/rspress.config.ts,
-      # @rspress/plugin-twoslash@2.0.21 (peer ^6.0.3 -> twoslash@0.3.9 peer
-      # ^5.5.0 || ^6.0.0), and typedoc@0.28.20 (peer 5.0.x–6.0.x;
-      # TypeStrong/typedoc#3098 targets TS 7.1) all need the JS compiler API
-      # and crash on 7.0.2. Root tsc is already 7.0.2; website stays on
-      # 6.0.3. Drop this ignore when TypeDoc and twoslash support TS 7.
-      - dependency-name: typescript
-        update-types:
-          - version-update:semver-major
   - package-ecosystem: github-actions
     # `/` covers .github/workflows/*; the composite actions under
     # .github/actions/* (where pnpm/setup lives) are separate directories.

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,22 @@
+const typescriptApiConsumers = new Set([
+  '@rspress/plugin-twoslash',
+  '@rspress/plugin-typedoc',
+  '@shikijs/twoslash',
+  'twoslash',
+  'typedoc',
+]);
+
+function readPackage(pkg) {
+  if (!typescriptApiConsumers.has(pkg.name)) {
+    return pkg;
+  }
+  // Keep JavaScript-API consumers isolated from the website's native TypeScript 7 peer.
+  pkg.dependencies ??= {};
+  pkg.dependencies.typescript = pkg.peerDependencies?.typescript ?? '*';
+  if (pkg.peerDependencies) {
+    delete pkg.peerDependencies.typescript;
+  }
+  return pkg;
+}
+
+module.exports = { hooks: { readPackage } };

--- a/docs/effect-conventions.md
+++ b/docs/effect-conventions.md
@@ -11,7 +11,7 @@ docs, or examples' user code. The four-concept newcomer ledger is untouched.
 | --- | --- |
 | npm `effect` | **`4.0.0-rc.112`** (exact). Latest published `rc` dist-tag on 2026-09-01. The Wave 3.5 brief named `4.0.0-rc.113`; that version was not on the registry. Re-pin chores take the next published RC. |
 | Vendored tree | `repos/effect` via `git subtree` from [Effect-TS/effect](https://github.com/Effect-TS/effect.git) `main` (v4). Squash commit tracks `packages/effect` version **4.0.0-rc.112**. |
-| `website` `typescript` | **`6.0.3`**, behind the root's TypeScript 7, because `typedoc@0.28` peers on `<= 6.0.x`. TypeDoc compiles the built `packages/agent-bundle/dist` declarations with it, while Twoslash compiles documentation samples against package source. Re-pin chores check whether a newer `typedoc` lifts the ceiling. |
+| `website` TypeScript | Native **`7.0.2`** runs `tsc`; the `typescript-6` alias stays on **`6.0.3`** for TypeDoc, Twoslash, and `rspress.config.ts` compiler-API calls. `.pnpmfile.cjs` turns those plugins' TypeScript peers into dependencies, and the scoped overrides in `pnpm-workspace.yaml` isolate them from TypeScript 7. Re-pin chores update the alias and overrides together. |
 
 Application code imports the npm package. Never import from `repos/**`.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,14 @@ settings:
 
 overrides:
   '@agent-bundle/runtime': workspace:*
+  '@rspress/plugin-twoslash>typescript': npm:typescript@6.0.3
+  '@rspress/plugin-typedoc>typescript': npm:typescript@6.0.3
+  '@shikijs/twoslash>typescript': npm:typescript@6.0.3
   rsc-markdown-stream: workspace:*
+  twoslash>typescript: npm:typescript@6.0.3
+  typedoc>typescript: npm:typescript@6.0.3
+
+pnpmfileChecksum: sha256-CjzDbxBVbwhtWuVc5QBOr0ymy8e8vyM9gWK88TVQjzA=
 
 patchedDependencies:
   '@rspress/core@2.0.21': 555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c
@@ -486,10 +493,10 @@ importers:
         version: 2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))
       '@rspress/plugin-twoslash':
         specifier: 2.0.21
-        version: 2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(react@19.2.8)(supports-color@7.2.0)(typescript@6.0.3)
+        version: 2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(react@19.2.8)(supports-color@7.2.0)
       '@rspress/plugin-typedoc':
         specifier: 2.0.21
-        version: 2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(typescript@6.0.3)
+        version: 2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))
       '@rspress/shared':
         specifier: 2.0.21
         version: 2.0.21(supports-color@7.2.0)
@@ -512,8 +519,11 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: 7.0.2
+        version: 7.0.2
+      typescript-6:
+        specifier: npm:typescript@6.0.3
+        version: typescript@6.0.3
       zod:
         specifier: 4.5.4
         version: 4.5.4
@@ -1211,7 +1221,6 @@ packages:
     peerDependencies:
       '@rspress/core': ^2.0.10
       react: '>=18.0.0'
-      typescript: ^6.0.3
 
   '@rspress/plugin-typedoc@2.0.21':
     resolution: {integrity: sha512-xM53g9wI9vl1mDirYn1wfTnh0Q+Fb+zkp0VxHYVQV8lJf/sHvxerf5CHlVSznBdd4Q1BMC5g/kIqdWGs7mqNYQ==}
@@ -1330,8 +1339,6 @@ packages:
   '@shikijs/twoslash@4.4.3':
     resolution: {integrity: sha512-m7HNzunEIHRk1jCya3ngGsO3+8pYxrPIIxtdJewg/W8ceW/+m/mSsm4jM3L9DvYYNa8Rvbu7Dabt3BOpCclz8Q==}
     engines: {node: '>=20'}
-    peerDependencies:
-      typescript: '>=5.5.0'
 
   '@shikijs/types@3.23.0':
     resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
@@ -3082,8 +3089,6 @@ packages:
 
   twoslash@0.3.9:
     resolution: {integrity: sha512-rDclk+OtzuTX+tnea7DYLCkqGQ3eP0IyfD+kzUJ7t46X/NzlaxwrhecmEBNuSCuEn3V+n1PhcjUUQQ7gUJzX5Q==}
-    peerDependencies:
-      typescript: ^5.5.0 || ^6.0.0
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -3099,8 +3104,6 @@ packages:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
-    peerDependencies:
-      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
@@ -4025,28 +4028,27 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0)
 
-  '@rspress/plugin-twoslash@2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(react@19.2.8)(supports-color@7.2.0)(typescript@6.0.3)':
+  '@rspress/plugin-twoslash@2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(react@19.2.8)(supports-color@7.2.0)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@rspress/core': 2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0)
-      '@shikijs/twoslash': 4.4.3(supports-color@7.2.0)(typescript@6.0.3)
+      '@shikijs/twoslash': 4.4.3(supports-color@7.2.0)
       mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       mdast-util-to-hast: 13.2.1
       picocolors: 1.1.1
       react: 19.2.8
-      twoslash: 0.3.9(supports-color@7.2.0)(typescript@6.0.3)
+      twoslash: 0.3.9(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@rspress/plugin-typedoc@2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))(typescript@6.0.3)':
+  '@rspress/plugin-typedoc@2.0.21(@rspress/core@2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0))':
     dependencies:
       '@rspress/core': 2.0.21(patch_hash=555fe9cee718693c8c981e2ae0e282cb514a1808af1744dfab977ed7ca90fa2c)(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@7.2.0))(supports-color@7.2.0)
-      typedoc: 0.28.20(typescript@6.0.3)
-      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
-    transitivePeerDependencies:
-      - typescript
+      typedoc: 0.28.20
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20)
+      typescript: 6.0.3
 
   '@rspress/shared@2.0.21(supports-color@7.2.0)':
     dependencies:
@@ -4169,11 +4171,11 @@ snapshots:
       '@shikijs/core': 4.4.3
       '@shikijs/types': 4.4.3
 
-  '@shikijs/twoslash@4.4.3(supports-color@7.2.0)(typescript@6.0.3)':
+  '@shikijs/twoslash@4.4.3(supports-color@7.2.0)':
     dependencies:
       '@shikijs/core': 4.4.3
       '@shikijs/types': 4.4.3
-      twoslash: 0.3.9(supports-color@7.2.0)(typescript@6.0.3)
+      twoslash: 0.3.9(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6246,7 +6248,7 @@ snapshots:
 
   twoslash-protocol@0.3.9: {}
 
-  twoslash@0.3.9(supports-color@7.2.0)(typescript@6.0.3):
+  twoslash@0.3.9(supports-color@7.2.0):
     dependencies:
       '@typescript/vfs': 1.6.4(supports-color@7.2.0)(typescript@6.0.3)
       twoslash-protocol: 0.3.9
@@ -6260,11 +6262,11 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)):
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20):
     dependencies:
-      typedoc: 0.28.20(typescript@6.0.3)
+      typedoc: 0.28.20
 
-  typedoc@0.28.20(typescript@6.0.3):
+  typedoc@0.28.20:
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,12 @@ packages:
 # this checkout is about to publish.
 overrides:
   '@agent-bundle/runtime': workspace:*
+  '@rspress/plugin-twoslash>typescript': npm:typescript@6.0.3
+  '@rspress/plugin-typedoc>typescript': npm:typescript@6.0.3
+  '@shikijs/twoslash>typescript': npm:typescript@6.0.3
   rsc-markdown-stream: workspace:*
+  'twoslash>typescript': npm:typescript@6.0.3
+  'typedoc>typescript': npm:typescript@6.0.3
 allowBuilds:
   '@google/genai': false
   msgpackr-extract: false

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,8 @@
     "@types/react": "19.2.18",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "typescript": "6.0.3",
+    "typescript": "7.0.2",
+    "typescript-6": "npm:typescript@6.0.3",
     "zod": "4.5.4"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -4,7 +4,7 @@ import { pluginLlms } from '@rspress/plugin-llms';
 import { pluginTwoslash } from '@rspress/plugin-twoslash';
 import { pluginTypeDoc } from '@rspress/plugin-typedoc';
 import { transformerNotationHighlight } from '@shikijs/transformers';
-import ts from 'typescript';
+import ts from 'typescript-6';
 import { generatedReference } from './plugins/generated-reference.ts';
 import { cleanGeneratedApiMarkdown, mirrorApiLocale } from './plugins/mirror-api-locale.ts';
 import { rehypeTableCellBreaks } from './plugins/rehype-table-cell-breaks.ts';
@@ -192,8 +192,8 @@ export default defineConfig({
   plugins: [
     // TypeDoc reads packages/agent-bundle/dist declarations produced by the
     // package build. Twoslash still compiles documentation samples against
-    // package sources. Both use the TypeScript 6 pin in website/package.json
-    // because typedoc 0.28 peers on `<= 6.0.x`.
+    // package sources. Both use the JavaScript compiler API from the
+    // `typescript-6` alias; the website's `typescript` dependency is native.
     pluginTypeDoc({
       entryPoints: publicApiEntryPoints,
       outDir: generatedApiDir,


### PR DESCRIPTION
## Summary
- run the website typecheck with native TypeScript 7.0.2 while `rspress.config.ts` imports a `typescript-6` compiler-API alias
- convert the TypeDoc/twoslash TypeScript peers into scoped dependencies pinned to 6.0.3, preventing them from resolving TypeScript 7
- remove the temporary Dependabot major-version ignore and update the pin reference

Refs #612.

## Local merge gate
Branch HEAD `5117aa75ed4bc96faa440fddee17c65609033200` contains current `origin/main` `46e8e7d25a3f7c0db26c8d13c1bbdf978cdcdc50`.

- `pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit` — passed; linted 1,421 files; 283 test files, 4,229 tests, 0 failures (4,223 passed, 6 skipped)
- `pnpm --filter @agent-bundle/docs typecheck` — passed under native TypeScript 7.0.2
- `pnpm docs:site:build` — passed; 110 sitemap pages, 0 broken links, 28,127 anchors checked, TypeDoc API generated, twoslash hover markup rendered
- `pnpm install --frozen-lockfile` — passed
- `pnpm why typescript -r` — TypeDoc/twoslash JS-API consumers resolve 6.0.3; website/root native typecheckers resolve 7.0.2; no peer dependency issues

The page count (110) and broken-link count (0) match #610's acceptance numbers.

## Deslop
Deslop: GPT-5.6 Sol, 1 edit (removed a redundant package-extension layer from the final dependency wiring).

## Self-review
Reviewer: Claude Fable 5.1 Thinking High.

- `.pnpmfile.cjs` was initially untracked while its checksum was in the lockfile: fixed by staging and committing it with the lockfile.
- `docs/effect-conventions.md` still described a website-wide TypeScript 6 pin: fixed to document native 7 plus the isolated 6.0.3 compiler API.
- Pin drift risk: the reference now explicitly requires updating the alias and scoped overrides together.
- Final pass on current `origin/main`: no merge blockers; patch scope is exactly the seven intended files and the pnpmfile checksum matches the lockfile.

No changeset: only private website and repository tooling/configuration changed (`skip-changeset`).
