### PR TITLE
Fix cli-tool scaffold inputJsonSchema for AB4814

### DIFF
--- a/.changeset/cli-tool-input-json-schema.md
+++ b/.changeset/cli-tool-input-json-schema.md
@@ -1,0 +1,5 @@
+---
+"create-agent-bundle": patch
+---
+
+Declare `config.inputJsonSchema` on the `cli-tool` template `greet` command so `create-agent-bundle` scaffolds a routed CLI that compiles after `AB4814`. The starter keeps the `name` positional and `--shout` flag.

--- a/.changeset/cli-tool-input-json-schema.md
+++ b/.changeset/cli-tool-input-json-schema.md
@@ -2,4 +2,4 @@
 "create-agent-bundle": patch
 ---
 
-Declare `config.inputJsonSchema` on the `cli-tool` template `greet` command so `create-agent-bundle` scaffolds a routed CLI that compiles after `AB4814`. The starter keeps the `name` positional and `--shout` flag.
+Declare `config.inputJsonSchema` on the `cli-tool` template `greet` command so `create-agent-bundle` scaffolds a routed CLI that compiles after `AB4814`. The starter keeps the `name` positional and `--shout` flag. (#785)

--- a/packages/create-agent-bundle/templates/cli-tool/README.md
+++ b/packages/create-agent-bundle/templates/cli-tool/README.md
@@ -4,11 +4,12 @@ A routed command-line tool and library built with
 [agent-bundle](https://github.com/ScriptedAlchemy/agent-bundle). There is no
 second bundler config, no hand-written bin shim, and no argv parser: the
 `src/cli/**` convention compiles each command module into one generated
-executable, `dist/bin/my-agent-plugin.mjs`, with help, argv grammar, input
-validation, and exit codes derived from the module's own `config` and zod
-schemas. `src/index.ts` is the library export with declarations, and
-`src/scripts/hello.ts` ships as a plain script inside every host artifact. One
-`agent-bundle build` produces all of it alongside the host artifacts.
+executable, `dist/bin/my-agent-plugin.mjs`, with help and argv grammar from
+literal `config.inputJsonSchema` (plus `config.positionals`), and input
+validation and exit codes from the module's own zod schemas. `src/index.ts`
+is the library export with declarations, and `src/scripts/hello.ts` ships as
+a plain script inside every host artifact. One `agent-bundle build` produces
+all of it alongside the host artifacts.
 
 ## Commands
 
@@ -40,10 +41,11 @@ Validate and publish the generated npm root with
 
 - `agent-bundle.config.ts` — the one typed config: plugin identity and
   targets. Commands, the script, and the library are discovered by convention.
-- `src/cli/greet.ts` — the `greet` command: static `config`, `inputSchema`,
-  `resultSchema`, and an async default function. The file path is the command
-  name; nesting (`src/cli/library/audit.ts`) becomes `library audit`. A `.tsx`
-  command renders through the Agent renderer with Markdown, TTY, `--json`, and
+- `src/cli/greet.ts` — the `greet` command: static `config` (including
+  `inputJsonSchema` and `positionals`), `inputSchema`, `resultSchema`, and
+  an async default function. The file path is the command name; nesting
+  (`src/cli/library/audit.ts`) becomes `library audit`. A `.tsx` command
+  renders through the Agent renderer with Markdown, TTY, `--json`, and
   `--ndjson` output modes.
 - `src/scripts/hello.ts` — a conventional plain script exporting `main(argv)`;
   the framework generates the process envelope and `scripts/hello.mjs`.

--- a/packages/create-agent-bundle/templates/cli-tool/src/cli/greet.ts
+++ b/packages/create-agent-bundle/templates/cli-tool/src/cli/greet.ts
@@ -5,13 +5,23 @@ import { greet } from '../index.js';
 
 /**
  * A routed CLI command: the file path is the command name (`my-agent-plugin
- * greet`), the static `config` and `inputSchema` compile into the argv
- * grammar and generated help, and `resultSchema` validates what the command
- * prints as one canonical JSON line. No argv parsing lives in this file.
+ * greet`). `config.inputJsonSchema` and `config.positionals` compile the argv
+ * grammar and generated help; `inputSchema` validates parsed argv at run time;
+ * `resultSchema` validates the one canonical JSON line the command prints.
+ * No argv parsing lives in this file.
  */
 export const config = {
   description: 'Greet one person by name.',
   positionals: ['name'],
+  inputJsonSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string', description: 'Who to greet.' },
+      shout: { type: 'boolean', description: 'Upper-case the greeting.' },
+    },
+    required: ['name'],
+  },
 } satisfies CliRouteConfig;
 
 export const inputSchema = z.object({

--- a/packages/create-agent-bundle/tests/scaffold.test.ts
+++ b/packages/create-agent-bundle/tests/scaffold.test.ts
@@ -304,6 +304,16 @@ layer(NodeServices.layer, { excludeTestServices: true })('scaffold (real filesys
     // proof asserts that exact text, so the rename must reach the test.
     expect(yield* readText(path.join(root, 'tests/projection/cli-dispatch.test.ts')))
       .toContain("Run 'status-plugin greet --help' for usage.");
+    // After #782 the compiler projects argv from literal inputJsonSchema, not
+    // from the Zod inputSchema expression. Missing metadata with positionals
+    // is AB4814 (`config.positionals names "name", which is not a projected
+    // inputSchema key`).
+    const greet = yield* readText(path.join(root, 'src/cli/greet.ts'));
+    expect(greet).toContain('inputJsonSchema');
+    expect(greet).toContain("positionals: ['name']");
+    expect(greet).toMatch(/name:\s*\{\s*type:\s*'string'/u);
+    expect(greet).toMatch(/shout:\s*\{\s*type:\s*'boolean'/u);
+    expect(greet).toMatch(/required:\s*\[\s*'name'\s*\]/u);
   }));
 
   for (const template of ['minimal', 'mcp-server', 'cli-tool'] as const) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#411 stays open and untouched. This is a standalone fix against `main` only (`6db7728`, includes #782 and #784). Do not merge this PR as part of Version Packages work.

## Verified on current `origin/main`

1. **#783/#784 already landed.** This PR does not reopen stale-entry / `DevHostInstallManager` work.
2. **#782 did not fix the CLI starter.** `packages/create-agent-bundle/templates/cli-tool/src/cli/greet.ts` on `main` still uses `config.positionals: ['name']` plus a Zod `inputSchema` and no `config.inputJsonSchema`. That is the AB4814 Nightly failure (`config.positionals names "name", which is not a projected inputSchema key`). `minimal` and `mcp-server` declare no CLI routes.
3. **AB7014/AB7015 template deps are already correct on `main`.** Both `cli-tool` and `mcp-server` `package_json` files already put `@agent-bundle/runtime`, `react`, `react-dom`, and `zod` in `devDependencies` and have no `dependencies` field. This PR does not rewrite those manifests. Packed-matrix `pack:check` for both templates passed.
4. Ordinary `build()` source-snapshot / AB7101 is out of scope.

## Change

- `packages/create-agent-bundle/templates/cli-tool/src/cli/greet.ts` — declare `config.inputJsonSchema` for `name` (required string) and `shout` (optional boolean); keep `positionals: ['name']` so `greet World` / `greet World --shout` stay the product UX
- Template README now names `inputJsonSchema` as the argv grammar source
- `packages/create-agent-bundle/tests/scaffold.test.ts` — generated `greet.ts` must contain `inputJsonSchema`, the `name` positional, and `required: ['name']`
- `.changeset/cli-tool-input-json-schema.md` — `create-agent-bundle` patch

The compiler stays fail-closed. No weaker diagnostic.

## Proof

Did not run full `pnpm check:release`. Ran the scaffolder slice that Nightly failed, plus generate/validate and unit tests.

1. `pnpm build` — pass
2. `pnpm exec rstest --config rstest.unit.config.ts packages/create-agent-bundle/tests` — 8 files, 90 tests, pass (includes the new `inputJsonSchema` scaffold assertion)
3. Generate + validate the `cli-tool` template:
   - `create-agent-bundle <dir> --template cli-tool --targets portable --no-install --framework-version file:<local-agent-bundle.tgz>`
   - `agent-bundle validate --json --root <dir>` — exit 0, `diagnostics: []`, no AB4814
   - Compiled command: `name` required positional 0, `shout` optional boolean flag
4. Packed-release scaffolder slice:

   `node scripts/run-packed-tests.mjs --release packages/create-agent-bundle/tests/scaffold-packed-matrix.e2e.test.ts`

   Both cases passed: `scaffolds the cli-tool template with a routed bin, lib, and artifact script` and `scaffolds the mcp-server template and serves the conventional entry from the artifact`. That path includes generated `check` / `validate` / `pack:check` and the cli-dispatch projection tests (`greet World`, `greet World --shout`).

Do not merge. Leave #411 alone until this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066427d-6aaa-46ca-bfac-2e5ec3e4679c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066427d-6aaa-46ca-bfac-2e5ec3e4679c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

