### PR TITLE
fix(packaging): align React peer ranges

### DIFF
--- a/.changeset/align-react-peer-ranges.md
+++ b/.changeset/align-react-peer-ranges.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Align `agent-bundle`'s optional React peer with `@agent-bundle/runtime`'s `^19.2.0` React and React DOM range so clean npm consumers resolve one compatible pair without preinstall pins (#780).

--- a/packages/agent-bundle/package.json
+++ b/packages/agent-bundle/package.json
@@ -144,7 +144,7 @@
   "peerDependencies": {
     "@agent-bundle/runtime": ">=0.0.0 <1",
     "@rstest/core": "^0.11.10",
-    "react": "19.2.8"
+    "react": "^19.2.0"
   },
   "peerDependenciesMeta": {
     "@agent-bundle/runtime": {

--- a/scripts/run-packed-tests.mjs
+++ b/scripts/run-packed-tests.mjs
@@ -105,9 +105,6 @@ try {
     '--ignore-scripts',
     '--no-audit',
     '--no-fund',
-    '--prefer-offline',
-    'react@19.2.8',
-    'react-dom@19.2.8',
     ...packedRecords.map((record) => record.tarball),
   ], { cwd: binConsumer, env: environment });
   const executedBins = [];

--- a/website/docs/en/guide/start/installation.mdx
+++ b/website/docs/en/guide/start/installation.mdx
@@ -67,6 +67,12 @@ These are installed only when a project uses the surface that needs them:
 | `react` | Rendering route modules and asserting on them. Also an optional peer dependency. |
 | `typescript` | `lib.dts` declaration generation, which resolves `typescript` from the project. |
 
+`agent-bundle` and `@agent-bundle/runtime` accept the same React `^19.2.0` line. The runtime
+declares that range for both React and React DOM, so a clean npm install can select one matching
+pair without preinstalling React or bypassing peer checks. Routed scaffolds still pin one
+known-good React/React DOM pair intentionally: generated projects start reproducibly, and their
+committed lockfiles preserve that pair.
+
 ## Once npm releases exist
 
 The commands below are the **future** installation path. They do not work yet, because no npm

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -37,8 +37,8 @@ selection and the separately versioned compiler/runtime pairing used by released
 | `mcp-server` | Conventional MCP tools with route/projection tests. The current starter also demonstrates an optional library export and an artifact script. |
 | `cli-tool` | A standalone routed CLI, with a script and library example. |
 
-The routed templates pin React and React DOM to the same release so a fresh install cannot select
-an incompatible peer pair.
+The routed templates intentionally pin one known-good React and React DOM release so generated
+projects start reproducibly and a fresh install cannot select an incompatible peer pair.
 
 The scaffolder offers every target the compiler builds: `amp`, `portable`, `claude`, `codex`, and
 `cursor`. One combination is refused — `amp` with this MCP starter, because Amp's skill-scoped MCP

--- a/website/docs/zh/guide/start/installation.mdx
+++ b/website/docs/zh/guide/start/installation.mdx
@@ -60,6 +60,11 @@ pnpm 与 yarn 接受同样的 URL（`pnpm add <url>`、`yarn add agent-bundle@<u
 | `react` | 渲染路由模块并对其断言。同样是可选 peer 依赖。 |
 | `typescript` | `lib.dts` 声明生成，它会从项目中解析 `typescript`。 |
 
+`agent-bundle` 与 `@agent-bundle/runtime` 接受相同的 React `^19.2.0` 版本范围。runtime 对
+React 和 React DOM 声明同一个范围，因此全新的 npm 安装可以选择一组匹配版本，无需预先安装
+React，也无需绕过 peer 检查。路由式脚手架仍会有意固定一组已验证的 React/React DOM 版本：
+生成的项目由此保持可复现，提交后的 lockfile 会继续保留这组版本。
+
 ## 等到 npm 正式发布之后
 
 下面这些命令是**未来**的安装路径。它们现在还不可用，因为尚未发布任何 npm 版本：

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -35,7 +35,8 @@ npm run check
 | `mcp-server` | 约定式 MCP 工具及路由、投影测试；当前 starter 还演示了可选的库导出与产物脚本。 |
 | `cli-tool` | 独立的路由式 CLI，附带脚本和库示例。 |
 
-路由式模板将 React 与 React DOM 固定为同一版本，避免全新安装选中不兼容的 peer 组合。
+路由式模板会有意固定一组已验证的 React 与 React DOM 版本，使生成项目保持可复现，并避免全新安装
+选中不兼容的 peer 组合。
 
 脚手架提供编译器构建的每一个 target：`amp`、`portable`、`claude`、`codex` 和 `cursor`。
 只有一种组合被拒绝——`amp` 与这个 MCP starter，因为 Amp 的 Skill 级 MCP 契约会拒绝 starter 中


### PR DESCRIPTION
## Summary
- align `agent-bundle`'s optional React peer with `@agent-bundle/runtime`'s `^19.2.0` React/React DOM range
- restore the packed bin consumer as an unpinned, registry-fresh npm install proof
- document the clean-install contract and intentional scaffold reproducibility pins in English and Chinese

## TDD evidence
- RED: the unpinned packed install selected React/React DOM 19.3.0 and failed with `ERESOLVE` against `agent-bundle`'s exact `react@19.2.8` peer
- GREEN: the focused packed install passed after widening the peer range

## Local gates
- `pnpm build` — pass
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test:unit` — pass (307 files, 4,541 tests; two load-sensitive timeouts from the parallel first run passed alone and the full rerun passed)
- `pnpm check:release` components — pack dry-run and release lint passed; the unrestricted packed pool twice hit unrelated fixed-timeout tests under ~88 host load, each passing alone; `node scripts/run-packed-tests.mjs --release --pool.maxWorkers 2` passed all 16 files / 47 tests, including the unpinned clean-consumer install
- `pnpm docs:site:build` — pass
- `node scripts/check-dist-fresh.mjs` — pass

Independent non-Grok review reported no merge-blocking findings.

Closes #780
