### PR TITLE
fix(test): isolate Amp installs from ambient XDG config

### DIFF
--- a/packages/agent-bundle/tests/amp-install.test.ts
+++ b/packages/agent-bundle/tests/amp-install.test.ts
@@ -10,6 +10,7 @@ import { readInstallReceipt } from '../src/install/receipt.ts';
 import { uninstallBundle } from '../src/install/uninstall.ts';
 import { writeInstallFixtureManifest } from './support/install-fixture.ts';
 
+const isolatedEnvironment: Readonly<NodeJS.ProcessEnv> = {};
 const pluginName = 'amp-install-fixture';
 
 const writeBundle = async (
@@ -48,6 +49,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
   try {
     const installed = await installBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -80,6 +82,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
 
     const unchanged = await installBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -91,6 +94,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
     await writeBundle(bundle, '1.0.0', 'second');
     const replaced = await installBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -104,6 +108,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
 
     const planned = await uninstallBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -116,6 +121,7 @@ it('installs, replaces, and uninstalls only the receipt-owned Amp directory', as
 
     const uninstalled = await uninstallBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -194,6 +200,7 @@ it('installs a mixed-case portable plugin name accepted by the Amp planner', asy
   try {
     const installed = await installBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -221,6 +228,7 @@ it('rejects an Amp manifest name that could escape the plugin root', async () =>
   try {
     await expect(installBundle({
       commandRunner: forbiddenRunner(),
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -244,6 +252,7 @@ it('refuses to replace a foreign Amp directory even with --replace', async () =>
 
   try {
     await expect(installBundle({
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -270,6 +279,7 @@ it('refuses a symlinked Amp plugin ancestor before writing outside the host root
 
   try {
     await expect(installBundle({
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',
@@ -292,6 +302,7 @@ it('refuses modified or unlisted files inside the generated Amp directory', asyn
 
   try {
     await expect(installBundle({
+      environment: isolatedEnvironment,
       from: bundle,
       home,
       host: 'amp',


### PR DESCRIPTION
## Summary

- pass an explicit empty environment to user-scope Amp install/uninstall test fixtures
- keep temporary `home` directories authoritative when the runner exports `XDG_CONFIG_HOME`
- leave production environment resolution and the explicit XDG-root coverage unchanged

## Root cause

`installBundle` and `uninstallBundle` intentionally default `options.environment` to `process.env`. The Amp tests supplied a temporary `home` but omitted `environment`, so CI's ambient `XDG_CONFIG_HOME=/home/runner/.config` redirected user-scope plugin operations outside each fixture. That changed destinations and bypassed the foreign-directory and symlink fixtures.

## Verification

RED on untouched `e3e78e2d8df2b2e089f2768f5e39f6e3090e40fa` with an explicit external XDG root:

```sh
XDG_CONFIG_HOME=/tmp/agent-bundle-ambient-xdg.EPAoJl pnpm test:unit -- packages/agent-bundle/tests/amp-install.test.ts
```

Result: 4 failed, 4,475 passed, 6 skipped. All failures were in `packages/agent-bundle/tests/amp-install.test.ts`, with destinations redirected under the ambient XDG root.

GREEN focused reproduction:

```sh
pnpm build
XDG_CONFIG_HOME=/tmp/agent-bundle-ambient-xdg.bTL1ND pnpm exec rstest packages/agent-bundle/tests/amp-install.test.ts --config rstest.unit.config.ts
```

Result: 7 passed, 0 failed.

Required local gate:

```sh
pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit
```

Result: PASS. Lint passed across 1,493 files; unit tests: 4,479 passed, 0 failed, 6 skipped.

## Changeset

No changeset: tests-only isolation fix; no publishable package behavior changed.

## Deslop

Deslop: GPT-5.6 Sol, 0 edits. One test file changed with no production behavior, new abstraction, dependency, or unrelated cleanup.

## Self-review

Reviewer: Claude Fable 5.1 xhigh

Finding: none.

Disposition: no changes required; the review confirmed the fixture-only environment isolation, preserved explicit-XDG coverage, current `origin/main` ancestry, and no documentation or changeset requirement.
