### PR TITLE
fix(test): mount pending MCP App calls

### DIFF
--- a/.changeset/browser-app-pending-opening-call.md
+++ b/.changeset/browser-app-pending-opening-call.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Allow `mountBrowserApp` to mount pending opening calls, derive `hostContext.toolInfo`, and report the invalid host-context field precisely. (#736)

--- a/examples/mcp-app/src/mcp/status/apps/status.ts
+++ b/examples/mcp-app/src/mcp/status/apps/status.ts
@@ -96,6 +96,14 @@ client.onToolError(showStatusRoute, (error) => {
   checks.replaceChildren();
 });
 
+client.onToolCancelled(({ reason }) => {
+  setStatus('unavailable');
+  summary.textContent = reason === undefined
+    ? 'Readiness check cancelled.'
+    : `Readiness check cancelled: ${reason}`;
+  checks.replaceChildren();
+});
+
 document.querySelector('#toggle-details')!.addEventListener('click', () => {
   document.querySelector('#details')!.toggleAttribute('hidden');
 });

--- a/examples/mcp-app/tests/browser-app/status-panel.browser.test.ts
+++ b/examples/mcp-app/tests/browser-app/status-panel.browser.test.ts
@@ -10,14 +10,6 @@ import {
 type BindingOperations = MountBrowserAppOptions['operations'];
 type ToolCallResult = Awaited<ReturnType<BindingOperations['callTool']>>;
 
-/**
- * The opening tool, `src/mcp/status/tools/show-status.tsx`. Framework hosts put
- * the leased tool definition in the initialize `hostContext.toolInfo`, and the
- * App client delivers `onToolInput`/`onToolResult` only to listeners on that
- * tool's route, so the harness has to open the panel with `show-status` for
- * the populated-state tests to go through the `tool:status/show-status`
- * listeners.
- */
 const showStatusTool = Object.freeze({
   _meta: Object.freeze({ ui: Object.freeze({ resourceUri: 'ui://mcp-app-example/status.html' }) }),
   description: 'Show the health of one example service.',
@@ -29,13 +21,6 @@ const showStatusTool = Object.freeze({
     type: 'object',
   }),
   name: 'show-status',
-});
-
-const openingHostContext = Object.freeze({
-  availableDisplayModes: Object.freeze(['inline']),
-  displayMode: 'inline',
-  platform: 'desktop',
-  toolInfo: Object.freeze({ tool: showStatusTool }),
 });
 
 const statusResult = Object.freeze({
@@ -118,7 +103,6 @@ const operations = (options: {
 
 const mountStatus = async (overrides: Partial<Parameters<typeof mountBrowserApp>[1]> = {}) => {
   const app = await mountBrowserApp('status', {
-    host: { context: openingHostContext },
     operations: operations(),
     toolDefinition: showStatusTool,
     toolInput: { service: 'payments-api' },
@@ -149,6 +133,11 @@ const initializeResult = (app: MountedBrowserApp): unknown => {
     ?.message.result;
 };
 
+const openingToolResults = (app: MountedBrowserApp): readonly BrowserAppTraffic[] =>
+  app.traffic.filter(({ direction, message }) => (
+    direction === 'host-to-app' && message.method === 'ui/notifications/tool-result'
+  ));
+
 it('mounts the compiled panel, initializes the bridge, and renders the published result accessibly', async () => {
   const app = await mountStatus();
   await waitFor(() => app.document.querySelector('#status')?.textContent === 'degraded');
@@ -166,9 +155,107 @@ it('mounts the compiled panel, initializes the bridge, and renders the published
   ]);
   expect(app.provenance).toMatchObject({ proofLevel: 'browser-app' });
   expect(['claude', 'codex', 'portable']).toContain(app.provenance.target);
-  expect(initializeResult(app)).toMatchObject({ hostContext: { toolInfo: { tool: { name: 'show-status' } } } });
+  expect(initializeResult(app)).toMatchObject({ hostContext: { toolInfo: { tool: showStatusTool } } });
   expect(app.traffic.some(({ message }) => message.method === 'ui/notifications/tool-input')).toBe(true);
   expect(app.traffic.some(({ message }) => message.method === 'ui/notifications/tool-result')).toBe(true);
+  expect(app.publishToolCancelled('too late')).toBe(false);
+});
+
+it('merges caller host context with the derived opening tool information', async () => {
+  const app = await mountStatus({ host: { context: { locale: 'fr-FR', theme: 'dark' } } });
+
+  expect(initializeResult(app)).toMatchObject({
+    hostContext: {
+      locale: 'fr-FR',
+      platform: 'desktop',
+      theme: 'dark',
+      toolInfo: { tool: { name: 'show-status' } },
+    },
+  });
+});
+
+it('fills the default object input schema for a partial tool definition', async () => {
+  const app = await mountStatus({
+    toolDefinition: {
+      _meta: showStatusTool._meta,
+      name: showStatusTool.name,
+    },
+  });
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'degraded');
+
+  expect(initializeResult(app)).toMatchObject({
+    hostContext: {
+      toolInfo: {
+        tool: {
+          inputSchema: { type: 'object' },
+          name: 'show-status',
+        },
+      },
+    },
+  });
+});
+
+it('rejects caller tool information that conflicts with the opening tool', async () => {
+  await expect(mountStatus({
+    host: {
+      context: {
+        toolInfo: {
+          tool: {
+            inputSchema: { type: 'object' },
+            name: 'other-tool',
+          },
+        },
+      },
+    },
+  })).rejects.toThrow(
+    'host.context.toolInfo.tool.name "other-tool" conflicts with opening tool "show-status"',
+  );
+});
+
+it('rejects a tool name that conflicts with its definition', async () => {
+  await expect(mountStatus({ toolName: 'other-tool' })).rejects.toThrow(
+    'toolDefinition.name "show-status" must match toolName "other-tool"',
+  );
+});
+
+it('mounts a pending opening call and renders its cancellation', async () => {
+  const app = await mountStatus({ toolResult: undefined });
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'checking');
+
+  expect(app.document.querySelector('h1')?.textContent).toBe('payments-api');
+  expect(openingToolResults(app)).toHaveLength(0);
+  expect(app.publishToolCancelled('The user stopped the readiness check.')).toBe(true);
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'unavailable');
+
+  expect(app.document.querySelector('#summary')?.textContent).toBe(
+    'Readiness check cancelled: The user stopped the readiness check.',
+  );
+  expect(app.traffic.some(({ message }) => message.method === 'ui/notifications/tool-cancelled')).toBe(true);
+  expect(app.publishToolResult(statusResult)).toBe(false);
+});
+
+it('settles a pending opening call with a later result', async () => {
+  const app = await mountStatus({ toolResult: undefined });
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'checking');
+
+  expect(app.publishToolResult(statusResult)).toBe(true);
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'degraded');
+
+  expect(openingToolResults(app)).toHaveLength(1);
+  expect(app.document.querySelector('h1')?.textContent).toBe('payments-api');
+});
+
+it('settles a pending opening call with a later error', async () => {
+  const app = await mountStatus({ toolResult: undefined });
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'checking');
+
+  expect(app.publishToolResult(failedStatusResult)).toBe(true);
+  await waitFor(() => app.document.querySelector('#status')?.textContent === 'unavailable');
+
+  expect(openingToolResults(app)).toHaveLength(1);
+  expect(app.document.querySelector('#summary')?.textContent).toBe(
+    'Readiness is unavailable: payments-api is not reachable from this host.',
+  );
 });
 
 it('uses the public App client without author wildcard or ext-apps plumbing', async () => {
@@ -251,11 +338,6 @@ it('fails closed when a consented binding operation is unavailable', async () =>
   expect(app.traffic.some(({ message }) => message.error?.code === -32000)).toBe(true);
   expect(app.document.querySelector('#bridge-outcome')?.textContent).not.toBe('Status refreshed.');
 });
-
-const openingToolResults = (app: MountedBrowserApp): readonly BrowserAppTraffic[] =>
-  app.traffic.filter(({ direction, message }) => (
-    direction === 'host-to-app' && message.method === 'ui/notifications/tool-result'
-  ));
 
 it('exits checking and renders an unavailable outcome when the opening result is an error', async () => {
   const calls: string[] = [];

--- a/packages/agent-bundle/src/dev/mcp-apps/mcp-app-bridge.ts
+++ b/packages/agent-bundle/src/dev/mcp-apps/mcp-app-bridge.ts
@@ -173,6 +173,8 @@ export interface McpAppBridgeCloseOptions {
 export interface CreateMcpAppBridgeOptions {
   readonly binding: McpAppBinding;
   readonly consentAuthority?: McpAppConsentAuthority;
+  /** Leave the opening call for an explicit result or cancellation publisher to settle. */
+  readonly deferInitialToolResult?: boolean;
   readonly host: McpAppBridgeHost;
   readonly maxQueuedHostMessageBytes?: number;
   readonly operations: McpAppBridgeBindingOperations;
@@ -304,8 +306,11 @@ const snapshotBinding = (value: McpAppBinding): BridgeBindingSnapshot => {
 const snapshotHost = (host: McpAppBridgeHost): McpAppBridgeHost => {
   if (!nonempty(host.info?.name) || !nonempty(host.info?.version)) throw new TypeError('MCP App host info must contain nonempty name and version values.');
   const capabilities = host.capabilities === undefined ? Object.freeze({}) : validHostCapabilities(host.capabilities);
-  const context = host.context === undefined ? Object.freeze({}) : validHostContext(host.context);
-  if (capabilities === undefined || context === undefined) throw new TypeError('MCP App host context must use stable MCP Apps field values.');
+  if (capabilities === undefined) throw new TypeError('MCP App host capabilities must use stable MCP Apps field values.');
+  const [context, contextError] = host.context === undefined
+    ? [Object.freeze({}), undefined] as const
+    : validHostContext(host.context);
+  if (context === undefined) throw new TypeError(contextError);
   return Object.freeze({
     ...host,
     capabilities,
@@ -491,60 +496,85 @@ const validObjectJsonSchema = (value: unknown): boolean => {
   return schema.required === undefined || (Array.isArray(schema.required) && schema.required.every((required) => typeof required === 'string'));
 };
 
-const validToolDefinition = (value: unknown): boolean => {
+const invalidToolDefinitionField = (value: unknown): string | undefined => {
   const tool = jsonRecord(value);
-  if (tool === undefined || !nonempty(tool.name) || !validObjectJsonSchema(tool.inputSchema)) return false;
-  if (tool.outputSchema !== undefined && !validObjectJsonSchema(tool.outputSchema)) return false;
-  if (tool.icons !== undefined && !validIcons(tool.icons)) return false;
-  if (tool.title !== undefined && typeof tool.title !== 'string') return false;
-  if (tool.description !== undefined && typeof tool.description !== 'string') return false;
+  if (tool === undefined) return 'tool';
+  if (!nonempty(tool.name)) return 'tool.name';
+  if (!validObjectJsonSchema(tool.inputSchema)) return 'tool.inputSchema';
+  if (tool.outputSchema !== undefined && !validObjectJsonSchema(tool.outputSchema)) return 'tool.outputSchema';
+  if (tool.icons !== undefined && !validIcons(tool.icons)) return 'tool.icons';
+  if (tool.title !== undefined && typeof tool.title !== 'string') return 'tool.title';
+  if (tool.description !== undefined && typeof tool.description !== 'string') return 'tool.description';
   if (tool.annotations !== undefined) {
     const annotations = jsonRecord(tool.annotations);
     if (annotations === undefined
       || (annotations.title !== undefined && !nonempty(annotations.title))
-      || ['readOnlyHint', 'destructiveHint', 'idempotentHint', 'openWorldHint'].some((key) => annotations[key] !== undefined && typeof annotations[key] !== 'boolean')) return false;
+      || ['readOnlyHint', 'destructiveHint', 'idempotentHint', 'openWorldHint'].some((key) => annotations[key] !== undefined && typeof annotations[key] !== 'boolean')) return 'tool.annotations';
   }
   if (tool.execution !== undefined) {
     const execution = jsonRecord(tool.execution);
-    if (execution === undefined || (execution.taskSupport !== undefined && execution.taskSupport !== 'required' && execution.taskSupport !== 'optional' && execution.taskSupport !== 'forbidden')) return false;
+    if (execution === undefined || (execution.taskSupport !== undefined && execution.taskSupport !== 'required' && execution.taskSupport !== 'optional' && execution.taskSupport !== 'forbidden')) return 'tool.execution';
   }
-  return true;
+  return undefined;
 };
 
-const validHostContext = (value: unknown): McpAppBridgeJsonRecord | undefined => {
+type HostContextValidation = readonly [
+  context: McpAppBridgeJsonRecord | undefined,
+  error: string | undefined,
+];
+
+const invalidHostContext = (field: string): HostContextValidation => [
+  undefined,
+  `MCP App host context.${field} must use a valid MCP Apps field value.`,
+];
+
+const validHostContext = (value: unknown): HostContextValidation => {
   const context = jsonRecord(value);
-  if (context === undefined) return undefined;
-  if (context.theme !== undefined && context.theme !== 'light' && context.theme !== 'dark') return undefined;
-  if (context.displayMode !== undefined && (typeof context.displayMode !== 'string' || !displayModes.has(context.displayMode as McpAppBridgeDisplayMode))) return undefined;
-  if (context.availableDisplayModes !== undefined && validDisplayModeList(context.availableDisplayModes) === undefined) return undefined;
-  if (context.locale !== undefined && !nonempty(context.locale)) return undefined;
-  if (context.timeZone !== undefined && !nonempty(context.timeZone)) return undefined;
-  if (context.userAgent !== undefined && !nonempty(context.userAgent)) return undefined;
-  if (context.platform !== undefined && context.platform !== 'web' && context.platform !== 'desktop' && context.platform !== 'mobile') return undefined;
+  if (context === undefined) return [undefined, 'MCP App host context must use stable MCP Apps field values.'];
+  if (context.theme !== undefined && context.theme !== 'light' && context.theme !== 'dark') {
+    return [undefined, 'MCP App host context.theme must be "light" or "dark".'];
+  }
+  if (context.displayMode !== undefined && (typeof context.displayMode !== 'string' || !displayModes.has(context.displayMode as McpAppBridgeDisplayMode))) return invalidHostContext('displayMode');
+  if (context.availableDisplayModes !== undefined && validDisplayModeList(context.availableDisplayModes) === undefined) return invalidHostContext('availableDisplayModes');
+  if (context.locale !== undefined && !nonempty(context.locale)) return invalidHostContext('locale');
+  if (context.timeZone !== undefined && !nonempty(context.timeZone)) return invalidHostContext('timeZone');
+  if (context.userAgent !== undefined && !nonempty(context.userAgent)) return invalidHostContext('userAgent');
+  if (context.platform !== undefined && context.platform !== 'web' && context.platform !== 'desktop' && context.platform !== 'mobile') return invalidHostContext('platform');
   if (context.toolInfo !== undefined) {
     const toolInfo = jsonRecord(context.toolInfo);
-    if (toolInfo === undefined || !validToolDefinition(toolInfo.tool) || (toolInfo.id !== undefined && !isRequestId(toolInfo.id))) return undefined;
+    if (toolInfo === undefined) return invalidHostContext('toolInfo');
+    const invalidToolField = invalidToolDefinitionField(toolInfo.tool);
+    if (invalidToolField === 'tool.inputSchema' || invalidToolField === 'tool.outputSchema') {
+      return [
+        undefined,
+        `MCP App host context.toolInfo.${invalidToolField} must be an object-rooted JSON Schema.`,
+      ];
+    }
+    if (invalidToolField !== undefined) return invalidHostContext(`toolInfo.${invalidToolField}`);
+    if (toolInfo.id !== undefined && !isRequestId(toolInfo.id)) {
+      return [undefined, 'MCP App host context.toolInfo.id must be a JSON-RPC request id.'];
+    }
   }
   if (context.deviceCapabilities !== undefined) {
     const device = jsonRecord(context.deviceCapabilities);
-    if (device === undefined || (device.touch !== undefined && typeof device.touch !== 'boolean') || (device.hover !== undefined && typeof device.hover !== 'boolean')) return undefined;
+    if (device === undefined || (device.touch !== undefined && typeof device.touch !== 'boolean') || (device.hover !== undefined && typeof device.hover !== 'boolean')) return invalidHostContext('deviceCapabilities');
   }
   if (context.styles !== undefined) {
     const styles = jsonRecord(context.styles);
     const variables = styles === undefined || styles.variables === undefined ? undefined : jsonRecord(styles.variables);
     const css = styles === undefined || styles.css === undefined ? undefined : jsonRecord(styles.css);
     if (styles === undefined || (styles.variables !== undefined && (variables === undefined || !Object.entries(variables).every(([key, variable]) => hostStyleVariables.has(key) && typeof variable === 'string')))
-      || (styles.css !== undefined && (css === undefined || (css.fonts !== undefined && typeof css.fonts !== 'string')))) return undefined;
+      || (styles.css !== undefined && (css === undefined || (css.fonts !== undefined && typeof css.fonts !== 'string')))) return invalidHostContext('styles');
   }
   if (context.containerDimensions !== undefined) {
     const dimensions = jsonRecord(context.containerDimensions);
-    if (dimensions === undefined || !['height', 'maxHeight', 'width', 'maxWidth'].every((key) => dimensions[key] === undefined || (typeof dimensions[key] === 'number' && Number.isFinite(dimensions[key]) && dimensions[key] >= 0))) return undefined;
+    if (dimensions === undefined || !['height', 'maxHeight', 'width', 'maxWidth'].every((key) => dimensions[key] === undefined || (typeof dimensions[key] === 'number' && Number.isFinite(dimensions[key]) && dimensions[key] >= 0))) return invalidHostContext('containerDimensions');
   }
   if (context.safeAreaInsets !== undefined) {
     const insets = jsonRecord(context.safeAreaInsets);
-    if (insets === undefined || !['top', 'right', 'bottom', 'left'].every((key) => typeof insets[key] === 'number' && Number.isFinite(insets[key]) && insets[key] >= 0)) return undefined;
+    if (insets === undefined || !['top', 'right', 'bottom', 'left'].every((key) => typeof insets[key] === 'number' && Number.isFinite(insets[key]) && insets[key] >= 0)) return invalidHostContext('safeAreaInsets');
   }
-  return context;
+  return [context, undefined];
 };
 
 const validResourceMetadata = (value: unknown): McpAppBridgeJsonRecord | undefined => {
@@ -1373,7 +1403,7 @@ export const createMcpAppBridge = (options: CreateMcpAppBridgeOptions): McpAppBr
       }
     },
     publishHostContextChanged(context: McpAppBridgeJsonRecord): boolean {
-      const snapshot = validHostContext(context);
+      const [snapshot] = validHostContext(context);
       if (snapshot === undefined) return false;
       const availableDisplayModes = snapshot.availableDisplayModes === undefined ? undefined : validDisplayModeList(snapshot.availableDisplayModes);
       const published = emitHost(Object.freeze({ jsonrpc: '2.0', method: 'ui/notifications/host-context-changed', params: snapshot }));
@@ -1452,7 +1482,7 @@ export const createMcpAppBridge = (options: CreateMcpAppBridgeOptions): McpAppBr
           }
           inputQueued = true;
         }
-        if (!terminalQueued) {
+        if (!terminalQueued && options.deferInitialToolResult !== true) {
           const resultMessage = Object.freeze({
             jsonrpc: '2.0',
             method: 'ui/notifications/tool-result',

--- a/packages/agent-bundle/src/test/browser.ts
+++ b/packages/agent-bundle/src/test/browser.ts
@@ -16,6 +16,7 @@ import type {
   McpAppJsonValue,
   McpAppToolDefinition,
 } from '../dev/mcp-apps/mcp-app-binding-service.ts';
+import { snapshotMcpAppJsonRecord } from '../dev/mcp-apps/mcp-app-json.ts';
 import type { McpAppProfileId } from '../dev/mcp-app-profile-descriptors.ts';
 import type {
   McpAppConsentAuthority,
@@ -74,7 +75,8 @@ export interface MountBrowserAppOptions {
   readonly toolDefinition?: McpAppToolDefinition;
   readonly toolInput?: McpAppBridgeJsonRecord;
   readonly toolName?: string;
-  readonly toolResult: McpAppJsonValue;
+  /** Initial terminal result; omit it while the opening call is in flight. */
+  readonly toolResult?: McpAppJsonValue;
 }
 
 export interface MountedBrowserApp {
@@ -112,6 +114,7 @@ export class BrowserAppTestError extends Error {
 const registrySymbol = Symbol.for(AGENT_BROWSER_TEST_REGISTRY_SYMBOL_KEY);
 const realm = globalThis as typeof globalThis & { [registrySymbol]?: AgentBrowserTestRegistry };
 let nextBindingId = 1;
+const pendingToolResult = Object.freeze({ content: Object.freeze([]) });
 
 const unavailableProvenance = (name: string): BrowserAppProvenance => ({
   name,
@@ -236,7 +239,12 @@ const bindingFor = (
   app: CompiledBrowserTestApp,
   options: MountBrowserAppOptions,
 ): McpAppBinding => {
-  const toolName = options.toolName ?? `show-${app.name}`;
+  const toolName = options.toolName ?? options.toolDefinition?.name ?? `show-${app.name}`;
+  if (options.toolDefinition !== undefined && options.toolDefinition.name !== toolName) {
+    throw new TypeError(
+      `Browser App toolDefinition.name ${JSON.stringify(options.toolDefinition.name)} must match toolName ${JSON.stringify(toolName)}.`,
+    );
+  }
   const serverNames = app.serverIds.map((id) => id.startsWith('mcp:') ? id.slice('mcp:'.length) : id);
   const serverName = options.serverName ?? (serverNames.length === 1 ? serverNames[0] : undefined);
   if (serverName === undefined || !serverNames.includes(serverName)) {
@@ -244,21 +252,23 @@ const bindingFor = (
       `Browser App ${JSON.stringify(app.name)} requires one serverName from ${JSON.stringify(serverNames)}.`,
     );
   }
+  const toolDefinition: McpAppToolDefinition = options.toolDefinition ?? {
+    _meta: { ui: { resourceUri: app.resourceUri } },
+    name: toolName,
+  };
   return Object.freeze({
     epochId: `browser-app:${app.name}`,
     id: `browser-app-binding-${String(nextBindingId++)}`,
     input: options.toolInput ?? {},
     previewProfile: selectedProfile(app, options.profile),
     resourceUri: app.resourceUri,
-    result: options.toolResult,
+    result: options.toolResult ?? pendingToolResult,
     serverName,
     sessionId: `browser-app-session:${app.name}`,
     target: app.target,
-    toolDefinition: options.toolDefinition ?? Object.freeze({
-      _meta: { ui: { resourceUri: app.resourceUri } },
-      inputSchema: { type: 'object' },
-      name: toolName,
-    }),
+    toolDefinition: toolDefinition.inputSchema === undefined
+      ? Object.freeze({ ...toolDefinition, inputSchema: { type: 'object' } })
+      : toolDefinition,
     toolName,
   });
 };
@@ -278,6 +288,38 @@ export const mountBrowserApp = async (
   const openLinks: string[] = [];
   const sizes: McpAppBridgeSize[] = [];
   const userHost = options.host;
+  const binding = (() => {
+    try {
+      return bindingFor(app, options);
+    } catch (error) {
+      throw new BrowserAppTestError('MCP App bridge could not be created.', provenance, [
+        `cause: ${error instanceof Error ? error.message : String(error)}`,
+      ]);
+    }
+  })();
+  const toolDefinition = snapshotMcpAppJsonRecord(binding.toolDefinition);
+  if (toolDefinition === undefined) {
+    throw new BrowserAppTestError('MCP App toolDefinition must use stable JSON field values.', provenance);
+  }
+  const userContextValue = userHost?.context;
+  const userContext = snapshotMcpAppJsonRecord(userContextValue);
+  if (userContextValue !== undefined && userContext === undefined) {
+    throw new BrowserAppTestError('MCP App host.context must use stable JSON field values.', provenance);
+  }
+  const suppliedToolInfoValue = userContext?.toolInfo;
+  const suppliedToolInfo = snapshotMcpAppJsonRecord(suppliedToolInfoValue);
+  if (suppliedToolInfoValue !== undefined) {
+    const suppliedTool = snapshotMcpAppJsonRecord(
+      suppliedToolInfo?.tool,
+    );
+    const suppliedName = suppliedTool?.name;
+    if (suppliedName !== binding.toolName) {
+      throw new BrowserAppTestError(
+        `MCP App host.context.toolInfo.tool.name ${JSON.stringify(suppliedName)} conflicts with opening tool ${JSON.stringify(binding.toolName)}.`,
+        provenance,
+      );
+    }
+  }
   const host: McpAppBridgeHost = {
     capabilities: userHost?.capabilities ?? {
       downloadFile: {},
@@ -286,10 +328,12 @@ export const mountBrowserApp = async (
       serverResources: {},
       serverTools: {},
     },
-    context: userHost?.context ?? {
+    context: {
       availableDisplayModes: ['inline'],
       displayMode: 'inline',
       platform: 'desktop',
+      ...userContext,
+      toolInfo: { ...suppliedToolInfo, tool: toolDefinition },
     },
     info: userHost?.info ?? { name: 'agent-bundle-browser-test', version: '1.0.0' },
     ...(userHost?.onDisplayMode === undefined ? {} : { onDisplayMode: userHost.onDisplayMode }),
@@ -351,8 +395,9 @@ export const mountBrowserApp = async (
   const bridge = (() => {
     try {
       return createMcpAppBridge({
-        binding: bindingFor(app, options),
+        binding,
         consentAuthority: authority,
+        deferInitialToolResult: options.toolResult === undefined,
         host,
         operations: options.operations,
         profile: selectedProfile(app, options.profile),
@@ -371,7 +416,7 @@ export const mountBrowserApp = async (
     }
   })();
   window.addEventListener('message', onMessage);
-  if (!bridge.publishToolResult(options.toolResult)) {
+  if (options.toolResult !== undefined && !bridge.publishToolResult(options.toolResult)) {
     window.removeEventListener('message', onMessage);
     await bridge.forceClose().catch(() => undefined);
     iframe.remove();

--- a/packages/agent-bundle/tests/mcp-app-bridge.test.ts
+++ b/packages/agent-bundle/tests/mcp-app-bridge.test.ts
@@ -150,6 +150,30 @@ it('preserves the stable Apps handshake and delays original tool data until init
   expect(bridge.lifecycle).toBe('initialized');
 });
 
+it('leaves the opening result pending when automatic publication is deferred', async () => {
+  const fixture = fixtureFor();
+  const bridge = createMcpAppBridge({
+    binding: fixture.binding,
+    deferInitialToolResult: true,
+    host: fixture.host,
+    operations: fixture.operations,
+    send: (message) => (fixture.sent.push(message), true),
+  });
+
+  await bridge.receive(initialize('init:pending'));
+  await bridge.receive(initialized());
+
+  expect(fixture.sent.slice(1)).toEqual([
+    { jsonrpc: '2.0', method: 'ui/notifications/tool-input', params: { arguments: { city: 'Paris', units: 'metric' } } },
+  ]);
+  expect(bridge.publishToolCancelled('user-dismissed')).toBe(true);
+  expect(fixture.sent.at(-1)).toEqual({
+    jsonrpc: '2.0',
+    method: 'ui/notifications/tool-cancelled',
+    params: { reason: 'user-dismissed' },
+  });
+});
+
 it('accepts the stable parameterless initialized notification before flushing host traffic', async () => {
   const fixture = fixtureFor();
   const bridge = createMcpAppBridge({ binding: fixture.binding, host: fixture.host, operations: fixture.operations, send: (message) => (fixture.sent.push(message), true) });
@@ -309,7 +333,9 @@ it('rejects host tool metadata whose JSON Schemas are not object-rooted', () => 
     },
   });
 
-  expect(() => createMcpAppBridge({ binding: fixture.binding, host: fixture.host, operations: fixture.operations, send: () => true })).toThrow('MCP App host context must use stable MCP Apps field values.');
+  expect(() => createMcpAppBridge({ binding: fixture.binding, host: fixture.host, operations: fixture.operations, send: () => true })).toThrow(
+    'MCP App host context.toolInfo.tool.inputSchema must be an object-rooted JSON Schema.',
+  );
 });
 
 it('forwards only same-binding app-visible tools and resources while retaining request ids', async () => {
@@ -580,19 +606,27 @@ it('rejects malformed JSON-RPC envelopes and payloads before executing host call
     host: { ...fixture.host, context: { theme: 'sepia' } },
     operations: fixture.operations,
     send: () => true,
-  })).toThrow('MCP App host context must use stable MCP Apps field values.');
+  })).toThrow('MCP App host context.theme must be "light" or "dark".');
   expect(() => createMcpAppBridge({
     binding: fixture.binding,
     host: { ...fixture.host, capabilities: { serverTools: { listChanged: 'yes' } } },
     operations: fixture.operations,
     send: () => true,
-  })).toThrow('MCP App host context must use stable MCP Apps field values.');
+  })).toThrow('MCP App host capabilities must use stable MCP Apps field values.');
   expect(() => createMcpAppBridge({
     binding: fixture.binding,
-    host: { ...fixture.host, context: { toolInfo: { id: {}, tool: { name: 'show-weather' } } } },
+    host: {
+      ...fixture.host,
+      context: {
+        toolInfo: {
+          id: {},
+          tool: { inputSchema: { type: 'object' }, name: 'show-weather' },
+        },
+      },
+    },
     operations: fixture.operations,
     send: () => true,
-  })).toThrow('MCP App host context must use stable MCP Apps field values.');
+  })).toThrow('MCP App host context.toolInfo.id must be a JSON-RPC request id.');
 
   fixture.operations.callTool = async () => ({ content: [{ text: 42, type: 'text' }] }) as unknown as McpAppJsonValue;
   await bridge.receive({ id: 'bad-result', jsonrpc: '2.0', method: 'tools/call', params: { name: 'refresh-weather' } });

--- a/website/docs/en/examples/mcp-app.mdx
+++ b/website/docs/en/examples/mcp-app.mdx
@@ -46,8 +46,9 @@ to see how the surfaces fit together instead of studying one of them alone.
   creates its client with `createAppClient` from `agent-bundle/app`, receives the opening
   `show-status` call's input and structured result through `onToolInput` / `onToolResult`, and
   surfaces failed or unstructured opening results through `onToolError` registered on
-  `tool:status/show-status` (delivered when the host's initialize result names `show-status` as
-  the opening tool). **Refresh status** calls the same `show-status` tool again for the service
+  `tool:status/show-status`. Those route listeners fire when the host's initialize result names
+  `show-status` as the opening tool; `onToolCancelled` separately surfaces a host-cancelled
+  opening call. **Refresh status** calls the same `show-status` tool again for the service
   on screen, and **Read policy** reads the `readiness-policy` resource through
   `request('resources/read', …)`. The route id, input, and result are typed by the generated
   `.agent-bundle/routes.d.ts`, so the App declares no contract map of its own. No JSON-RPC ids,

--- a/website/docs/en/guide/development/testing.mdx
+++ b/website/docs/en/guide/development/testing.mdx
@@ -236,6 +236,14 @@ product bridge in a real browser page — and `simulated` reuses the installed-h
 an isolated host-shaped root and spawned without a host-owned install, which is weaker than
 `host-install`.
 
+`mountBrowserApp` derives the opening call's `hostContext.toolInfo` from `toolName` and
+`toolDefinition`, publishes `toolInput`, and merges any other `host.context` fields. Do not repeat
+`toolInfo` in `host.context`; a conflicting opening tool name is rejected. Pass `toolResult` to
+publish an already-settled result during mount. Omit it when the opening call is still in flight,
+then settle exactly once with `publishToolResult(...)` — including an `isError: true` result — or
+`publishToolCancelled(reason?)`. Each publisher returns whether the bridge accepted that terminal
+notification.
+
 ```ts twoslash
 import { cliJson, cliNdjson, invokeCli, invokeMcpTool } from 'agent-bundle/test';
 

--- a/website/docs/zh/examples/mcp-app.mdx
+++ b/website/docs/zh/examples/mcp-app.mdx
@@ -37,8 +37,9 @@ description: 'MCP App 示例：把一条服务就绪度工作流表达为生成�
   [测试](../guide/development/testing.mdx)中的 `browser-app` 级别。
 - **App 是桥接的客户端，而不是自带 transport。** `src/mcp/status/apps/status.ts` 从 `agent-bundle/app`
   创建客户端，通过 `onToolInput` / `onToolResult` 接收打开 App 的 `show-status` 输入与结构化结果，并用
-  注册在 `tool:status/show-status` 上的 `onToolError` 展示失败或缺少结构化数据的打开结果（当宿主的
-  initialize 结果指定 `show-status` 为打开工具时送达）。**Refresh status** 为屏幕上的服务再次调用同一个
+  注册在 `tool:status/show-status` 上的 `onToolError` 展示失败或缺少结构化数据的打开结果；
+  当宿主的 initialize 结果指定 `show-status` 为打开工具时，这些路由监听器才会触发；
+  `onToolCancelled` 则独立展示被宿主取消的开场调用。**Refresh status** 为屏幕上的服务再次调用同一个
   `show-status` 工具，**Read policy** 通过 `request('resources/read', …)` 读取 `readiness-policy`
   资源。路由 id、输入与结果由生成的 `.agent-bundle/routes.d.ts` 提供类型，因此 App 自己不声明任何契约
   表。视图中不再保留 JSON-RPC id、pending map、`postMessage('*')` 或 `structuredContent` 解包逻辑。详见

--- a/website/docs/zh/guide/development/testing.mdx
+++ b/website/docs/zh/guide/development/testing.mdx
@@ -206,6 +206,13 @@ try {
 —— 一份输出的捆绑包被直接投放到隔离的宿主形状根目录并在没有宿主自有安装的情况下启动，它比
 `host-install` 更弱。
 
+`mountBrowserApp` 会根据 `toolName` 与 `toolDefinition` 派生开场调用的
+`hostContext.toolInfo`，发布 `toolInput`，并合并其他 `host.context` 字段。不要在
+`host.context` 中重复提供 `toolInfo`；冲突的开场工具名会被拒绝。传入 `toolResult`
+会在挂载期间发布已经结算的结果。若开场调用仍在进行中，则省略它，之后再用
+`publishToolResult(...)`（包括 `isError: true` 的结果）或 `publishToolCancelled(reason?)`
+结算且只能结算一次。每个发布方法都会返回桥接层是否接受了该终态通知。
+
 ```ts twoslash
 import { cliJson, cliNdjson, invokeCli, invokeMcpTool } from 'agent-bundle/test';
 


### PR DESCRIPTION
Closes #736.

## Summary

- Make `MountBrowserAppOptions.toolResult` optional: omission mounts the opening call in flight, publishes its input, and leaves cancellation/result/error to the mounted harness publishers.
- Derive canonical `hostContext.toolInfo.tool` from `toolName` / `toolDefinition`, fill the existing object-schema default for partial definitions, merge caller host context, and reject conflicting tool names.
- Name invalid MCP App host-context fields in bridge construction errors instead of reporting only generic unstable values.
- Prove cancellation through the convention-first MCP App, preserve initial-result behavior, and document the public contract in English and Chinese.

## Proof

The browser-App suite observes `onToolInput` render `checking`, then proves each terminal path independently: cancellation renders through `onToolCancelled`, a later result renders `degraded`, and a later `isError` result renders unavailable. The existing initial result still arrives during mount and rejects later cancellation. It also verifies derived full tool metadata, caller-context merging, partial tool definitions, and conflicting metadata rejection.

## Local merge gate

Branch contains `origin/main` at `240d7b0a97`.

```text
pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit
# passed: build, typecheck, lint (1,493 files), 4,482 tests / 0 failed (4,476 passed, 6 skipped)

AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest --config rstest.integration.config.ts \
  packages/agent-bundle/tests/examples-contract.test.ts \
  packages/agent-bundle/tests/mcp-apps-compile.test.ts \
  packages/agent-bundle/tests/serve-app.test.ts \
  packages/workbench/tests/mcp-app-preview-browser.test.ts \
  packages/workbench/tests/mcp-app-frame.test.ts \
  packages/workbench/tests/mcp-app-real.e2e.test.ts \
  packages/workbench/tests/examples-real.e2e.test.ts \
  packages/workbench/tests/web-command.e2e.test.ts
# passed: 60 / 60

pnpm --filter @agent-bundle-example/mcp-app check
pnpm --dir examples/mcp-app test:browser-app
# passed: validate/build/typecheck; 14 / 14 browser-App tests

pnpm docs:site:build
# passed: locale parity, 0 broken links / 29,989 anchors
```

## Deslop

Deslop: GPT-5.6 Sol, 1 edit (moved the opening-result test helper before its first use).

## Self-review

Reviewer: Claude Fable 5.1 Thinking (high), `change-risk-reviewer`, two passes.

| Finding | Disposition |
| --- | --- |
| Medium: deriving `toolInfo` made a name-only `toolDefinition` fail for missing `inputSchema` | Fixed by filling the harness's existing `{ type: 'object' }` default; browser regression added. |
| Low: example prose made opening-tool gating appear to apply to `onToolCancelled` | Fixed in English and Chinese; route listeners and global cancellation are now distinct. |
| Low: caller `toolInfo` conflict detection is name-only | Accepted: the opening tool name is the routing identity; the canonical definition always comes from harness options, and docs tell callers not to duplicate it. |
| Low: explicit deferred terminal state is not replayed after a second `ui/initialize` | Accepted: `mountBrowserApp` models one mounted opening call; no rebind surface is exposed by the harness. |
| Info: pending bindings carry an internal empty result for `loadResource()` fallback | Accepted: browser-App mounts compiled `srcdoc` and never resolves its resource through that fallback; no placeholder reaches the App wire. |
| Low: default display context now survives a partial caller context | Accepted and documented: merging defaults plus caller fields is the requested harness behavior. |

Second pass: both fixes verified; no remaining merge blockers.
