### PR TITLE
fix(build): stabilize external issuer ordering

### DIFF
--- a/.changeset/sort-issuer-identities.md
+++ b/.changeset/sort-issuer-identities.md
@@ -2,4 +2,4 @@
 'agent-bundle': patch
 ---
 
-Keep AB6005 issuer ordering stable across checkout paths. (#PR)
+Keep AB6005 issuer ordering stable across checkout paths. (#768)

--- a/.changeset/sort-issuer-identities.md
+++ b/.changeset/sort-issuer-identities.md
@@ -1,0 +1,5 @@
+---
+'agent-bundle': patch
+---
+
+Keep AB6005 issuer ordering stable across checkout paths. (#PR)

--- a/packages/agent-bundle/src/build/external-policy.ts
+++ b/packages/agent-bundle/src/build/external-policy.ts
@@ -85,7 +85,7 @@ export const viewSelfContainmentDiagnostics = (
   evidence.externals.map((external) => artifactDiagnostic(
     'AB6005',
     `Compiled MCP App view ${JSON.stringify(asset)} `
-      + keptExternalClause(external, external.issuers.map((issuer) => posixRelativeWhenInside(projectRoot, issuer)))
+      + keptExternalClause(external, external.issuers.map((issuer) => posixRelativeWhenInside(projectRoot, issuer)).sort())
       + 'a view inlines every module it loads.',
     asset,
   ));

--- a/packages/agent-bundle/src/build/rslib.ts
+++ b/packages/agent-bundle/src/build/rslib.ts
@@ -781,7 +781,7 @@ export const compileResultOf = (
     externals: Object.freeze(record.externals.map((external): ExternalIR => ({
       asset,
       externalType: external.externalType,
-      issuers: external.issuers.map((issuer) => posixRelativeWhenInside(options.cwd, issuer)),
+      issuers: external.issuers.map((issuer) => posixRelativeWhenInside(options.cwd, issuer)).sort(),
       kind: classifyExternal(external, { asset, emittedAssets: options.emittedAssets }),
       request: external.request,
       userRequest: external.userRequest,

--- a/packages/agent-bundle/tests/compile-stages.test.ts
+++ b/packages/agent-bundle/tests/compile-stages.test.ts
@@ -4,9 +4,10 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import type { CompilationEvidence } from '../src/build/compile-result.ts';
 import { compileRslibSurfaces, settledRslibSurface } from '../src/build/compiler.ts';
 import { generatedMetaModulePath, metaModuleSpecifier } from '../src/build/meta.ts';
-import { buildRslibSurfaces, entryLibId, type RslibEntry } from '../src/build/rslib.ts';
+import { buildRslibSurfaces, compileResultOf, entryLibId, type RslibEntry } from '../src/build/rslib.ts';
 import { planCompileStages } from '../src/build/compile-stages.ts';
 import type { AgentBundleMeta } from '../src/meta.ts';
 
@@ -105,6 +106,36 @@ const surfaceEntry = (name: string, outputRelativePath: string, source: string):
   outputRelativePath,
   source,
   sourceInputs: [source],
+});
+
+describe('compileResultOf', () => {
+  it('sorts issuer identities after making project paths relative', () => {
+    const project = join(tmpdir(), 'a-agent-bundle-project');
+    const externalIssuer = join(tmpdir(), 'z-agent-bundle-source', 'terminal-capability.ts');
+    const projectIssuer = join(project, 'src', 'scripts', 'pad.ts');
+    const record: CompilationEvidence = {
+      compiler: 'agent-bundle-scripts-pad',
+      externals: [{
+        externalType: 'global',
+        issuers: [projectIssuer, externalIssuer].sort(),
+        request: 'fs',
+        userRequest: 'node:fs',
+      }],
+      modules: [],
+    };
+
+    const result = compileResultOf(record, {
+      asset: { path: 'scripts/pad.mjs', sourceInputs: [projectIssuer] },
+      cwd: project,
+      dependencyRoots: new Map(),
+      emittedAssets: new Set(['scripts/pad.mjs']),
+    });
+
+    expect(result.externals[0]?.issuers).toEqual([
+      externalIssuer,
+      'src/scripts/pad.ts',
+    ].sort());
+  });
 });
 
 describe('buildRslibSurfaces', () => {

--- a/packages/agent-bundle/tests/external-policy.test.ts
+++ b/packages/agent-bundle/tests/external-policy.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from '@rstest/core';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import type { CompileResult, ExternalIR } from '../src/build/compile-result.ts';
+import type { CompilationEvidence, CompileResult, ExternalIR } from '../src/build/compile-result.ts';
 import {
   classifyExternal,
   externalizedSpecifiers,
   selfContainmentDiagnostics,
+  viewSelfContainmentDiagnostics,
 } from '../src/build/external-policy.ts';
 
 const resultWith = (externals: readonly ExternalIR[]): CompileResult => ({
@@ -136,6 +139,28 @@ describe('selfContainmentDiagnostics', () => {
         userRequest: './sibling.mjs',
       },
     ]))).toEqual([]);
+  });
+});
+
+describe('viewSelfContainmentDiagnostics', () => {
+  it('sorts issuer identities after making project paths relative', () => {
+    const project = join(tmpdir(), 'a-agent-bundle-project');
+    const externalIssuer = join(tmpdir(), 'z-agent-bundle-source', 'view-runtime.ts');
+    const projectIssuer = join(project, 'views', 'status.tsx');
+    const evidence: CompilationEvidence = {
+      compiler: 'agent-bundle-mcp-app-status',
+      externals: [{
+        externalType: 'module',
+        issuers: [projectIssuer, externalIssuer].sort(),
+        request: 'react',
+        userRequest: 'react',
+      }],
+      modules: [],
+    };
+
+    expect(viewSelfContainmentDiagnostics(evidence, 'mcp-apps/status.html', project)[0]?.message).toBe(
+      `Compiled MCP App view "mcp-apps/status.html" keeps "react" external (module) from ${externalIssuer}, views/status.tsx; a view inlines every module it loads.`,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- re-sort external issuer identities after project-relative normalization
- apply the same invariant to host-surface and MCP App AB6005 diagnostics
- add regression tests proving checkout-path-independent ordering
- add the required `agent-bundle` patch changeset

## Root cause
The compiler audit correctly recorded sorted, unique absolute issuer paths. Diagnostic lowering converted project-owned issuers to relative paths without re-sorting, so checkout location could change diagnostic order and break the release gate.

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` (4,539 tests; 4,533 passed, 6 skipped)
- focused issuer-order integration test, 3 consecutive passes after final review fix
- `pnpm test:integration:run` (1,175 tests; 1,171 passed, 4 skipped)
- automatic Codex P2 fixed and thread resolved
- independent non-Grok Fable final review: no merge blockers
