### PR TITLE
fix(dev): source watcher ignores the package build's .compile- scratch dir (red main)

### DIFF
--- a/.changeset/watcher-compile-scratch.md
+++ b/.changeset/watcher-compile-scratch.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Ignore the package build's `.<output>.compile-XXXXXX` scratch directory in the `agent-bundle dev` source watcher, so a `dist/` package build no longer republishes the epoch it just produced and Workbench invocations run under the epoch that was active when they were queued. (#PR)
+Ignore the package build's `.<output>.compile-XXXXXX` scratch directory in the `agent-bundle dev` source watcher, so a `dist/` package build no longer republishes the epoch it just produced and Workbench invocations run under the epoch that was active when they were queued. (#669)

--- a/.changeset/watcher-compile-scratch.md
+++ b/.changeset/watcher-compile-scratch.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Ignore the package build's `.<output>.compile-XXXXXX` scratch directory in the `agent-bundle dev` source watcher, so a `dist/` package build no longer republishes the epoch it just produced and Workbench invocations run under the epoch that was active when they were queued. (#PR)

--- a/packages/agent-bundle/src/dev/watcher.ts
+++ b/packages/agent-bundle/src/dev/watcher.ts
@@ -37,14 +37,15 @@ const relativePath = (root: string, path: string): string | undefined => {
  * Whether `source` is inside the staging directory an output root is
  * assembled in: the package build (`package-build.ts`) and the artifact
  * build (`build.ts`) `mkdtemp` a `.<output>.stage-XXXXXX` sibling of the
- * output root and rename it into place, so those paths are build output
- * too, not source. Without this, every `dist/` package build inside
+ * output root and rename it into place, and the package build compiles in a
+ * `.<output>.compile-XXXXXX` sibling first (#656), so those paths are build
+ * output too, not source. Without this, every `dist/` package build inside
  * `agent-bundle dev` would invalidate the epoch it just produced.
  */
 const isOutputStagingPath = (output: string, source: string): boolean => {
   const parent = dirname(output);
-  const prefix = `${parent === '.' ? '' : `${parent}/`}.${basename(output)}.stage-`;
-  return source.startsWith(prefix);
+  const prefix = `${parent === '.' ? '' : `${parent}/`}.${basename(output)}.`;
+  return source.startsWith(`${prefix}stage-`) || source.startsWith(`${prefix}compile-`);
 };
 
 const defaultPathSignature = async (path: string): Promise<string | undefined> => {

--- a/packages/agent-bundle/tests/dev-watcher.test.ts
+++ b/packages/agent-bundle/tests/dev-watcher.test.ts
@@ -71,6 +71,10 @@ it('debounces only relevant source paths into one ordered invalidation and close
   // renaming it into place; that staging tree is output, not source.
   fake.emit('addDir', '/project with spaces/.dist.stage-W3rHAr');
   fake.emit('add', '/project with spaces/.dist.stage-W3rHAr/bin/plugin.js');
+  // ... and compiles into a `.dist.compile-XXXXXX` sibling first (#656).
+  fake.emit('addDir', '/project with spaces/.dist.compile-Qm2xLp');
+  fake.emit('add', '/project with spaces/.dist.compile-Qm2xLp/bin/plugin.js');
+  fake.emit('unlinkDir', '/project with spaces/.dist.compile-Qm2xLp');
   fake.emit('add', '/project with spaces/.distinct-source.ts');
   await watcher.flush();
 


### PR DESCRIPTION
Fixes red `main` (`Verify (integration-2)` at `7e56517756`, `route-invocation-dev-server.test.ts` ×2).

## Root cause

#656 made the package build compile into a second scratch sibling of the output root, `.<output>.compile-XXXXXX`, beside the existing `.<output>.stage-XXXXXX`. The `agent-bundle dev` source watcher (`dev/watcher.ts`, `isOutputStagingPath`) only knew the `.stage-` prefix, so the compile directory's creation and removal counted as a source change: every `dist/` package build inside the dev server invalidated and republished the epoch it had just produced (same source revision, new epoch id). Anything pinned to the first epoch — the parity fixtures' operator `.env`, an invocation queued against it — then ran under, or was compared against, the second one (`operator: 'missing'`, `pluginRoot` epoch mismatch).

## Fix

`isOutputStagingPath` recognises both `.<output>.stage-` and `.<output>.compile-`. `dev-watcher.test.ts` emits `addDir`/`add`/`unlinkDir` for a `.dist.compile-XXXXXX` tree and asserts no invalidation (red without the fix: `failedTests: 1`, the compile paths appear in `paths`).

## Gates (local merge gate, AGENTS.md #662; branch = `origin/main` `7e56517756` + this commit)

```
pnpm build && pnpm typecheck && pnpm lint      # ok
pnpm test:unit                                 # 4272 passed, 0 failed
AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest --config rstest.integration.config.ts \
  packages/agent-bundle/tests/route-invocation-dev-server.test.ts packages/agent-bundle/tests/dev-workbench.test.ts \
  packages/agent-bundle/tests/dev-package-build.test.ts        # 37 passed, 0 failed
```

No website change (internal watcher rule). Changeset: `patch`.

## Not fixed here

The same `main` run also fails `route-register-typegen.test.ts` ("Type 'false' does not satisfy the constraint 'true'") and three `prepack.test.ts` cases (`zod`/`vendored` dependency findings, `document.files is not iterable`) — these reproduce at `45beb54792` (#656) / `7e56517756` (#665) and are independent of this watcher rule; reported to their authors on #600.

## Self-review

Reviewer: Claude Fable 5.1 Thinking High (read-only, diff vs `origin/main`). Findings: (1) prefix derivation matches `package-build.ts:389-392`/`build.ts:695` for nested and default outputs — VERIFIED; (2) no other in-root scratch directory left unhandled (`node_modules/.agent-bundle-dts-` and `.agent-bundle/**` are excluded by directory name) — VERIFIED; (3) a shared prefix helper is a reasonable follow-up, not a blocker for a hotfix — accepted; (4) changeset ended in the literal `(#PR)` — fixed to `(#669)`. Verdict: MERGE.
