### PR TITLE
fix(app): authenticate MCP hosts by parent source

### DIFF
--- a/.changeset/authenticate-app-parent-source.md
+++ b/.changeset/authenticate-app-parent-source.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Make `createAppClient()` authenticate unconfigured MCP App transports by exact parent source while preserving strict HTTP(S) `targetOrigin` pinning.

--- a/.changeset/authenticate-app-parent-source.md
+++ b/.changeset/authenticate-app-parent-source.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Make `createAppClient()` authenticate unconfigured MCP App transports by exact parent source while preserving strict HTTP(S) `targetOrigin` pinning.
+Make `createAppClient()` authenticate unconfigured MCP App transports by exact parent source while preserving strict HTTP(S) `targetOrigin` pinning. (#779)

--- a/docs/entry-conventions.md
+++ b/docs/entry-conventions.md
@@ -1726,7 +1726,7 @@ client rather than by hand-written frames: `tests/serve-app.test.ts` connects
 relay uses, and the Workbench real-App E2E
 (`packages/workbench/tests/mcp-app-real.e2e.test.ts`) compiles a fixture view
 on `createAppClient` and reads its `call()` result through the relay. The
-client's own contract — envelopes, handshake, pinning, dispatch, cancellation,
+client's own contract — envelopes, handshake, transport authentication, dispatch, cancellation,
 rebind, disposal — is proven in `tests/app-client.test.ts` over injected
 ports. The client never decides which server a call reaches or which
 capability needs consent.
@@ -1742,8 +1742,8 @@ capability needs consent.
 | `request(method, params?, options?)` | The typed JSON-RPC escape hatch for `resources/read` and supported `ui/*` methods; resolves the raw result. An empty method rejects with a `TypeError`. |
 | `onToolInput(routeId, listener)` / `onToolResult(routeId, listener)` / `onToolError(routeId, listener)` | The opening call's `ui/notifications/tool-input` arguments, the decoded `structuredContent` of a successful `ui/notifications/tool-result`, and that notification's failures as an `AppClientError` — `isError: true` is `rpc` with the whole result on `data`; a malformed envelope or one without an object `structuredContent` is `invalid-message`; a failed result never reaches `onToolResult`. The notifications carry no tool name, so dispatch keys on the tool the handshake named: `hostContext.toolInfo.tool.name` from the initialize result, matched against the final segment of each registered route id. Listeners for other tools stay silent; when the initialize result names no tool, `tool-input` and `tool-result` reach no listener. Listeners run on a microtask, exceptions dropped. Each returns its unsubscribe function. |
 | `onToolCancelled(listener)` | `ui/notifications/tool-cancelled` as `{ reason? }`, unfiltered; returns its unsubscribe function. |
-| `rebind({ parent?, targetOrigin?, window? })` | Bumps the connection generation and rejects the previous generation's pending requests with `connection-rebound` — a `connect()` still in flight included; its late response can never become the live connection — clears the pinned origin and the opening tool name, moves the message listener when `window` changes, adopts the new parent, keeps the configured `targetOrigin` unless the call names the key, and runs `connect()` again. |
-| `dispose()` | Idempotent. Removes the message listener, rejects pending requests with `disposed`, drops every registration and the pin. A host `ui/resource-teardown` request is answered with `{}` and disposes the client; any other host request is answered `-32601`. |
+| `rebind({ parent?, targetOrigin?, window? })` | Bumps the connection generation and rejects the previous generation's pending requests with `connection-rebound` — a `connect()` still in flight included; its late response can never become the live connection — clears the opening tool name, moves the message listener when `window` changes, adopts the new parent, keeps the configured `targetOrigin` unless the call names the key, and runs `connect()` again. |
+| `dispose()` | Idempotent. Removes the message listener, rejects pending requests with `disposed`, and drops every registration. A host `ui/resource-teardown` request is answered with `{}` and disposes the client; any other host request is answered `-32601`. |
 | `connected` / `disposed` | Read-only state. |
 
 `CreateAppClientOptions` are `appInfo` (`{ name, version }`, default
@@ -1799,25 +1799,24 @@ that cancellation cannot bypass consent or reach a request the App did not
 start. Hosts outside the framework apply their own policy; the client's
 behavior is the same either way.
 
-### Dynamic sandbox handshake
+### Parent transport authentication
 
 The Workbench and `serve-app` render the App as `<iframe sandbox="allow-scripts"
 referrerpolicy="no-referrer" srcdoc=…>`, so the document has an opaque
-origin and no referrer to learn its host origin from. The client therefore
-sends exactly one frame to `'*'` — its own `ui/initialize` — and accepts a
-response only when `event.source` is the configured parent, the id is that
-bootstrap request's, and the result validates; it then pins `event.origin`
-raw for inbound messages. Exact `http:` or `https:` origins are also used as
-the outbound target; opaque `'null'` and host-private origins such as
-`codex-sandbox://…` use `'*'` outbound. An empty or literal `'*'` origin fails
-the handshake as `invalid-message`. Every later inbound message must match
-both the parent and exact raw pinned origin. The initialize result also names the opening tool
-(`hostContext.toolInfo.tool.name`), which is what the opening-notification
-listeners dispatch on. A malformed message that still names a pending id
-rejects that request as `invalid-message`. A host that can name its origin
-passes `targetOrigin` — an exact `http:` or `https:` origin; `'*'`, `'null'`,
-other schemes, and non-origin strings are a `TypeError` — and no wildcard frame
-is sent. The transport is DOM-shaped
+origin and no referrer to learn its host origin from. Without `targetOrigin`,
+the client sends every frame to `'*'` and authenticates every incoming frame
+by exact `event.source === parent` identity plus strict JSON-RPC validation.
+It does not inspect or pin `event.origin`. The initialize result also names
+the opening tool (`hostContext.toolInfo.tool.name`), which is what the
+opening-notification listeners dispatch on. A malformed message that still
+names a pending id rejects that request as `invalid-message`.
+
+A host that can name a trusted origin passes `targetOrigin` — an exact
+`http:` or `https:` origin; `'*'`, `'null'`, other schemes, and non-origin
+strings are a `TypeError`. The client then uses that exact origin for every
+outgoing frame and requires every incoming `event.origin` to match it. The
+Workbench and `serve-app` sandbox proxy keep their exact HTTP source-and-origin
+checks on the host side before relaying. The transport is DOM-shaped
 (`AppWindow`, `AppMessageTarget`) rather than bound to the global `window`, so
 `tests/app-client.test.ts` and non-DOM hosts drive the same core through
 injected ports.

--- a/packages/agent-bundle/src/app/index.ts
+++ b/packages/agent-bundle/src/app/index.ts
@@ -198,11 +198,6 @@ interface PendingRequest {
   readonly abort?: () => void;
 }
 
-interface AppOriginPin {
-  readonly incoming: string;
-  readonly outgoing: string;
-}
-
 type AnyListener = (value: unknown) => Promise<void> | void;
 
 const allowedMessageKeys = Object.freeze(['error', 'id', 'jsonrpc', 'method', 'params', 'result']);
@@ -240,17 +235,6 @@ const trustedOrigin = (value: string | undefined): string | undefined => {
     throw new TypeError('App client targetOrigin must be an exact trusted http: or https: origin.');
   }
   return value;
-};
-
-const originPin = (value: string): AppOriginPin => {
-  if (value === '*' || !nonempty(value)) {
-    throw new TypeError('App client cannot pin an empty or wildcard origin.');
-  }
-  try {
-    return { incoming: value, outgoing: trustedOrigin(value)! };
-  } catch {
-    return { incoming: value, outgoing: '*' };
-  }
 };
 
 const currentWindow = (): AppWindow => {
@@ -354,8 +338,6 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
   let boundWindow = options.window ?? currentWindow();
   let parent = options.parent ?? boundWindow.parent;
   let configuredOrigin = trustedOrigin(options.targetOrigin);
-  let pinnedOrigin = configuredOrigin;
-  let postOrigin = configuredOrigin;
   let nextId = 0;
   let connectionGeneration = 0;
   let connection: Promise<AppInitializeResult> | undefined;
@@ -400,13 +382,13 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
   };
 
   const notifyCancelled = (id: null | number | string, reason: string): void => {
-    if (connectedResult === undefined || postOrigin === undefined) return;
+    if (connectedResult === undefined) return;
     try {
       post({
         jsonrpc: '2.0',
         method: 'notifications/cancelled',
         params: { reason, requestId: id },
-      }, postOrigin);
+      }, configuredOrigin ?? '*');
     } catch {
       // The original timeout or abort remains the observable request failure.
     }
@@ -424,8 +406,7 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
   };
 
   const sendResponse = (id: null | number | string, result: JsonObject): void => {
-    if (postOrigin === undefined) return;
-    post({ id, jsonrpc: '2.0', result }, postOrigin);
+    post({ id, jsonrpc: '2.0', result }, configuredOrigin ?? '*');
   };
 
   const publishOpening = (listeners: Map<string, Set<AnyListener>>, value: unknown): void => {
@@ -445,8 +426,6 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
     connection = undefined;
     connectedResult = undefined;
     openingToolName = undefined;
-    pinnedOrigin = undefined;
-    postOrigin = undefined;
     inputListeners.clear();
     resultListeners.clear();
     errorListeners.clear();
@@ -455,7 +434,7 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
 
   const receive = (event: AppMessageEvent): void => {
     if (isDisposed || event.source !== parent) return;
-    if (pinnedOrigin !== undefined && event.origin !== pinnedOrigin) return;
+    if (configuredOrigin !== undefined && event.origin !== configuredOrigin) return;
     const message = rpcMessage(event.data);
     if (message === undefined) {
       const id = candidateId(event.data);
@@ -468,15 +447,6 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
     if (message.method === undefined) {
       const request = message.id === undefined ? undefined : clearPending(message.id);
       if (request === undefined) return;
-      let responseOrigin: AppOriginPin | undefined;
-      if (request.initialize && configuredOrigin === undefined) {
-        try {
-          responseOrigin = originPin(event.origin);
-        } catch {
-          request.reject(new AppClientError('invalid-message', 'The App host returned an unpinnable origin.'));
-          return;
-        }
-      }
       if (message.error !== undefined) {
         request.reject(errorFromRpc(message.error));
         return;
@@ -489,15 +459,11 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
         request.reject(new AppClientError('invalid-message', `The App host did not negotiate protocol ${APP_PROTOCOL_VERSION}.`));
         return;
       }
-      if (responseOrigin !== undefined) {
-        pinnedOrigin = responseOrigin.incoming;
-        postOrigin = responseOrigin.outgoing;
-      }
       request.resolve(message.result);
       return;
     }
 
-    if (postOrigin === undefined || connectedResult === undefined) return;
+    if (connectedResult === undefined) return;
     if (message.id !== undefined) {
       if (message.method === 'ui/resource-teardown') {
         try {
@@ -511,7 +477,7 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
         error: { code: -32601, message: `${message.method} is not supported by this App client.` },
         id: message.id,
         jsonrpc: '2.0',
-      }, postOrigin);
+      }, configuredOrigin ?? '*');
       return;
     }
     if (message.method === 'ui/notifications/tool-input') {
@@ -571,10 +537,7 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
       return Promise.reject(new AppClientError('invalid-message', 'App client request params must be finite strict JSON.'));
     }
     const id = ++nextId;
-    const targetOrigin = initialize ? configuredOrigin ?? '*' : postOrigin;
-    if (targetOrigin === undefined) {
-      return Promise.reject(new AppClientError('capability-unavailable', 'The App client is not connected.'));
-    }
+    const targetOrigin = configuredOrigin ?? '*';
     return new Promise<JsonValue>((resolvePromise, rejectPromise) => {
       const timeout = setTimeout(() => {
         if (clearPending(id) === undefined) return;
@@ -625,10 +588,10 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
         throw new AppClientError('connection-rebound', 'The App client connection was rebound.');
       }
       const initialized = initializeResult(result);
-      if (initialized === undefined || pinnedOrigin === undefined || postOrigin === undefined) {
+      if (initialized === undefined) {
         throw new AppClientError('invalid-message', 'The App host returned an invalid initialize result.');
       }
-      post({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, postOrigin);
+      post({ jsonrpc: '2.0', method: 'ui/notifications/initialized' }, configuredOrigin ?? '*');
       connectedResult = initialized;
       const toolInfo = isPlainDataRecord(initialized.hostContext.toolInfo)
         ? initialized.hostContext.toolInfo
@@ -735,8 +698,6 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
       connection = undefined;
       connectedResult = undefined;
       openingToolName = undefined;
-      pinnedOrigin = undefined;
-      postOrigin = undefined;
       const replacementWindow = rebindOptions.window ?? boundWindow;
       if (replacementWindow !== boundWindow) {
         boundWindow.removeEventListener('message', receive);
@@ -745,8 +706,6 @@ export const createAppClient = (options: CreateAppClientOptions = {}): AppClient
       }
       parent = rebindOptions.parent ?? boundWindow.parent;
       configuredOrigin = nextOrigin;
-      pinnedOrigin = configuredOrigin;
-      postOrigin = configuredOrigin;
       return await connect();
     },
     dispose,

--- a/packages/agent-bundle/tests/app-client.test.ts
+++ b/packages/agent-bundle/tests/app-client.test.ts
@@ -74,10 +74,12 @@ interface PostedMessage {
 
 const hostOrigin = 'https://host.example';
 const codexOrigin = 'codex-sandbox://stable-dashboard-id';
-const dynamicHostOriginMatrix = [
-  { host: 'Codex Desktop registered scheme', incoming: codexOrigin, outgoing: '*' },
-  { host: 'Codex opaque sandbox', incoming: 'null', outgoing: '*' },
-  { host: 'Workbench HTTP parent', incoming: hostOrigin, outgoing: hostOrigin },
+const dynamicHostOrigins = [
+  hostOrigin,
+  'null',
+  'codex-sandbox://x',
+  'vscode-webview://x',
+  'https://abc.claudemcpcontent.com',
 ] as const;
 const typeProofs: readonly [
   RouteIdProof,
@@ -157,12 +159,23 @@ it('uses one shared protocol version for the App client and MCP App profile', ()
   expect(APP_PROTOCOL_VERSION).toBe(MCP_APP_PROTOCOL_VERSION);
 });
 
-it('conforms to the dynamic host origin matrix', async () => {
-  for (const profile of dynamicHostOriginMatrix) {
+it('connects and calls through arbitrary origins from the exact parent', async () => {
+  for (const origin of dynamicHostOrigins) {
     const target = harness();
     const client = createAppClient({ window: target.window });
-    await connect(client, target, profile.incoming);
-    expect(target.posts.at(-1)?.targetOrigin, profile.host).toBe(profile.outgoing);
+    await connect(client, target, origin);
+    const called = client.call('tool:hauler/hauler_status', { limit: 40 }, { timeoutMs: 50 });
+    const request = target.posts.at(-1)!;
+    target.emit({
+      id: responseId(request),
+      jsonrpc: '2.0',
+      result: {
+        content: [{ text: 'healthy', type: 'text' }],
+        structuredContent: { active: 3, status: 'healthy' },
+      },
+    }, origin === hostOrigin ? 'vscode-webview://response-changed' : hostOrigin);
+    await expect(called, origin).resolves.toEqual({ active: 3, status: 'healthy' });
+    expect(target.posts.every(({ targetOrigin }) => targetOrigin === '*'), origin).toBe(true);
     client.dispose();
   }
 });
@@ -173,7 +186,7 @@ it('accepts AbortController signals through the structural app contract', () => 
   expect(options.signal?.aborted).toBe(false);
 });
 
-it('connects and calls through Codex opaque origin only for the matching parent', async () => {
+it('ignores a foreign WindowProxy even when its origin matches the exact parent', async () => {
   expect(typeProofs).toEqual([true, true, true, true, true, true]);
   const target = harness();
   const foreignParent = {};
@@ -199,12 +212,12 @@ it('connects and calls through Codex opaque origin only for the matching parent'
 
   let initialized = false;
   void connecting.then(() => { initialized = true; }, () => { initialized = true; });
-  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, 'null', foreignParent);
-  target.emit({ id: 99, jsonrpc: '2.0', result: initializeResult }, 'null');
+  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, hostOrigin, foreignParent);
+  target.emit({ id: 99, jsonrpc: '2.0', result: initializeResult }, hostOrigin);
   await flushListeners();
   expect(initialized).toBe(false);
 
-  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, 'null');
+  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, hostOrigin);
   await expect(connecting).resolves.toEqual(initializeResult);
   expect(client.connected).toBe(true);
   expect(target.posts.at(-1)).toEqual({
@@ -212,53 +225,11 @@ it('connects and calls through Codex opaque origin only for the matching parent'
     targetOrigin: '*',
   });
 
-  const called = client.call('tool:hauler/hauler_status', { limit: 40 });
+  const called = client.call('tool:hauler/hauler_status', { limit: 40 }, { timeoutMs: 50 });
   expect(target.posts.at(-1)?.targetOrigin).toBe('*');
   const callId = responseId(target.posts.at(-1)!);
   let settled = false;
   void called.then(() => { settled = true; }, () => { settled = true; });
-  target.emit({
-    id: callId,
-    jsonrpc: '2.0',
-    result: {
-      content: [{ text: 'forged', type: 'text' }],
-      structuredContent: { active: 99, status: 'forged' },
-    },
-  }, hostOrigin);
-  await flushListeners();
-  expect(settled).toBe(false);
-  target.emit({
-    id: callId,
-    jsonrpc: '2.0',
-    result: {
-      content: [{ text: 'healthy', type: 'text' }],
-      structuredContent: { active: 3, status: 'healthy' },
-    },
-  }, 'null');
-  await expect(called).resolves.toEqual({ active: 3, status: 'healthy' });
-});
-
-it('connects and calls through a pinned Codex custom-scheme origin', async () => {
-  const target = harness();
-  const foreignParent = {};
-  const client = createAppClient({ window: target.window });
-  const connecting = client.connect();
-
-  let initialized = false;
-  void connecting.then(() => { initialized = true; }, () => { initialized = true; });
-  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, codexOrigin, foreignParent);
-  await flushListeners();
-  expect(initialized).toBe(false);
-  target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, codexOrigin);
-  await expect(connecting).resolves.toEqual(initializeResult);
-  expect(target.posts.at(-1)).toEqual({
-    message: { jsonrpc: '2.0', method: 'ui/notifications/initialized' },
-    targetOrigin: '*',
-  });
-
-  const called = client.call('tool:hauler/hauler_status', { limit: 40 });
-  expect(target.posts.at(-1)?.targetOrigin).toBe('*');
-  const callId = responseId(target.posts.at(-1)!);
   const result = {
     id: callId,
     jsonrpc: '2.0',
@@ -267,34 +238,11 @@ it('connects and calls through a pinned Codex custom-scheme origin', async () =>
       structuredContent: { active: 3, status: 'healthy' },
     },
   } as const;
-  let settled = false;
-  void called.then(() => { settled = true; }, () => { settled = true; });
-  target.emit(result, codexOrigin, foreignParent);
-  target.emit(result, 'https://host.example');
-  target.emit(result, 'null');
-  target.emit(result, 'codex-sandbox://changed-dashboard-id');
+  target.emit(result, hostOrigin, foreignParent);
   await flushListeners();
   expect(settled).toBe(false);
-  target.emit(result, codexOrigin);
+  target.emit(result, 'vscode-webview://response-changed');
   await expect(called).resolves.toEqual({ active: 3, status: 'healthy' });
-});
-
-it('dynamically pins the Workbench HTTP parent origin', async () => {
-  const target = harness();
-  const client = createAppClient({ window: target.window });
-  await connect(client, target);
-
-  const request = client.request('ping', {});
-  expect(target.posts.at(-1)?.targetOrigin).toBe(hostOrigin);
-  const pingId = responseId(target.posts.at(-1)!);
-  let settled = false;
-  void request.then(() => { settled = true; }, () => { settled = true; });
-  target.emit({ id: pingId, jsonrpc: '2.0', result: { forged: true } }, 'null');
-  target.emit({ id: pingId, jsonrpc: '2.0', result: { forged: true } }, 'https://attacker.example');
-  await flushListeners();
-  expect(settled).toBe(false);
-  target.emit({ id: pingId, jsonrpc: '2.0', result: { accepted: true } });
-  await expect(request).resolves.toEqual({ accepted: true });
 });
 
 it('uses an exact trusted targetOrigin from the first message and rejects a mismatched response origin', async () => {
@@ -314,6 +262,17 @@ it('uses an exact trusted targetOrigin from the first message and rejects a mism
   expect(settled).toBe(false);
   target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult });
   await expect(connecting).resolves.toEqual(initializeResult);
+
+  const requested = client.request('ping', {});
+  const request = target.posts.at(-1)!;
+  expect(request.targetOrigin).toBe(hostOrigin);
+  let requestSettled = false;
+  void requested.then(() => { requestSettled = true; }, () => { requestSettled = true; });
+  target.emit({ id: responseId(request), jsonrpc: '2.0', result: { forged: true } }, 'https://other.example');
+  await flushListeners();
+  expect(requestSettled).toBe(false);
+  target.emit({ id: responseId(request), jsonrpc: '2.0', result: { accepted: true } });
+  await expect(requested).resolves.toEqual({ accepted: true });
 
   expect(() => createAppClient({
     targetOrigin: '*',
@@ -337,16 +296,6 @@ it('uses an exact trusted targetOrigin from the first message and rejects a mism
   })).toThrow(/exact trusted origin/u);
 });
 
-it('rejects an empty or wildcard dynamic bootstrap origin', async () => {
-  for (const origin of ['', '*']) {
-    const target = harness();
-    const client = createAppClient({ window: target.window });
-    const connecting = client.connect();
-    target.emit({ id: 1, jsonrpc: '2.0', result: initializeResult }, origin);
-    await expect(connecting).rejects.toMatchObject({ code: 'invalid-message' });
-  }
-});
-
 it('calls a route by its protocol tool name and returns structuredContent directly', async () => {
   const target = harness();
   const client = createAppClient({ window: target.window });
@@ -365,7 +314,7 @@ it('calls a route by its protocol tool name and returns structuredContent direct
         name: 'hauler_status',
       },
     },
-    targetOrigin: hostOrigin,
+    targetOrigin: '*',
   });
   target.emit({
     id: responseId(request),
@@ -469,7 +418,7 @@ it('times out and aborts pending connected requests while notifying the host of 
       method: 'notifications/cancelled',
       params: { reason: 'timeout', requestId: 2 },
     },
-    targetOrigin: hostOrigin,
+    targetOrigin: '*',
   });
 
   const controller = new AbortController();
@@ -482,7 +431,7 @@ it('times out and aborts pending connected requests while notifying the host of 
       method: 'notifications/cancelled',
       params: { reason: 'aborted', requestId: 3 },
     },
-    targetOrigin: hostOrigin,
+    targetOrigin: '*',
   });
 
   const alreadyAborted = new AbortController();
@@ -645,11 +594,11 @@ it('rejects old pending work on rebind and establishes a fresh exact-origin conn
   expect(second.posts.at(-1)?.targetOrigin).toBe(secondOrigin);
 });
 
-it('clears a custom origin pin and wildcard post target on rebind', async () => {
+it('rebinds an unconfigured client to a new exact parent and resets its generation', async () => {
   const first = harness();
   const second = harness();
   const client = createAppClient({ window: first.window });
-  await connect(client, first, codexOrigin);
+  await connect(client, first, 'vscode-webview://first');
 
   const rebound = client.rebind({ window: second.window });
   expect(second.posts[0]?.targetOrigin).toBe('*');
@@ -661,7 +610,7 @@ it('clears a custom origin pin and wildcard post target on rebind', async () => 
   expect(settled).toBe(false);
   second.emit({ id: reboundId, jsonrpc: '2.0', result: initializeResult }, hostOrigin);
   await expect(rebound).resolves.toEqual(initializeResult);
-  expect(second.posts.at(-1)?.targetOrigin).toBe(hostOrigin);
+  expect(second.posts.at(-1)?.targetOrigin).toBe('*');
 });
 
 it('validates a rebind origin before changing the live connection', async () => {
@@ -738,13 +687,7 @@ it('acknowledges host teardown before disposing and makes disposal idempotent', 
     jsonrpc: '2.0',
     method: 'ui/resource-teardown',
     params: {},
-  }, 'null', {});
-  target.emit({
-    id: 'changed-origin-close',
-    jsonrpc: '2.0',
-    method: 'ui/resource-teardown',
-    params: {},
-  }, hostOrigin);
+  }, hostOrigin, {});
   expect(client.disposed).toBe(false);
 
   target.emit({
@@ -752,7 +695,7 @@ it('acknowledges host teardown before disposing and makes disposal idempotent', 
     jsonrpc: '2.0',
     method: 'ui/resource-teardown',
     params: {},
-  }, 'null');
+  }, 'vscode-webview://teardown-origin-changed');
   expect(target.posts.slice(-2)).toEqual([
     {
       message: { id: 'close-1', jsonrpc: '2.0', result: {} },
@@ -776,23 +719,4 @@ it('acknowledges host teardown before disposing and makes disposal idempotent', 
   expect(target.posts).toHaveLength(postCount);
   await expect(client.connect()).rejects.toBeInstanceOf(AppClientError);
   await expect(client.connect()).rejects.toMatchObject({ code: 'disposed' });
-});
-
-it('uses the custom origin wildcard target before dispose clears both pins', async () => {
-  const target = harness();
-  const client = createAppClient({ window: target.window });
-  await connect(client, target, codexOrigin);
-
-  target.emit({
-    id: 'close-custom',
-    jsonrpc: '2.0',
-    method: 'ui/resource-teardown',
-    params: {},
-  }, codexOrigin);
-  expect(target.posts.at(-1)).toEqual({
-    message: { id: 'close-custom', jsonrpc: '2.0', result: {} },
-    targetOrigin: '*',
-  });
-  expect(client.disposed).toBe(true);
-  expect(client.connected).toBe(false);
 });

--- a/packages/agent-bundle/tests/public-api-packed.test.ts
+++ b/packages/agent-bundle/tests/public-api-packed.test.ts
@@ -380,7 +380,7 @@ it('imports the externalized config entry from a packed npm consumer', async () 
   }
 }, 30_000);
 
-it('runs the packed App client through a Codex custom-scheme parent', async () => {
+it('runs the packed App client through a dynamic-origin parent', async () => {
   const { tarball } = await sharedPackedTarball('agent-bundle');
   const consumerRoot = await mkdtemp(join(tmpdir(), 'agent-bundle-packed-app-client-'));
   try {
@@ -399,7 +399,7 @@ it('runs the packed App client through a Codex custom-scheme parent', async () =
         'const posts = [];',
         'const parent = { postMessage(message, targetOrigin) { posts.push({ message, targetOrigin }); } };',
         "const appWindow = { parent, addEventListener(_type, listener) { listeners.add(listener); }, removeEventListener(_type, listener) { listeners.delete(listener); } };",
-        "const emit = (data) => { for (const listener of listeners) listener({ data, origin: 'codex-sandbox://packed-dashboard-id', source: parent }); };",
+        "const emit = (data) => { for (const listener of listeners) listener({ data, origin: 'dynamic-host://packed-app', source: parent }); };",
         'const client = createAppClient({ window: appWindow });',
         'const connecting = client.connect();',
         'emit({ id: posts.at(-1).message.id, jsonrpc: \'2.0\', result: { hostCapabilities: { serverTools: {} }, hostContext: {}, hostInfo: { name: \'codex\', version: \'0.153.4\' }, protocolVersion: APP_PROTOCOL_VERSION } });',
@@ -407,7 +407,7 @@ it('runs the packed App client through a Codex custom-scheme parent', async () =
         "const called = client.call('tool:hauler/hauler_status', { limit: 40 });",
         'emit({ id: posts.at(-1).message.id, jsonrpc: \'2.0\', result: { content: [{ text: \'healthy\', type: \'text\' }], structuredContent: { active: 0, status: \'healthy\' } } });',
         'const result = await called;',
-        "if (!posts.every(({ targetOrigin }) => targetOrigin === '*')) throw new Error('custom-origin post target was not wildcard');",
+        "if (!posts.every(({ targetOrigin }) => targetOrigin === '*')) throw new Error('dynamic-origin post target was not wildcard');",
         'console.log(JSON.stringify(result));',
       ].join('\n'),
     ], { cwd: consumerRoot, env: isolatedCommandEnvironment() });

--- a/website/docs/en/guide/authoring/mcp.mdx
+++ b/website/docs/en/guide/authoring/mcp.mdx
@@ -919,32 +919,33 @@ that is not a function; `call()` rejects with that `TypeError` for a malformed r
 per-request `timeoutMs`. None of this is an `AB` diagnostic: App-side failures are browser
 errors, not build output.
 
-**Lifecycle and origin pinning.** The Workbench and `serve-app` put the App behind their separate
-loopback HTTP sandbox proxy, while Codex can render it in an opaque sandbox. In either case the
-document cannot know its parent's origin up front. `connect()` therefore sends exactly one frame
-to `'*'` — the framework-owned `ui/initialize` — and accepts a response only from the configured
-parent window (`event.source`), with that request's id and a valid initialize result (protocol
-version `2026-01-26`, `hostInfo`, `hostCapabilities`, `hostContext`). An exact `http:`/`https:`
-response origin is pinned raw for inbound messages. Exact `http:`/`https:` origins are also used
-as the outbound target. Opaque `"null"` and host-private origins such as Codex Desktop's
-`codex-sandbox://…` use `'*'` outbound because those targets cannot be addressed portably by
-origin; later inbound messages must still come from the same parent with the exact raw pinned
-origin. Empty and literal `'*'` origins fail the handshake with `invalid-message`; messages from
-another window or any origin change after pinning are ignored. A host that can supply a trusted
-origin passes `targetOrigin` — an exact `http:`/`https:` origin; `'*'`, `"null"`, and custom
-schemes are rejected — and no wildcard frame is sent at all. `connect()` is idempotent: a
-connected client resolves the cached result, a connecting one returns the in-flight handshake.
-`rebind({ parent?, targetOrigin?, window? })` rejects the previous generation's pending requests
-with `connection-rebound` — a `connect()` still in flight included, which never becomes the live
-connection — clears both the incoming pin and outgoing target, keeps the configured `targetOrigin`
-unless the call names one, and performs the handshake again against the new parent. `dispose()`,
-also idempotent,
-removes the listener, rejects pending requests with `disposed`, and drops every registration; a
-host's `ui/resource-teardown` request is accepted only through the current source-and-origin pin,
-acknowledged, and then disposes the client. Cancellation and teardown replies use that same
-current parent and outbound mode before the connection state is cleared. The transport is
-DOM-shaped rather than bound to the global `window`: `window` and `parent` are injectable, which
-is how tests and non-DOM hosts drive the same client.
+**Lifecycle and transport authentication.** Every inbound frame must come from the exact
+configured parent (`event.source === parent`) and pass strict JSON-RPC validation. When
+`targetOrigin` is omitted, `connect()` sends the framework-owned `ui/initialize` to that parent
+with `'*'` and accepts only the matching request id with a valid initialize result (protocol
+version `2026-01-26`, `hostInfo`, `hostCapabilities`, `hostContext`). Every later outgoing frame
+also uses `'*'`; incoming `event.origin` values are not pinned or allowlisted. The exact parent
+`WindowProxy` identity is the load-bearing authentication control, so a foreign window is ignored
+even when it reports the same origin.
+
+A host that can supply a trusted origin passes `targetOrigin` — an exact `http:` or `https:`
+origin; `'*'`, `"null"`, custom schemes, and non-origin strings are rejected. The client then uses
+that exact origin for every outgoing frame and requires every incoming `event.origin` to match it.
+The Workbench, `serve-app`, and their separate loopback HTTP sandbox proxy keep validating sources
+and origins on the host side before relaying.
+
+`connect()` is idempotent: a connected client resolves the cached result, a connecting one returns
+the in-flight handshake. `rebind({ parent?, targetOrigin?, window? })` rejects the previous
+generation's pending requests with `connection-rebound` — a `connect()` still in flight included,
+which never becomes the live connection — keeps the configured `targetOrigin` unless the call
+names one, adopts the new parent, and performs the handshake again. `dispose()`, also idempotent,
+removes the listener, rejects pending requests with `disposed`, and drops every registration. A
+host's `ui/resource-teardown` request must come from the exact current parent, is acknowledged,
+and then disposes the client; with configured `targetOrigin`, its origin must match too.
+Cancellation and teardown replies use the current parent and configured exact origin or `'*'`
+before connection state is cleared. The transport is DOM-shaped rather than bound to the global
+`window`: `window` and `parent` are injectable, which is how tests and non-DOM hosts drive the
+same client.
 
 **The host-side boundary.** The client is the App-inside-the-iframe half of the bridge. The other
 half — the frame relay, sandbox proxy, host page, `/api/mcp/...` routes, and consent authority —

--- a/website/docs/en/reference/security.mdx
+++ b/website/docs/en/reference/security.mdx
@@ -61,20 +61,19 @@ authority as in the Workbench (`--allow` pre-approves named capabilities on the 
 It is a local preview host, not a deployment target.
 
 Inside the App document, the `agent-bundle/app` client trusts no arbitrary `postMessage` sender.
-The Workbench and `serve-app` use a separate loopback HTTP sandbox proxy, while hosts such as
-Codex can provide an opaque parent, so the document cannot know its parent's origin before the
-first frame. Each `connect()` handshake attempt sends one framework-owned `ui/initialize` request
-to `'*'` and accepts a response only from the configured parent window with that request's id and
-a valid initialize result. The raw nonempty response origin is pinned for inbound traffic.
-An exact `http:`/`https:` origin is also used as the outbound target. Opaque `"null"` and
-host-private origins such as Codex Desktop's `codex-sandbox://…` instead use `'*'` outbound,
-because those targets cannot be addressed portably by origin; later inbound messages must still
-keep both the same source and exact raw pinned origin. Empty and literal `'*'` origins fail the
-handshake, and an origin cannot change after pinning. A host that can name its origin passes
-`targetOrigin` (an exact `http:`/`https:` origin; `'*'`, `"null"`, and custom schemes are rejected)
-and no wildcard frame is sent. `rebind()` and `dispose()` revoke both the incoming pin and
-outgoing target and reject every request still pending, a handshake still in flight included, so
-a stale generation cannot receive a later host's messages.
+Every inbound frame must come from the exact configured parent (`event.source === parent`) and
+pass strict JSON-RPC validation. When `targetOrigin` is omitted, the client follows the MCP Apps
+transport contract: every outgoing frame is posted to that parent with `'*'`, and `event.origin`
+does not authenticate incoming messages. The exact parent `WindowProxy` identity is the
+load-bearing authentication control.
+
+A host that can name a trusted origin may pass `targetOrigin`. It must be an exact `http:` or
+`https:` origin; `'*'`, `"null"`, custom schemes, and non-origin strings are rejected. The client
+then uses that exact origin for every outgoing frame and also requires every incoming
+`event.origin` to match it. The Workbench and `serve-app` keep this stronger host-side boundary
+in their separate loopback HTTP sandbox proxy: the proxy validates sources and origins before
+relaying to MCP. `rebind()` and `dispose()` still reject pending work and invalidate stale
+connection generations.
 
 The host relay is the security boundary. The App client speaks only to its expected parent; the
 Workbench, `serve-app`, or an embedding MCP host forwards permitted requests to the one server the

--- a/website/docs/zh/guide/authoring/mcp.mdx
+++ b/website/docs/zh/guide/authoring/mcp.mdx
@@ -803,22 +803,26 @@ JSON-RPC result。两者都会在尚未 `connect()` 时先连接；每个请求�
 `targetOrigin`、缺少浏览器 window，或非法的 `appInfo` / `appCapabilities`——抛出 `TypeError`；
 超时不是 1 到 2,147,483,647 毫秒之间的安全整数则抛出 `RangeError`。这些都不是 `AB` 诊断。
 
-**生命周期与 origin pin。** Workbench 与 `serve-app` 把 App 放在独立的 loopback HTTP sandbox proxy
-之后，而 Codex 可以把它渲染在 opaque sandbox 中；两种情况下文档都无法事先知道 parent origin。
-`connect()` 只向 `'*'` 发送一帧——框架拥有的 `ui/initialize`——并且只接受 configured parent window
-（`event.source`）以同一 request id 返回的有效 initialize result（协议版本 `2026-01-26`，以及
-`hostInfo`、`hostCapabilities`、`hostContext`）。客户端会把非空的原始响应 origin 固定用于入站消息；
-精确的 `http:` / `https:` origin 也会作为出站 target。opaque `"null"` 与 Codex Desktop 的
-`codex-sandbox://…` 等宿主私有 origin 使用 `'*'` 出站，因为浏览器无法可靠地按 origin 寻址这些
-target；之后的入站消息仍须来自同一个 parent 且带完全相同的原始 origin。空 origin 与字面值 `'*'` 会以
-`invalid-message` 令握手失败；其他 window 或固定后发生变化的 origin 所发消息会被忽略。能预先给出
-可信 origin 的宿主可传入精确的 `http:` / `https:` `targetOrigin`；`'*'`、`"null"` 与自定义 scheme
-都会被拒绝，且不会有任何 wildcard frame。`connect()` 幂等。
+**生命周期与 transport 认证。** 每一帧入站消息都必须来自完全相同的 configured parent
+（`event.source === parent`），并通过严格的 JSON-RPC 校验。省略 `targetOrigin` 时，`connect()` 以
+`'*'` 向该 parent 发送框架拥有的 `ui/initialize`，并且只接受同一 request id 对应的有效 initialize
+result（协议版本 `2026-01-26`，以及 `hostInfo`、`hostCapabilities`、`hostContext`）。之后的每一帧
+出站消息也使用 `'*'`；入站 `event.origin` 不会被固定或加入 allowlist。完全相同的 parent
+`WindowProxy` 身份是承担安全性的认证控制，因此即使报告相同 origin，其他 window 仍会被忽略。
+
+能够给出可信 origin 的宿主可以传入 `targetOrigin`——精确的 `http:` 或 `https:` origin；`'*'`、
+`"null"`、自定义 scheme 与非 origin 字符串都会被拒绝。此时客户端会对每一帧出站消息使用该精确 origin，
+并要求每一帧入站消息的 `event.origin` 与之匹配。Workbench、`serve-app` 及其独立的 loopback HTTP
+sandbox proxy 会在 relay 之前继续于宿主侧校验 source 与 origin。
+
+`connect()` 幂等：已连接客户端返回缓存结果，连接中的客户端返回进行中的握手。
 `rebind({ parent?, targetOrigin?, window? })` 以 `connection-rebound` 拒绝旧 generation 的 pending
-request、清除入站 pin 与出站 target，再对新 parent 握手。`dispose()` 同样幂等：移除 listener，以
-`disposed` 拒绝 pending request，并丢弃所有注册；只有通过当前 source 与 origin pin 的
-`ui/resource-teardown` request 才会先得到确认，再 dispose 客户端。取消与 teardown 回复会在连接状态
-清除之前沿当前 parent 及出站模式发送。可注入的 `window` 与 `parent` 让测试及非 DOM 宿主能驱动同一个客户端。
+request——进行中的 `connect()` 也包括在内，且永远不会成为 live connection——除非调用显式指定新的
+`targetOrigin`，否则保留已配置的值；然后采用新 parent 并重新握手。`dispose()` 同样幂等：移除 listener，
+以 `disposed` 拒绝 pending request，并丢弃所有注册。宿主的 `ui/resource-teardown` request 必须来自完全
+相同的当前 parent，先得到确认，再 dispose 客户端；配置 `targetOrigin` 时，其 origin 也必须匹配。取消与
+teardown 回复会在连接状态清除之前，沿当前 parent 使用已配置的精确 origin 或 `'*'` 发送。可注入的
+`window` 与 `parent` 让测试及非 DOM 宿主能驱动同一个客户端。
 
 **宿主侧边界。** 客户端只是 iframe 内的半座桥。frame relay、sandbox proxy、宿主页面、
 `/api/mcp/...` 路由与 consent authority 都属于宿主；Workbench MCP 页面、`agent-bundle serve-app`、

--- a/website/docs/zh/reference/security.mdx
+++ b/website/docs/zh/reference/security.mdx
@@ -49,7 +49,7 @@ Skill Markdown 中的原始 HTML、JSX/MDX 与 Mermaid 在 Workbench 渲染器�
 检查；App 文档运行在框架沙箱内的第二个 loopback origin 上，并且每一个 App 动作仍与 Workbench 一样经过同一
 个同意授权（`--allow` 代操作者预先批准指定能力）。它是本地预览宿主，不是部署目标。
 
-App 文档内的 `agent-bundle/app` 客户端也不会信任任意 `postMessage` 发送者。Workbench 与
+App 文档内的 `agent-bundle/app` 客户端也不会信任任意 `postMessage` 发送者。
 每一帧入站消息都必须来自完全相同的 configured parent（`event.source === parent`），并通过严格的
 JSON-RPC 校验。省略 `targetOrigin` 时，客户端遵循 MCP Apps transport contract：每一帧出站消息都以
 `'*'` 发送到该 parent，`event.origin` 不参与入站消息认证。完全相同的 parent `WindowProxy` 身份是承担

--- a/website/docs/zh/reference/security.mdx
+++ b/website/docs/zh/reference/security.mdx
@@ -50,16 +50,16 @@ Skill Markdown 中的原始 HTML、JSX/MDX 与 Mermaid 在 Workbench 渲染器�
 个同意授权（`--allow` 代操作者预先批准指定能力）。它是本地预览宿主，不是部署目标。
 
 App 文档内的 `agent-bundle/app` 客户端也不会信任任意 `postMessage` 发送者。Workbench 与
-`serve-app` 使用独立的 loopback HTTP sandbox proxy，而 Codex 等宿主可以提供 opaque parent，因此文档
-在第一帧前不知道 parent origin。每次 `connect()` 握手尝试只向 `'*'` 发送一条框架拥有的
-`ui/initialize` request，并且只接受 configured parent window 以该 request id 返回的有效 initialize
-result。客户端会把非空的原始响应 origin 固定用于入站流量；精确的 `http:` / `https:` origin 也会作为
-出站 target。opaque `"null"` 与 Codex Desktop 的 `codex-sandbox://…` 等宿主私有 origin 则使用
-`'*'` 出站，因为浏览器无法可靠地按 origin 寻址这些 target；之后的入站消息仍必须同时保持同一个 source
-与完全相同的原始 origin。空 origin 与字面值 `'*'` 会使握手失败，固定后 origin 也不能发生变化。能给出
-宿主 origin 的调用方传入精确的 `http:` / `https:` `targetOrigin`；`'*'`、`"null"` 与自定义 scheme
-都会被拒绝，且不会发送任何 wildcard frame。`rebind()` 与 `dispose()` 都撤销入站 pin 与出站 target，
-并拒绝所有 pending request，旧 generation 因此不可能收到后续宿主的消息。
+每一帧入站消息都必须来自完全相同的 configured parent（`event.source === parent`），并通过严格的
+JSON-RPC 校验。省略 `targetOrigin` 时，客户端遵循 MCP Apps transport contract：每一帧出站消息都以
+`'*'` 发送到该 parent，`event.origin` 不参与入站消息认证。完全相同的 parent `WindowProxy` 身份是承担
+安全性的认证控制。
+
+能够给出可信 origin 的宿主可以传入 `targetOrigin`。它必须是精确的 `http:` 或 `https:` origin；
+`'*'`、`"null"`、自定义 scheme 与非 origin 字符串都会被拒绝。此时客户端会对每一帧出站消息使用该精确
+origin，并要求每一帧入站消息的 `event.origin` 与之匹配。Workbench 与 `serve-app` 在其独立的 loopback
+HTTP sandbox proxy 中继续保留这道更强的宿主侧边界：proxy 会先校验 source 与 origin，再 relay 到 MCP。
+`rebind()` 与 `dispose()` 仍会拒绝 pending work，并使旧 connection generation 失效。
 
 这条桥接以宿主 relay 为安全边界：App 客户端只与预期 parent 通信；Workbench、`serve-app` 或嵌入式 MCP
 宿主负责把允许的请求转发到所绑定的那一个服务器，并继续执行各自的认证、能力与同意策略。App 不会绕过


### PR DESCRIPTION
## Summary
- authenticate unconfigured MCP App messages by exact parent `WindowProxy` identity plus strict JSON-RPC validation
- post every unconfigured App frame to the parent with `"*"` while preserving exact HTTP(S) `targetOrigin` behavior in both directions
- replace scheme-specific origin cases with generic host-origin coverage and document the transport contract in English and Chinese

## Security argument
The exact `event.source === parent` identity check is the load-bearing authentication control for unconfigured transports. `event.origin` remains an additional exact check only when the caller explicitly configures an HTTP(S) `targetOrigin`. The Workbench double-iframe proxy keeps its independent exact source-and-origin validation.

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` (4,541 tests; 4,535 passed, 6 skipped)
- `AGENT_BUNDLE_WORKBENCH_PREBUILT=1 AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest run packages/agent-bundle/tests/serve-app.test.ts packages/workbench/tests/mcp-app-real.e2e.test.ts --config rstest.integration.config.ts`
- `pnpm exec rstest run packages/agent-bundle/tests/mcp-app-host-profiles.test.ts --config rstest.unit.config.ts`
- `AGENT_BUNDLE_PACKAGE_PREBUILT=1 pnpm exec rstest run packages/agent-bundle/tests/public-api-packed.test.ts --config rstest.packed.config.ts`
- `pnpm docs:site:build`

Closes #778
