### PR TITLE
fix(dev): fail closed when packaged internal child executables are missing

### DIFF
--- a/.changeset/fail-closed-internal-children.md
+++ b/.changeset/fail-closed-internal-children.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Fail closed when package-owned route invocation or lifecycle render child executables are missing instead of falling back to same-named files under the caller's current working directory.

--- a/packages/agent-bundle/src/dev/playground/lifecycle-replay-service.ts
+++ b/packages/agent-bundle/src/dev/playground/lifecycle-replay-service.ts
@@ -1,7 +1,7 @@
 import { fork } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { createJiti } from 'jiti';
@@ -133,7 +133,6 @@ const lifecycleRenderChildPath = (): string => {
     : [
         join(here, 'lifecycle-render-child.js'),
         join(here, 'lifecycle-render-child.ts'),
-        resolve(process.cwd(), 'packages/agent-bundle/src/dev/playground/lifecycle-render-child.ts'),
       ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) return candidate;

--- a/packages/agent-bundle/src/dev/routes/route-invocation-service.ts
+++ b/packages/agent-bundle/src/dev/routes/route-invocation-service.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { fork, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join, posix, resolve } from 'node:path';
+import { dirname, join, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { AgentDocument, AgentDocumentNode, AgentRenderEvent } from '@agent-bundle/runtime';
@@ -537,7 +537,6 @@ const childPath = (): string => {
     : [
         join(here, 'route-invocation-child.js'),
         join(here, 'route-invocation-child.ts'),
-        resolve(process.cwd(), 'packages/agent-bundle/src/dev/routes/route-invocation-child.ts'),
       ];
   const found = candidates.find(existsSync);
   if (found === undefined) throw new Error('Unable to locate the route invocation render child.');

--- a/packages/agent-bundle/tests/internal-child-resolution-policy.test.ts
+++ b/packages/agent-bundle/tests/internal-child-resolution-policy.test.ts
@@ -1,0 +1,18 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from '@rstest/core';
+
+const internalChildOwners = [
+  '../src/dev/playground/lifecycle-replay-service.ts',
+  '../src/dev/routes/route-invocation-service.ts',
+] as const;
+
+describe('internal child executable resolution', () => {
+  for (const sourcePath of internalChildOwners) {
+    it(`${sourcePath} never resolves framework children from the caller cwd`, async () => {
+      const source = await readFile(new URL(sourcePath, import.meta.url), 'utf8');
+
+      expect(source).not.toContain("resolve(process.cwd(), 'packages/agent-bundle/src/");
+    });
+  }
+});


### PR DESCRIPTION
## Final audit finding

Two compiled dev-service resolvers fell back to `process.cwd()/packages/agent-bundle/src/...` when their package-owned child executable was absent. In normal source development the `.ts` child is already resolved relative to `import.meta.url`; in a valid built package the emitted `.js` child is an explicit Rslib entry beside the bundle. The cwd fallback was therefore unnecessary for either supported topology.

If a package is incomplete/corrupted, that fallback could execute a same-named TypeScript file from the caller's workspace instead of failing closed. It also made framework behavior depend on an unrelated consumer cwd.

## Fix

- Remove the compiled-mode caller-cwd candidate from route invocation child resolution.
- Remove the compiled-mode caller-cwd candidate from lifecycle render child resolution.
- Remove the now-unused `resolve` imports.
- Add a regression policy test covering both framework-owned child resolvers.
- Add the required `agent-bundle` patch changeset.

## Verification

The first test-only commit intentionally established the regression and failed the unit gate for exactly the two new assertions. The follow-up `18e235e1a02ae553dd1e2fbf3d93bbc29a4443e0` applies the production fix.

Before moving the branch ref, the follow-up commit was compared against its parent through GitHub's commit graph: exactly three implementation files changed, with each production source at **+1/-2**, plus the patch changeset. The automated P1 review asking for the production fix has been addressed and resolved. Fresh full CI is running on the fixed head.

Base audited: `12c2740c96c04d9e3c313f8e8edb3cb5c1c2c65f`.