### PR TITLE
fix(test): compare invocation replay with retained suffix

### DIFF
--- a/packages/agent-bundle/tests/route-invocation-dev-server.test.ts
+++ b/packages/agent-bundle/tests/route-invocation-dev-server.test.ts
@@ -1997,7 +1997,8 @@ it('bounds the render history a compiled child produces by count and bytes acros
     expect(JSON.stringify(cancelled.document)).toContain(`${String(boundaries - 1)}:`);
     const reconnected = await readInvocationStream(reconnectedResponse);
     expect(reconnected[0]).toEqual({ type: 'truncated' });
-    expect(renderEvents(reconnected)).toEqual(cancelled.events);
+    // A live reconnect may include replay events evicted before the terminal envelope.
+    expect(renderEvents(reconnected).slice(-cancelled.events.length)).toEqual(cancelled.events);
     expect(reconnected.at(-1)).toEqual({ invocation: cancelled, type: 'final' });
     await live.next(isFinal);
     expect(live.seen.filter((message) => message.type === 'truncated')).toHaveLength(1);


### PR DESCRIPTION
## Summary
- compare the cancellation envelope with the retained suffix of an active reconnect stream
- document why earlier replay events may legitimately precede that suffix
- keep production behavior unchanged; no package changeset is needed for this test-only fix

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` (4,503 passed, 6 skipped)
- affected integration test: 5 repeated normal runs
- forced-race timing: failed 216 vs 167 before the assertion fix, passed after it
