### PR TITLE
Snapshot dev host cleanup environment

### DIFF
--- a/.changeset/snapshot-dev-host-environment.md
+++ b/.changeset/snapshot-dev-host-environment.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Keep development host cleanup bound to the environment used when the host was installed. (#678)

--- a/packages/agent-bundle/src/dev/host-install-manager.ts
+++ b/packages/agent-bundle/src/dev/host-install-manager.ts
@@ -21,8 +21,10 @@ import { platformRunOf } from './platform-run.ts';
 import type { DevPlatformRuntime } from './platform-runtime.ts';
 import type { Diagnostic } from '../core/diagnostics.ts';
 import {
+  defaultCommandRunner,
   installBundle as defaultInstallBundle,
   type InstallBundleOptions,
+  type InstallCommandRunner,
   type InstallHost,
   type InstallResult,
 } from '../install/install.ts';
@@ -329,6 +331,7 @@ const syncDiagnostic = (host: InstallHost, epochId: string, error: unknown): Dia
 /** Owns opt-in host development installs for one foreground dev session. */
 export class DevHostInstallManager {
   readonly #adoption: EpochAdoptionSource | undefined;
+  readonly #commandRunner: InstallCommandRunner;
   readonly #epochStore: EpochReferenceSource;
   readonly #environment: Readonly<NodeJS.ProcessEnv>;
   readonly #eventHub: ProjectEventHub;
@@ -345,10 +348,20 @@ export class DevHostInstallManager {
 
   constructor(options: DevHostInstallManagerOptions) {
     this.#adoption = options.adoption;
-    this.#epochStore = options.epochStore;
     this.#environment = Object.freeze({ ...(options.environment ?? process.env) });
+    this.#commandRunner = Object.freeze({
+      run: (
+        command: string,
+        args: readonly string[],
+        commandOptions: { readonly cwd: string; readonly environment?: Readonly<NodeJS.ProcessEnv> },
+      ) => defaultCommandRunner.run(command, args, {
+        ...commandOptions,
+        environment: this.#environment,
+      }),
+    });
+    this.#epochStore = options.epochStore;
     this.#eventHub = options.eventHub;
-    this.#home = options.home;
+    this.#home = options.home ?? homedir();
     this.#hosts = Object.freeze([...new Set(options.hosts)]);
     this.#installBundle = options.installBundle ?? defaultInstallBundle;
     this.#projectRoot = resolve(options.projectRoot);
@@ -439,6 +452,7 @@ export class DevHostInstallManager {
       const root = stableDevBundle(this.#projectRoot, host);
       try {
         await this.#uninstallBundle({
+          commandRunner: this.#commandRunner,
           environment: this.#environment,
           force: true,
           from: root,
@@ -463,6 +477,7 @@ export class DevHostInstallManager {
       if (installed === undefined) {
         if (host !== 'cursor') await ensureStableDevBundle(prepared.root, source);
         const result = await this.#installBundle({
+          commandRunner: this.#commandRunner,
           environment: this.#environment,
           from: source,
           ...(this.#home === undefined ? {} : { home: this.#home }),

--- a/packages/agent-bundle/src/dev/host-install-manager.ts
+++ b/packages/agent-bundle/src/dev/host-install-manager.ts
@@ -346,7 +346,7 @@ export class DevHostInstallManager {
   constructor(options: DevHostInstallManagerOptions) {
     this.#adoption = options.adoption;
     this.#epochStore = options.epochStore;
-    this.#environment = options.environment ?? process.env;
+    this.#environment = Object.freeze({ ...(options.environment ?? process.env) });
     this.#eventHub = options.eventHub;
     this.#home = options.home;
     this.#hosts = Object.freeze([...new Set(options.hosts)]);

--- a/packages/agent-bundle/src/install/install.ts
+++ b/packages/agent-bundle/src/install/install.ts
@@ -71,7 +71,7 @@ export interface InstallCommandRunner {
   run(
     command: string,
     args: readonly string[],
-    options: { readonly cwd: string },
+    options: { readonly cwd: string; readonly environment?: Readonly<NodeJS.ProcessEnv> },
   ): Promise<InstallCommandResult>;
 }
 
@@ -125,9 +125,12 @@ export const defaultCommandRunner: InstallCommandRunner = Object.freeze({
   run: (
     command: string,
     args: readonly string[],
-    options: { readonly cwd: string },
+    options: { readonly cwd: string; readonly environment?: Readonly<NodeJS.ProcessEnv> },
   ): Promise<InstallCommandResult> => new Promise((resolvePromise, reject) => {
-    execFile(command, [...args], { cwd: options.cwd }, (error, stdout, stderr) => {
+    execFile(command, [...args], {
+      cwd: options.cwd,
+      ...(options.environment === undefined ? {} : { env: options.environment }),
+    }, (error, stdout, stderr) => {
       if (error !== null && isErrno(error, 'ENOENT')) {
         reject(error);
         return;


### PR DESCRIPTION
## Summary
- snapshot the dev host install environment and home for the full manager lifecycle
- pass that snapshot to host CLI processes during install and teardown
- prevent callers that restore `process.env` before server close from redirecting cleanup or making host binaries disappear

Follow-up for #677 after the merged main integration matrix exposed the teardown boundary.

## Validation
- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm test:unit` — passed
- `pnpm exec rstest packages/workbench/tests/sessions.e2e.test.ts` — passed on the branch rebased onto #677; this is the exact test that failed on all three main integration matrix versions

## Deslop
Deslop: GPT-5.6 Sol, 0 edits.

## Self-review
Reviewer: Claude Fable 5.1 Thinking High

First pass findings and disposition:
- Blocking: branch initially used a stale `origin/main`, so the test did not include #677. Fixed by fetching and rebasing onto merge commit `c2e69f20cc`.
- Blocking: snapshotting path calculations alone did not control the environment inherited by host CLI processes. Fixed by passing the snapshot through `InstallCommandRunner` to `execFile`.
- Residual: implicit `homedir()` could still change. Fixed by resolving and retaining home at manager construction.

Second pass: both blockers resolved; no blocking findings. The exact merged-main E2E is the regression guard.
