### PR TITLE
fix(amp): colocate standalone event workers

### DIFF
--- a/.changeset/fix-amp-event-worker.md
+++ b/.changeset/fix-amp-event-worker.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Keep standalone event workers beside nested Amp hook wrappers so relocated plugins can execute event routes (#739).

--- a/.changeset/fix-amp-event-worker.md
+++ b/.changeset/fix-amp-event-worker.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Keep standalone event workers beside nested Amp hook wrappers so relocated plugins can execute event routes (#739).
+Keep standalone event workers beside nested Amp hook wrappers so relocated plugins can execute event routes (#740).

--- a/packages/agent-bundle/src/build/entries.ts
+++ b/packages/agent-bundle/src/build/entries.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
-import { dirname, extname, join, relative, resolve } from 'node:path';
+import { dirname, extname, join, posix, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { hooksFlightWorkerPath } from '../adapters/composite-layout.ts';
@@ -570,12 +570,22 @@ const hookEntrySourceInputs = (entry: TargetHookEntry): readonly string[] => {
   ]);
 };
 
+const requiresStandaloneHookWorker = (entry: TargetHookEntry): boolean =>
+  entry.hook.eventRoute?.runtime === 'standalone' || entry.hook.eventRoute?.fallback === 'standalone';
+
+const hookWorkerPath = (entry: TargetHookEntry): string =>
+  posix.join(posix.dirname(entry.relativePath), posix.basename(hooksFlightWorkerPath));
+
 export const planCompiledHooks = (
   entries: readonly TargetHookEntry[],
   options: { readonly outDir: string },
 ): readonly CompiledHookEntry[] => {
-  const workerOwner = entries.findIndex((entry) =>
-    entry.hook.eventRoute?.runtime === 'standalone' || entry.hook.eventRoute?.fallback === 'standalone');
+  const workerOwners = new Map<string, number>();
+  entries.forEach((entry, index) => {
+    if (requiresStandaloneHookWorker(entry) && !workerOwners.has(hookWorkerPath(entry))) {
+      workerOwners.set(hookWorkerPath(entry), index);
+    }
+  });
   const workerSourceInputs = Object.freeze([...new Set(entries
     .filter((entry) =>
       entry.hook.eventRoute?.runtime === 'standalone' || entry.hook.eventRoute?.fallback === 'standalone')
@@ -600,9 +610,9 @@ export const planCompiledHooks = (
         executorSourceInputs: Object.freeze([entry.hook.provenance.sourcePath, entry.hook.source]),
       }),
     ...(entry.timeout === undefined ? {} : { timeout: entry.timeout }),
-    ...(index === workerOwner
+    ...(workerOwners.get(hookWorkerPath(entry)) === index
       ? {
-        workerOutput: resolveArtifactDestination(options.outDir, hooksFlightWorkerPath),
+        workerOutput: resolveArtifactDestination(options.outDir, hookWorkerPath(entry)),
         workerSourceInputs,
       }
       : {}),
@@ -629,39 +639,41 @@ export const planHooksSurface = (
   const compiled = planCompiledHooks(entries, options);
   const routeEntries = entries.filter((entry) => entry.hook.eventRoute !== undefined);
   const standaloneEventRoutes = [...new Map(routeEntries
-    .filter((entry) =>
-      entry.hook.eventRoute?.runtime === 'standalone' || entry.hook.eventRoute?.fallback === 'standalone')
+    .filter(requiresStandaloneHookWorker)
     .map((entry) => [entry.hook.id, entry.hook])).values()];
+  const workerPlans = [...new Map(entries
+    .filter(requiresStandaloneHookWorker)
+    .map((entry) => [hookWorkerPath(entry), entry.hook])).entries()];
   const workerArtifactEpoch = generatedRouteArtifactEpoch(options.plugin);
   const eventIpcRuntime = routeEntries.length === 0 ? undefined : eventRuntimeModulePath('ipc');
   const eventProjectRuntime = routeEntries.length === 0 ? undefined : eventRuntimeModulePath('project');
   const launchEnvRuntime = launchEnvRuntimePath();
-  const workerEntry = standaloneEventRoutes.length === 0
-    ? undefined
-    : {
-      name: 'hooks-flight',
-      outputRelativePath: hooksFlightWorkerPath,
-      reactServer: true as const,
-      rscManifest: true as const,
-      source: standaloneEventRoutes[0]!.source,
-      sourceInputs: Object.freeze([
-        ...new Set([
-          ...standaloneEventRoutes.flatMap((hook) => [hook.provenance.sourcePath, hook.source]),
-          ...(options.providers ?? []).map((provider) => provider.source),
-          ...(options.state === undefined ? [] : [options.state.provenance.sourcePath, options.state.source]),
-        ]),
+  const workerEntries = workerPlans.map(([outputRelativePath, hook]) => ({
+    name: outputRelativePath === hooksFlightWorkerPath
+      ? 'hooks-flight'
+      : outputRelativePath.replaceAll('/', '-').replace(/\.mjs$/u, ''),
+    outputRelativePath,
+    reactServer: true as const,
+    rscManifest: true as const,
+    source: hook.source,
+    sourceInputs: Object.freeze([
+      ...new Set([
+        ...standaloneEventRoutes.flatMap((hook) => [hook.provenance.sourcePath, hook.source]),
+        ...(options.providers ?? []).map((provider) => provider.source),
+        ...(options.state === undefined ? [] : [options.state.provenance.sourcePath, options.state.source]),
       ]),
-      virtualSource: generatedRouteFlightWorkerSource({
-        artifactEpoch: workerArtifactEpoch,
-        eventRoutes: standaloneEventRoutes,
-        ...(options.noticeDelivery === undefined ? {} : { noticeDelivery: options.noticeDelivery }),
-        providers: options.providers ?? [],
-        routes: [],
-        serverName: 'hooks',
-        ...(options.noticeRetention === undefined ? {} : { noticeRetention: options.noticeRetention }),
-        ...(options.state === undefined ? {} : { state: options.state }),
-      }),
-    };
+    ]),
+    virtualSource: generatedRouteFlightWorkerSource({
+      artifactEpoch: workerArtifactEpoch,
+      eventRoutes: standaloneEventRoutes,
+      ...(options.noticeDelivery === undefined ? {} : { noticeDelivery: options.noticeDelivery }),
+      providers: options.providers ?? [],
+      routes: [],
+      serverName: 'hooks',
+      ...(options.noticeRetention === undefined ? {} : { noticeRetention: options.noticeRetention }),
+      ...(options.state === undefined ? {} : { state: options.state }),
+    }),
+  }));
   return {
     entries: [
       ...compiled.flatMap((entry, index) => {
@@ -716,7 +728,7 @@ export const planHooksSurface = (
           },
         ];
       }),
-      ...(workerEntry === undefined ? [] : [workerEntry]),
+      ...workerEntries,
     ],
     ignoredSourcePaths: [
       runtimeIgnoredRoot(launchEnvRuntime),
@@ -732,7 +744,7 @@ export const planHooksSurface = (
             ?? (() => { throw new Error(`Missing bundled deferred hook executor evidence for ${JSON.stringify(entry.name)}.`); })(),
         }),
         ...(entry.workerOutput === undefined ? {} : {
-          workerSourceInputs: evidenceByPath.get(hooksFlightWorkerPath) ?? (() => { throw new Error('Missing bundled hook Flight worker evidence.'); })(),
+          workerSourceInputs: evidenceByPath.get(hookWorkerPath(entries[index]!)) ?? (() => { throw new Error('Missing bundled hook Flight worker evidence.'); })(),
         }),
       })));
     },

--- a/packages/agent-bundle/src/build/entries.ts
+++ b/packages/agent-bundle/src/build/entries.ts
@@ -587,8 +587,7 @@ export const planCompiledHooks = (
     }
   });
   const workerSourceInputs = Object.freeze([...new Set(entries
-    .filter((entry) =>
-      entry.hook.eventRoute?.runtime === 'standalone' || entry.hook.eventRoute?.fallback === 'standalone')
+    .filter(requiresStandaloneHookWorker)
     .flatMap((entry) => [entry.hook.provenance.sourcePath, entry.hook.source]))]);
   return deepFreeze(entries.map((entry, index) => ({
     event: entry.event,

--- a/packages/agent-bundle/src/dev/routes/route-invocation-service.ts
+++ b/packages/agent-bundle/src/dev/routes/route-invocation-service.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { fork, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, posix, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { AgentDocument, AgentDocumentNode, AgentRenderEvent } from '@agent-bundle/runtime';
@@ -603,7 +603,11 @@ const productionBindingFor = (
         && candidate.hosts.some((candidateHost) => eligibleHosts.has(candidateHost))
         && candidate.launch?.worker !== undefined))
       .find((candidate) => candidate !== undefined);
-    const standalone = manifest.files.find((file) => file.path === hooksFlightWorkerPath)?.path;
+    const standalone = [
+      ...(wrapper === undefined ? wrappers : [wrapper])
+        .map((candidate) => posix.join(posix.dirname(candidate.path), posix.basename(hooksFlightWorkerPath))),
+      hooksFlightWorkerPath,
+    ].find((candidate) => manifest.files.some((file) => file.path === candidate));
     const executable = execution.runtime === 'standalone'
       ? standalone
       : shared?.launch?.worker ?? (execution.fallback === 'standalone' ? standalone : undefined);

--- a/packages/agent-bundle/tests/amp-adapter.test.ts
+++ b/packages/agent-bundle/tests/amp-adapter.test.ts
@@ -13,7 +13,7 @@ import { validateArtifact } from '../src/build/validate-artifact.ts';
 import type { JsonObject } from '../src/core/strict-json.ts';
 import type { NormalizedHook, NormalizedPlugin } from '../src/core/types.ts';
 import { projectEventDocument } from '../src/events/projection.ts';
-import { emptyCompiledRouteGraph } from '../src/routes/graph.ts';
+import { compileRouteGraph, emptyCompiledRouteGraph } from '../src/routes/graph.ts';
 import { build } from './support/build.ts';
 import { runNodeScript } from './support/run-node-script.ts';
 
@@ -732,6 +732,82 @@ it('compiles a nested Amp hook wrapper that returns the documented tool.call dec
         hook_event_name: 'tool.call',
         session_id: 'thread-1',
         tool_input: { command: 'rm -rf /' },
+        tool_name: 'shell',
+        tool_use_id: 'tool-1',
+      }),
+    });
+    expect(result).toEqual({
+      code: 0,
+      stderr: '',
+      stdout: '{"action":"reject-and-continue","message":"blocked"}',
+    });
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+it('runs a relocated standalone event route with its worker inside the Amp plugin', async () => {
+  const projectRoot = await mkdtemp(join(process.cwd(), 'packages', 'agent-bundle', '.amp-event-route-'));
+  const config = join(projectRoot, 'agent-bundle.config.ts');
+  const handler = join(projectRoot, 'src', 'events', 'tool', 'before.tsx');
+  const outputRoot = join(projectRoot, 'artifact');
+  const relocated = join(projectRoot, 'relocated');
+  await mkdir(join(projectRoot, 'src', 'events', 'tool'), { recursive: true });
+  await writeFile(config, 'export default {};\n');
+  await writeFile(handler, [
+    "import { Agent } from '@agent-bundle/runtime';",
+    "import { createElement } from 'react';",
+    "export const config = { runtime: 'standalone' };",
+    "export default async function BeforeTool() {",
+    "  return createElement(Agent.Result, { value: { outcome: 'deny', reason: 'blocked' } });",
+    '}',
+    '',
+  ].join('\n'));
+  const base = plugin();
+  const hook = eventHook('tool-before', 'beforeTool', 'tool/before');
+  const model: NormalizedPlugin = {
+    ...base,
+    hooks: [{
+      ...hook,
+      id: 'hook:event-route:tool-before',
+      name: 'event-route-tool-before',
+      provenance: { kind: 'conventional', sourcePath: handler },
+      source: handler,
+    }],
+    mcpServers: [],
+    metadata: { ...base.metadata, provenance: { kind: 'config', sourcePath: config } },
+    skills: [],
+    targets: [{
+      id: 'target:amp',
+      name: 'amp',
+      provenance: { kind: 'config', sourcePath: config },
+    }],
+  };
+
+  try {
+    const registry = createDefaultRegistry();
+    const routeGraph = await compileRouteGraph(projectRoot, {
+      plugin: { name: 'amp-review', version: '1.0.0' },
+    });
+    const built = await build({
+      model,
+      outputRoot,
+      projectRoot: join(process.cwd(), 'packages', 'agent-bundle'),
+      registry,
+      routeGraph,
+    });
+    const wrapper = '.amp/plugins/amp-review/hooks/event-route-tool-before.mjs';
+    const worker = '.amp/plugins/amp-review/hooks/hooks-flight.mjs';
+    expect(built.manifest.files.map((file) => file.path)).toContain(worker);
+    expect(await validateArtifact({ artifactRoot: outputRoot, registry })).toEqual([]);
+
+    await rename(outputRoot, relocated);
+    const result = await runNodeScript({
+      args: [join(relocated, wrapper)],
+      input: JSON.stringify({
+        hook_event_name: 'tool.call',
+        session_id: 'thread-1',
+        tool_input: { command: 'pwd' },
         tool_name: 'shell',
         tool_use_id: 'tool-1',
       }),

--- a/packages/agent-bundle/tests/amp-adapter.test.ts
+++ b/packages/agent-bundle/tests/amp-adapter.test.ts
@@ -798,7 +798,16 @@ it('runs a relocated standalone event route with its worker inside the Amp plugi
     });
     const wrapper = '.amp/plugins/amp-review/hooks/event-route-tool-before.mjs';
     const worker = '.amp/plugins/amp-review/hooks/hooks-flight.mjs';
+    expect(built.manifest.projections).toEqual([{
+      builtInHost: 'amp',
+      documents: { entry: '.amp/plugins/amp-review/index.js' },
+      host: 'amp',
+    }]);
     expect(built.manifest.files.map((file) => file.path)).toContain(worker);
+    expect(built.manifest.files.map((file) => file.path).filter((path) => path.endsWith('/index.js')))
+      .toEqual(['.amp/plugins/amp-review/index.js']);
+    expect(built.manifest.compiler.provenance).toContainEqual(expect.objectContaining({ path: worker }));
+    expect(built.compileEvidence.assets).toContainEqual(expect.objectContaining({ path: worker }));
     expect(await validateArtifact({ artifactRoot: outputRoot, registry })).toEqual([]);
 
     await rename(outputRoot, relocated);

--- a/packages/agent-bundle/tests/amp-install.test.ts
+++ b/packages/agent-bundle/tests/amp-install.test.ts
@@ -20,7 +20,9 @@ const writeBundle = async (
 ): Promise<void> => {
   const plugin = join(root, '.amp', 'plugins', name);
   await mkdir(join(plugin, 'skills', 'review'), { recursive: true });
+  await mkdir(join(plugin, 'hooks'), { recursive: true });
   await writeFile(join(plugin, 'index.js'), `export default async function () { /* ${marker} */ }\n`);
+  await writeFile(join(plugin, 'hooks', 'hooks-flight.mjs'), `export const marker = ${JSON.stringify(marker)};\n`);
   await writeFile(join(plugin, 'skills', 'review', 'SKILL.md'), '---\nname: review\ndescription: Review code.\n---\n');
   await writeFile(join(root, 'outside.txt'), 'must not be installed\n');
   await writeInstallFixtureManifest(root, { name, version }, [{ host: 'amp' }]);
@@ -65,8 +67,10 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
       'Run `amp plugins list` in a shell to inspect the installed plugin.',
     ]);
     await expect(readFile(join(destination, 'index.js'), 'utf8')).resolves.toContain('first');
+    await expect(readFile(join(destination, 'hooks', 'hooks-flight.mjs'), 'utf8')).resolves.toContain('first');
     await expect(readFile(join(destination, 'outside.txt'), 'utf8')).rejects.toThrow();
     expect(await readInstallReceipt(destination)).toMatchObject({
+      files: expect.arrayContaining(['hooks/hooks-flight.mjs']),
       host: 'amp',
       mode: 'local',
       plugin: pluginName,
@@ -94,6 +98,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
     });
     expect(replaced.state).toBe('replaced');
     await expect(readFile(join(destination, 'index.js'), 'utf8')).resolves.toContain('second');
+    await expect(readFile(join(destination, 'hooks', 'hooks-flight.mjs'), 'utf8')).resolves.toContain('second');
     await expect(readFile(join(destination, 'disabled-state.json'), 'utf8')).resolves.toBe('{"disabled":true}\n');
     await expect(readFile(settings, 'utf8')).resolves.toBe('{"amp.plugins.disabled":["amp-install-fixture"]}\n');
 
@@ -122,6 +127,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
       state: 'uninstalled',
     });
     await expect(readFile(join(destination, 'index.js'), 'utf8')).rejects.toThrow();
+    await expect(readFile(join(destination, 'hooks', 'hooks-flight.mjs'), 'utf8')).rejects.toThrow();
     await expect(readFile(join(destination, 'skills', 'review', 'SKILL.md'), 'utf8')).rejects.toThrow();
     await expect(readFile(join(destination, 'disabled-state.json'), 'utf8')).resolves.toBe('{"disabled":true}\n');
     await expect(readFile(settings, 'utf8')).resolves.toBe('{"amp.plugins.disabled":["amp-install-fixture"]}\n');

--- a/packages/agent-bundle/tests/entries.test.ts
+++ b/packages/agent-bundle/tests/entries.test.ts
@@ -171,4 +171,45 @@ describe('event-route preflight source graph (#595)', () => {
     expect(executor.virtualSource).toContain('requestEventRuntime');
     expect(executor.virtualSource).toContain('preflight-entries@1.0.0');
   });
+
+  it('emits the standalone worker beside a nested host wrapper', () => {
+    const standalone = {
+      ...hook,
+      eventRoute: { event: 'tool/before' as const, fallback: 'none' as const, runtime: 'standalone' as const },
+      targets: ['amp'],
+    };
+    const nested = planHooks({ ...model, hooks: [standalone] }, 'amp', {
+      commandRoot: '',
+      encodePlaygroundInput: (input) => input,
+      encodePlaygroundOutput: (result) => result,
+      eventNames: {},
+      eventRouteNames: { 'tool/before': 'tool.call' },
+      hostContractRevision: 'test',
+      manifestPath: '.amp/hooks.json',
+      matchers: {},
+      registration: 'api',
+      wrapperPath: (candidate) => `.amp/plugins/preflight-entries/hooks/${candidate.name}.mjs`,
+      wrapperSource: () => 'config-hook-only\n',
+    }).hookEntries;
+    const rootWrapper = {
+      ...nested[0]!,
+      relativePath: 'hooks/event-route-tool-before.claude.mjs',
+      target: 'claude',
+    };
+    const combined = [rootWrapper, ...nested];
+    const workers = [
+      'hooks/hooks-flight.mjs',
+      '.amp/plugins/preflight-entries/hooks/hooks-flight.mjs',
+    ];
+
+    expect(planCompiledHooks(combined, { outDir: '/tmp/artifact' })
+      .flatMap((entry) => entry.workerOutput === undefined ? [] : [entry.workerOutput]))
+      .toEqual(workers.map((worker) => `/tmp/artifact/${worker}`));
+    const outputs = planHooksSurface(combined, {
+      artifactEpoch: 'preflight-entries@1.0.0',
+      outDir: '/tmp/artifact',
+      plugin: { name: 'preflight-entries', version: '1.0.0' },
+    }).entries.map((entry) => entry.outputRelativePath);
+    expect(outputs).toEqual(expect.arrayContaining(workers));
+  });
 });

--- a/packages/agent-bundle/tests/route-invocation-service.test.ts
+++ b/packages/agent-bundle/tests/route-invocation-service.test.ts
@@ -463,7 +463,7 @@ it('publishes failed event invocations with native provenance', async () => {
   });
 });
 
-it('keeps hostless shared events on their declared standalone fallback', async () => {
+it('keeps hostless shared events on a nested host standalone fallback', async () => {
   const route = {
     config: [],
     event: 'tool/after',
@@ -492,14 +492,14 @@ it('keeps hostless shared events on their declared standalone fallback', async (
           manifest: {
             executables: {
               hooks: [{
-                host: 'claude',
+                host: 'amp',
                 kind: 'event-route',
-                path: 'hooks/event-route-tool-after.claude.mjs',
+                path: '.amp/plugins/fixture/hooks/event-route-tool-after.mjs',
                 routeId: route.id,
               }],
               mcpServers: [],
             },
-            files: [{ path: 'hooks/hooks-flight.mjs' }],
+            files: [{ path: '.amp/plugins/fixture/hooks/hooks-flight.mjs' }],
             routes: {
               digest: 'digest',
               events: [{
@@ -513,7 +513,7 @@ it('keeps hostless shared events on their declared standalone fallback', async (
         },
         manifest: { plugin: { name: 'fixture', version: '1.0.0' }, projectRoot: '/project' } as never,
         stateRoot: '/project/.agent-bundle/state',
-        targets: ['claude'],
+        targets: ['amp'],
       },
       release: () => undefined,
     }),
@@ -531,7 +531,10 @@ it('keeps hostless shared events on their declared standalone fallback', async (
     diagnostics: [{ code: 'AB8236' }],
     status: 'failed',
   });
-  expect(production).toEqual({ executable: 'hooks/hooks-flight.mjs', kind: 'direct' });
+  expect(production).toEqual({
+    executable: '.amp/plugins/fixture/hooks/hooks-flight.mjs',
+    kind: 'direct',
+  });
 });
 
 const echoRoute = {

--- a/packages/agent-bundle/tests/route-invocation-service.test.ts
+++ b/packages/agent-bundle/tests/route-invocation-service.test.ts
@@ -463,7 +463,20 @@ it('publishes failed event invocations with native provenance', async () => {
   });
 });
 
-it('keeps hostless shared events on a nested host standalone fallback', async () => {
+it.each([
+  {
+    host: 'claude',
+    label: 'the shared root',
+    worker: 'hooks/hooks-flight.mjs',
+    wrapper: 'hooks/event-route-tool-after.claude.mjs',
+  },
+  {
+    host: 'amp',
+    label: 'a nested Amp plugin',
+    worker: '.amp/plugins/fixture/hooks/hooks-flight.mjs',
+    wrapper: '.amp/plugins/fixture/hooks/event-route-tool-after.mjs',
+  },
+] as const)('keeps hostless shared events on the standalone fallback in $label', async ({ host, worker, wrapper }) => {
   const route = {
     config: [],
     event: 'tool/after',
@@ -492,14 +505,14 @@ it('keeps hostless shared events on a nested host standalone fallback', async ()
           manifest: {
             executables: {
               hooks: [{
-                host: 'amp',
+                host,
                 kind: 'event-route',
-                path: '.amp/plugins/fixture/hooks/event-route-tool-after.mjs',
+                path: wrapper,
                 routeId: route.id,
               }],
               mcpServers: [],
             },
-            files: [{ path: '.amp/plugins/fixture/hooks/hooks-flight.mjs' }],
+            files: [{ path: worker }],
             routes: {
               digest: 'digest',
               events: [{
@@ -513,7 +526,7 @@ it('keeps hostless shared events on a nested host standalone fallback', async ()
         },
         manifest: { plugin: { name: 'fixture', version: '1.0.0' }, projectRoot: '/project' } as never,
         stateRoot: '/project/.agent-bundle/state',
-        targets: ['amp'],
+        targets: ['claude'],
       },
       release: () => undefined,
     }),
@@ -532,7 +545,7 @@ it('keeps hostless shared events on a nested host standalone fallback', async ()
     status: 'failed',
   });
   expect(production).toEqual({
-    executable: '.amp/plugins/fixture/hooks/hooks-flight.mjs',
+    executable: worker,
     kind: 'direct',
   });
 });

--- a/website/docs/en/reference/targets-artifacts.mdx
+++ b/website/docs/en/reference/targets-artifacts.mdx
@@ -32,6 +32,8 @@ directories appear only when the project authors them):
 artifact/
 ├── .amp/plugins/<name>/index.js          # Amp PluginAPI factory
 ├── .amp/plugins/<name>/skills/           # explicitly registered Amp skills
+├── .amp/plugins/<name>/hooks/<hook>.mjs  # Amp event callback wrappers
+├── .amp/plugins/<name>/hooks/hooks-flight.mjs  # sibling standalone event worker
 ├── .agents/plugins/marketplace.json      # Codex marketplace
 ├── .claude-plugin/plugin.json            # Claude Code manifest
 ├── .claude-plugin/marketplace.json
@@ -62,11 +64,13 @@ artifact/
 (`bundle`) file; `validate --artifact` re-checks a listed record against the
 file table (`AB6039`).
 
-Host manifests live in their dotfolders at the root. `skills/`, `hooks/`, `mcp/`, `scripts/`,
-`bin/`, and `assets/` are shared and emitted **once** — no per-host copies. Nothing else appears
-at the root: no generated `AGENTS.md`, no `hooks/hooks-cursor.json`, no `web/` directory. The
-browser host for configured MCP Apps ships inside `bin/<plugin>.mjs` as the framework-owned
-`web` command. That bin is emitted when `src/cli/**` compiled at least one command, when
+Host manifests live in their dotfolders at the root. Root-level `skills/`, `hooks/`, `mcp/`,
+`scripts/`, `bin/`, and `assets/` are shared and emitted **once**. Amp's registered skills,
+event wrappers, and each wrapper directory's sibling standalone worker stay inside
+`.amp/plugins/<name>/` so the installed plugin remains self-contained. Nothing else appears at
+the root: no generated `AGENTS.md`, no `hooks/hooks-cursor.json`, no `web/` directory. The browser
+host for configured MCP Apps ships inside `bin/<plugin>.mjs` as the framework-owned `web` command.
+That bin is emitted when `src/cli/**` compiled at least one command, when
 [`web`](./configuration.mdx#web) is configured (even with no authored CLI commands), or both.
 
 ### Where each host reads its documents

--- a/website/docs/en/reference/targets-artifacts.mdx
+++ b/website/docs/en/reference/targets-artifacts.mdx
@@ -66,7 +66,7 @@ file table (`AB6039`).
 
 Host manifests live in their dotfolders at the root. Root-level `skills/`, `hooks/`, `mcp/`,
 `scripts/`, `bin/`, and `assets/` are shared and emitted **once**. Amp's registered skills,
-event wrappers, and each wrapper directory's sibling standalone worker stay inside
+event wrappers, and the standalone worker beside those wrappers in each directory stay inside
 `.amp/plugins/<name>/` so the installed plugin remains self-contained. Nothing else appears at
 the root: no generated `AGENTS.md`, no `hooks/hooks-cursor.json`, no `web/` directory. The browser
 host for configured MCP Apps ships inside `bin/<plugin>.mjs` as the framework-owned `web` command.

--- a/website/docs/zh/reference/targets-artifacts.mdx
+++ b/website/docs/zh/reference/targets-artifacts.mdx
@@ -27,6 +27,8 @@ target 表格——各宿主投影携带什么，以及 portable 标准为何省
 artifact/
 ├── .amp/plugins/<name>/index.js          # Amp PluginAPI 工厂
 ├── .amp/plugins/<name>/skills/           # 显式注册的 Amp Skill
+├── .amp/plugins/<name>/hooks/<hook>.mjs  # Amp 事件回调 wrapper
+├── .amp/plugins/<name>/hooks/hooks-flight.mjs  # 同目录的独立事件 worker
 ├── .agents/plugins/marketplace.json      # Codex 市场
 ├── .claude-plugin/plugin.json            # Claude Code 清单
 ├── .claude-plugin/marketplace.json
@@ -56,10 +58,12 @@ artifact/
 `agent-bundle.compile-evidence.json` 是编译器对每个已编译（`bundle`）文件的记录；
 `validate --artifact` 把已列入清单的记录对照文件表复核（`AB6039`）。
 
-宿主清单位于根目录下各自的点目录中。`skills/`、`hooks/`、`mcp/`、`scripts/`、`bin/` 与 `assets/` 是共享的，
-只输出**一次**——没有逐宿主副本。根目录下不会出现其他任何东西：没有生成的 `AGENTS.md`，也没有
-`hooks/hooks-cursor.json`，也没有 `web/` 目录。已配置 MCP App 的浏览器宿主作为框架拥有的 `web` 命令
-装在 `bin/<plugin>.mjs` 里。该 bin 在 `src/cli/**` 编译出至少一条命令时、在配置了
+宿主清单位于根目录下各自的点目录中。根级 `skills/`、`hooks/`、`mcp/`、`scripts/`、`bin/` 与 `assets/`
+是共享的，只输出**一次**。Amp 注册的 Skill、事件 wrapper，以及与各 wrapper 目录同级的独立 worker
+都保留在 `.amp/plugins/<name>/` 内，使安装后的插件保持自包含。根目录下不会出现其他任何东西：
+没有生成的 `AGENTS.md`，也没有 `hooks/hooks-cursor.json`，也没有 `web/` 目录。已配置 MCP App 的浏览器
+宿主作为框架拥有的 `web` 命令装在 `bin/<plugin>.mjs` 里。该 bin 在 `src/cli/**` 编译出至少一条命令时、
+在配置了
 [`web`](./configuration.mdx#web) 时（即使没有手写 CLI 命令），或两者兼有时输出。
 
 ### 各宿主从哪里读取文档

--- a/website/docs/zh/reference/targets-artifacts.mdx
+++ b/website/docs/zh/reference/targets-artifacts.mdx
@@ -59,8 +59,8 @@ artifact/
 `validate --artifact` 把已列入清单的记录对照文件表复核（`AB6039`）。
 
 宿主清单位于根目录下各自的点目录中。根级 `skills/`、`hooks/`、`mcp/`、`scripts/`、`bin/` 与 `assets/`
-是共享的，只输出**一次**。Amp 注册的 Skill、事件 wrapper，以及与各 wrapper 目录同级的独立 worker
-都保留在 `.amp/plugins/<name>/` 内，使安装后的插件保持自包含。根目录下不会出现其他任何东西：
+是共享的，只输出**一次**。Amp 注册的 Skill、事件 wrapper，以及各目录内与这些 wrapper 同级的独立
+worker 都保留在 `.amp/plugins/<name>/` 内，使安装后的插件保持自包含。根目录下不会出现其他任何东西：
 没有生成的 `AGENTS.md`，也没有 `hooks/hooks-cursor.json`，也没有 `web/` 目录。已配置 MCP App 的浏览器
 宿主作为框架拥有的 `web` 命令装在 `bin/<plugin>.mjs` 里。该 bin 在 `src/cli/**` 编译出至少一条命令时、
 在配置了


### PR DESCRIPTION
## Summary
- emit each standalone event worker beside the wrappers that load it
- preserve the existing root worker while supporting nested Amp and mixed-host artifacts
- make hostless Workbench invocation select a wrapper-adjacent worker before the legacy root fallback
- build, relocate, validate, install, replace, uninstall, and execute the nested Amp worker in regression coverage
- document the nested Amp hook layout in English and Chinese

Follow-up to #729 after delayed self-review found nested Amp event wrappers could not load the root-level Flight worker.

## Local gate
- `pnpm build` — pass
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test:unit` — pass
- `pnpm test:route-unit` — pass
- `pnpm test:projection` — pass
- `pnpm test:integration:run` — pass
- `pnpm test:packed` — pass
- `pnpm docs:site:build` — pass

All commands ran after rebasing onto current `origin/main` at HEAD `1a32aaaeb7`.

## Deslop
Deslop: GPT-5.6 Sol, 1 edit. Reused the standalone-worker predicate for source-input planning; no defensive casts, redundant comments, or unrelated abstractions remain.

## Self-review
- Claude Fable 5.1 Thinking xhigh: found Workbench's root-only hostless worker lookup, missing bilingual layout updates, a fixture host type error, ambiguous prose, and lost root fallback coverage. All were fixed and verified.
- Claude Fable 5.1 Thinking xhigh rerun after fixes: no findings; merge-ready.
- GPT-5.6 Sol: verified per-directory planning, sibling launch resolution, manifest and compile evidence, receipt-owned install/replace/uninstall, relocation execution, one Amp `index.js`, and root+nested hostless lookup. No remaining findings.
- Codex review shown by `gh pr view --comments` completed on the opening commit without a concrete suggestion body.
