### PR TITLE
docs(audiobook-curator): optional --report/--receipt covers thirteen commands, not two

### DIFF
--- a/.changeset/725-receipt-paths-optional.md
+++ b/.changeset/725-receipt-paths-optional.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Document the `audiobook-curator` example's CLI migration accurately: since the `<tool>.cli.ts` projections replaced the `src/cli/` tree (#734), `inventory --report` and `convert --receipt` are optional, as they are on the tools, instead of required; a command run without one writes no report or receipt file, and exit codes, `--apply` gating, and error output are unchanged. (#738)
+Document the `audiobook-curator` example's CLI migration accurately: since the `<tool>.cli.ts` projections replaced the `src/cli/` tree (#734), every `--report` and `--receipt` option (thirteen of the sixteen commands, `inventory --report` and `convert --receipt` among them) is optional, as it is on the tools, instead of required; a command run without one writes no report or receipt file, and exit codes, `--apply` gating, and error output are unchanged. (#738)

--- a/examples/audiobook-curator/README.md
+++ b/examples/audiobook-curator/README.md
@@ -168,10 +168,12 @@ Suspense fallback, and byte for byte the `structuredContent` of the tool call.
 `--report` and `--receipt` are optional on the command line exactly as they are
 on the tool; a command that gets one still writes the receipt file
 when it succeeds. This is a
-behavior change from the retired `src/cli/` tree, where `inventory --report`
-and `convert --receipt` were required: both commands now run without a receipt
-path and write no report or receipt file, and their exit codes, `--apply` gating, and error
-output are unchanged either way.
+behavior change from the retired `src/cli/` tree, where every command that
+took a report or receipt path — thirteen of the sixteen, `inventory --report`
+and `convert --receipt` among them — required it: those commands now run
+without the path and write no report or receipt file, and their exit codes,
+`--apply` gating, and error output are unchanged either way. `inspect`,
+`prepare`, and `shelf` never took one.
 
 Each tool module declares its `inputSchema` as an inline zod literal, because
 the argv projection is compiled statically from that literal; it is the only

--- a/website/docs/en/examples/audiobook-curator.mdx
+++ b/website/docs/en/examples/audiobook-curator.mdx
@@ -77,9 +77,10 @@ emits one result-schema-validated JSON value followed by a newline: the canonica
 and byte for byte the `structuredContent` of the tool call. `--report` and `--receipt` are
 optional on the command line exactly as they are on the tool; a command that gets one still
 writes the receipt file when it succeeds. This is a behavior change from the retired `src/cli/` tree, where
-`inventory --report` and `convert --receipt` were required: both commands now run without a
-receipt path and write no report or receipt file, and their exit codes, `--apply` gating, and error output are
-unchanged either way.
+every command that took a report or receipt path — thirteen of the sixteen, `inventory --report`
+and `convert --receipt` among them — required it: those commands now run without the path and
+write no report or receipt file, and their exit codes, `--apply` gating, and error output are
+unchanged either way. `inspect`, `prepare`, and `shelf` never took one.
 
 ## Working in the workspace
 

--- a/website/docs/zh/examples/audiobook-curator.mdx
+++ b/website/docs/zh/examples/audiobook-curator.mdx
@@ -62,8 +62,9 @@ description: '有声书策展器示例：一个由路由模块、请求上下文
 并输出一个经结果 schema 校验的 JSON 值加一个换行：这是最终的规范 `Agent.Result` 值，绝不是 Markdown
 表现，也绝不是中间的 Suspense 回退，并且与工具调用的 `structuredContent` 逐字节一致。`--report` 与
 `--receipt` 在命令行上和在工具上一样是可选的；传入了的命令在成功时仍会写出收据文件。这相对于已移除的
-`src/cli/` 树是一处行为变化：那里的 `inventory --report` 与 `convert --receipt` 是必填的；现在这两条命令
-不带收据路径也能运行且不写报告或收据文件，而退出码、`--apply` 把关与错误输出在两种情况下都不变。
+`src/cli/` 树是一处行为变化：那里每条接受报告或收据路径的命令（十六条中的十三条，包括 `inventory --report`
+与 `convert --receipt`）都把它设为必填；现在这些命令不带该路径也能运行且不写报告或收据文件，而退出码、
+`--apply` 把关与错误输出在两种情况下都不变。`inspect`、`prepare` 与 `shelf` 从来不接受这个参数。
 
 ## 在工作区中开发
 


### PR DESCRIPTION
Follow-up to #738. Its migration note named only `inventory --report` and `convert --receipt`, but every retired `src/cli/` route that took a report or receipt path required it — thirteen of sixteen (`inspect`, `prepare`, `shelf` never took one):

```
git ls-tree a2eb7f4ea5^ examples/audiobook-curator/src/cli/  # receipt/report: z.string().min(1).max(4096) in 13 files
```

Docs-only: en/zh example page, example README, and the wording of the not-yet-versioned `.changeset/725-receipt-paths-optional.md` (#738). No code, no schema change; the #738 tests already cover the omitted-path behavior on inventory, audible-select, and convert, and the other ten share the same `if (input.receipt !== undefined) writeReceipt(...)` path.

Gate: `pnpm lint` ok; `pnpm build && pnpm docs:site:build` ok (0 broken links).

Deslop: n/a (prose). Self-review: wording change to an existing sentence; the PR #738 reviewer pass covered the surrounding claims.