### PR TITLE
ci(release): qualify generated Version Packages heads automatically

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -124,8 +124,10 @@ because they change no publishable package.
    events created with the built-in `GITHUB_TOKEN`, so for that PR to get
    PR CI the repository needs a `CHANGESETS_GITHUB_TOKEN` secret (fine-grained
    PAT or GitHub App installation token with `contents: write` and
-   `pull-requests: write` on this repository); the workflow falls back to
-   `GITHUB_TOKEN`, in which case close and reopen the PR to trigger CI.
+   `pull-requests: write` on this repository). When the workflow falls back to
+   `GITHUB_TOKEN`, it explicitly dispatches `ci.yml` on the generated
+   `changeset-release/main` branch after confirming the Version Packages PR
+   exists, so no close/reopen is needed.
 3. Merging Version Packages pushes a `Version Packages` commit to `main`
    with no pending changesets. With publishing disabled (the default) the
    workflow then runs the release gates (`pnpm check:release`) and stops;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       # duplicate run: that token's pull_request event already starts CI.
       - name: Dispatch CI for Version Packages candidate
         if: >-
-          steps.changesets.outputs.has-changesets == 'true' &&
+          steps.changesets.outputs.hasChangesets == 'true' &&
           env.CHANGESETS_TOKEN_CONFIGURED != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -101,7 +101,7 @@ jobs:
         id: qualify
         if: >-
           env.PUBLISH_ENABLED != 'true' &&
-          steps.changesets.outputs.has-changesets == 'false' &&
+          steps.changesets.outputs.hasChangesets == 'false' &&
           startsWith(github.event.head_commit.message, 'Version Packages')
         run: pnpm check:release
       # Registry proof is a separate authorized-publication step. Disabled
@@ -128,7 +128,7 @@ jobs:
       - name: Release outcome summary
         if: always()
         env:
-          HAS_CHANGESETS: ${{ steps.changesets.outputs.has-changesets }}
+          HAS_CHANGESETS: ${{ steps.changesets.outputs.hasChangesets }}
           PUBLISHED: ${{ steps.changesets.outputs.published }}
           QUALIFY_OUTCOME: ${{ steps.qualify.outcome }}
           CHANGESETS_OUTCOME: ${{ steps.changesets.outcome }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,15 @@ on:
 
 # contents: write and pull-requests: write let changesets/action push the
 # changeset-release/main branch and open/update the "Version Packages" PR.
+# actions: write lets the built-in token dispatch CI for that generated branch
+# when no external Changesets token is configured. workflow_dispatch is one of
+# the explicit recursion exceptions for GITHUB_TOKEN-created events.
 # id-token: write is required for npm package provenance once publishing is
 # enabled; it is inert while PUBLISH_ENABLED below is false. The repository
 # setting "Allow GitHub Actions to create and approve pull requests" must
 # also be on, or the PR step fails after the branch is pushed.
 permissions:
+  actions: write
   contents: write
   id-token: write
   pull-requests: write
@@ -34,6 +38,7 @@ jobs:
       # updates the Version Packages PR, and merging that PR only runs the
       # release gates (`pnpm check:release`) so the tree stays publishable.
       PUBLISH_ENABLED: ${{ vars.AGENT_BUNDLE_NPM_PUBLISH == 'true' && secrets.NPM_TOKEN != '' }}
+      CHANGESETS_TOKEN_CONFIGURED: ${{ secrets.CHANGESETS_GITHUB_TOKEN != '' }}
       AGENT_BUNDLE_PLAYWRIGHT_CHANNEL: chromium
       # Packed qualification writes package/digest evidence here when
       # `pnpm check:release` / `pnpm release` runs. `github.workspace` is
@@ -68,16 +73,27 @@ jobs:
           publish-script: ${{ env.PUBLISH_ENABLED == 'true' && 'pnpm release' || '' }}
           commit-message: Version Packages
           pr-title: Version Packages
-          # Events created with the built-in GITHUB_TOKEN never start other
-          # workflows, so a Version Packages PR opened with it gets no PR CI.
-          # Provide CHANGESETS_GITHUB_TOKEN (a fine-grained PAT or GitHub App
-          # installation token with contents: write + pull-requests: write on
-          # this repository) to have CI run on that PR; without it the action
-          # still works and the PR can be closed/reopened to trigger CI.
+          # An external PAT/App token makes the generated PR's native
+          # pull_request event run CI directly. With only GITHUB_TOKEN, the
+          # step below dispatches CI explicitly so the candidate still gets
+          # pre-merge qualification without a manual close/reopen.
           github-token: ${{ secrets.CHANGESETS_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+      # GITHUB_TOKEN-created pushes do not recursively start workflows, but
+      # workflow_dispatch is an explicit GitHub exception. ci.yml documents
+      # manual dispatch as the full main-push matrix on any ref, including the
+      # Node floor and release-gates job, so qualify the exact generated head.
+      # Skip this when an external Changesets token is configured to avoid a
+      # duplicate run: that token's pull_request event already starts CI.
+      - name: Dispatch CI for Version Packages candidate
+        if: >-
+          steps.changesets.outputs.has-changesets == 'true' &&
+          env.CHANGESETS_TOKEN_CONFIGURED != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref changeset-release/main
       # Publishing disabled: when the Version Packages PR lands (no pending
       # changesets, "Version Packages" merge commit), prove the versioned
       # tree still passes the pre-publish gates that `pnpm release` would run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,12 @@ jobs:
       # duplicate run: that token's pull_request event already starts CI.
       - name: Dispatch CI for Version Packages candidate
         if: >-
-          steps.changesets.outputs.hasChangesets == 'true' &&
+          steps.changesets.outputs.has-changesets == 'true' &&
+          steps.changesets.outputs.pr-number != '' &&
           env.CHANGESETS_TOKEN_CONFIGURED != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh workflow run ci.yml --ref changeset-release/main
       # Publishing disabled: when the Version Packages PR lands (no pending
       # changesets, "Version Packages" merge commit), prove the versioned
@@ -101,7 +103,7 @@ jobs:
         id: qualify
         if: >-
           env.PUBLISH_ENABLED != 'true' &&
-          steps.changesets.outputs.hasChangesets == 'false' &&
+          steps.changesets.outputs.has-changesets == 'false' &&
           startsWith(github.event.head_commit.message, 'Version Packages')
         run: pnpm check:release
       # Registry proof is a separate authorized-publication step. Disabled
@@ -128,7 +130,7 @@ jobs:
       - name: Release outcome summary
         if: always()
         env:
-          HAS_CHANGESETS: ${{ steps.changesets.outputs.hasChangesets }}
+          HAS_CHANGESETS: ${{ steps.changesets.outputs.has-changesets }}
           PUBLISHED: ${{ steps.changesets.outputs.published }}
           QUALIFY_OUTCOME: ${{ steps.qualify.outcome }}
           CHANGESETS_OUTCOME: ${{ steps.changesets.outcome }}


### PR DESCRIPTION
## Final audit finding

The current machine-owned Version Packages PR (#411) has no check runs on its generated head. `release.yml` documents this as a `GITHUB_TOKEN` recursion limitation and currently requires either `CHANGESETS_GITHUB_TOKEN` or a manual close/reopen to start CI.

GitHub's current `GITHUB_TOKEN` contract explicitly exempts `workflow_dispatch` from recursion suppression. `ci.yml` already defines `workflow_dispatch` as the full main-push matrix on any ref, so the release job can qualify the exact `changeset-release/main` head itself.

## Change

- Grant the release workflow narrowly scoped `actions: write` in addition to its existing release permissions.
- When Changesets reports pending changesets and no external Changesets token is configured, dispatch `ci.yml` against `changeset-release/main` using `github.token`.
- Skip the dispatch when `CHANGESETS_GITHUB_TOKEN` is configured so its native PR event remains the single CI run.
- Keep post-merge `pnpm check:release` and publication behavior unchanged.

This is workflow-only; no package changeset is appropriate.

## Evidence

- #411 head `c9e3ee58927907f41945e7faac780dbc74202b73` currently has zero check runs.
- GitHub documents `workflow_dispatch` and `repository_dispatch` as exceptions that always create workflow runs for `GITHUB_TOKEN`-authenticated actions.
- `ci.yml` explicitly states that a manual dispatch runs the full main-push matrix on any ref and its matrix expression runs Node 22.19.0, 24, and 26 outside pull_request/merge_group events.

Reference: https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs