### PR TITLE
Test manifest v3 CLI summary

### DIFF
--- a/packages/agent-bundle/tests/cli.test.ts
+++ b/packages/agent-bundle/tests/cli.test.ts
@@ -631,7 +631,7 @@ it('includes a built-manifest summary on inspect --json after a build, and omits
 
     const human = await runSourceCliWithOutput(['inspect', '--root', project.root]);
     expect(human).toMatchObject({ code: 0, stderr: '' });
-    expect(human.stdout).toContain('Built manifest: v2 cli-fixture (codex, portable)');
+    expect(human.stdout).toContain('Built manifest: v3 cli-fixture (codex, portable)');
 
     const artifact = await runSourceCliWithOutput([
       'inspect', '--artifact', join(project.root, 'dist'), '--json',


### PR DESCRIPTION
## Summary
- update the stale human `inspect` assertion to match manifest v3 after #656

## Local merge gate
- `pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit` — passed
- `pnpm exec rstest --config rstest.integration.config.ts packages/agent-bundle/tests/cli.test.ts` — passed

Deslop: GPT-5.6 Sol, 0 edits.

## Self-review
Reviewer: Claude Fable 5.1 high. No merge risks; the JSON assertion already expected manifest v3 and the formatter prints the manifest version verbatim.
