### PR TITLE
fix: fail closed on dangling symlink containment in project paths

### DIFF
--- a/.changeset/dangling-symlink-ancestor-containment.md
+++ b/.changeset/dangling-symlink-ancestor-containment.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Treat a dangling symlink ancestor as its target when `createProjectContext` judges a missing path, so a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears.

--- a/.changeset/dangling-symlink-ancestor-containment.md
+++ b/.changeset/dangling-symlink-ancestor-containment.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Treat a dangling symlink ancestor as its target when `createProjectContext` judges a missing path, so a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears.
+Treat a dangling symlink ancestor as its target when `createProjectContext` judges a missing path, so a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears. (#789)

--- a/.changeset/dangling-symlink-ancestor-containment.md
+++ b/.changeset/dangling-symlink-ancestor-containment.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Fail closed in `createProjectContext` when a project path walks a dangling symlink: resolve relative `readlink` targets against the physical containing directory, apply authored `..` after each hop instead of flattening `symlink/../leaf`, and propagate `ELOOP` for cyclic payload roots and descendants instead of hashing a repeated target as contained. (#789)
+Fail closed in `createProjectContext` when a project path walks a dangling symlink: walk raw `readlink` targets in filesystem order without collapsing `pivot/../missing`, keep POSIX backslashes as filename data, inspect symlinks before the JS `realpathSync` shortcut, and retain the resolved prefix so missing descendants do not re-walk every parent. Propagate `ELOOP` for cyclic payload roots and descendants instead of hashing a repeated target as contained. (#789)

--- a/.changeset/dangling-symlink-ancestor-containment.md
+++ b/.changeset/dangling-symlink-ancestor-containment.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Treat a dangling symlink ancestor as its target when `createProjectContext` judges a missing path, so a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears. (#789)
+Treat a dangling symlink at the current path and every recursively visited target as its fully resolved destination when `createProjectContext` judges a missing path, so a payload-root link, a chained relative hop, or a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears. (#789)

--- a/.changeset/dangling-symlink-ancestor-containment.md
+++ b/.changeset/dangling-symlink-ancestor-containment.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Treat a dangling symlink at the current path and every recursively visited target as its fully resolved destination when `createProjectContext` judges a missing path, so a payload-root link, a chained relative hop, or a leaf under an escaping symlink still fails closed as outside the project root instead of reconstructing a lexical-inside path that can resolve outside after the target appears. (#789)
+Fail closed in `createProjectContext` when a project path walks a dangling symlink: resolve relative `readlink` targets against the physical containing directory, apply authored `..` after each hop instead of flattening `symlink/../leaf`, and propagate `ELOOP` for cyclic payload roots and descendants instead of hashing a repeated target as contained. (#789)

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -170,6 +170,7 @@ not build the Workbench e2e example payload):
 - `install.test.ts` / `uninstall.test.ts` (receipt ownership)
 - `durable-fs.test.ts` (atomic publish, Windows directory fsync)
 - `internal-child-resolution-policy.test.ts` (packaged child resolution, #769)
+- `npm-cli-resolution.test.ts` (Windows official + Unix/nvm + PATH + split-prefix/pnpm `npm_execpath`)
 - `packed-install-bin.test.ts` (packaged installer bin from a consumer cwd)
 - `rstest-worker-isolation.test.ts` (canonical TMPDIR; macOS `/tmp` → `/private/tmp`)
 

--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -1,4 +1,4 @@
-import { readFileSync, realpathSync } from 'node:fs';
+import { lstatSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
@@ -263,10 +263,12 @@ const projectRelativePath = (root: string, value: string, label: string): string
  * Existing paths collapse to on-disk identity (8.3, junctions, symlink hops).
  * Missing paths resolve the nearest existing ancestor and append the missing
  * suffix so a dangling leaf under an escaping symlink is judged against the
- * canonical target, not the lexical spelling. A path with no existing
- * ancestor stays lexical.
+ * canonical target, not the lexical spelling. A dangling symlink ancestor is
+ * not treated as missing: its target is resolved even when that target does
+ * not exist yet, so containment sees the escape before the link materializes.
+ * A path with no existing ancestor stays lexical.
  */
-const onDiskOrNearestAncestorPath = (lexicalPath: string): string => {
+const onDiskOrNearestAncestorPath = (lexicalPath: string, seen: ReadonlySet<string> = new Set()): string => {
   try {
     return realpathSync(lexicalPath);
   } catch (error) {
@@ -282,8 +284,17 @@ const onDiskOrNearestAncestorPath = (lexicalPath: string): string => {
       return join(realpathSync(parent), ...missing);
     } catch (error) {
       if (!isErrno(error, 'ENOENT')) throw error;
-      cursor = parent;
     }
+    try {
+      if (lstatSync(parent).isSymbolicLink()) {
+        const target = resolve(dirname(parent), readlinkSync(parent));
+        if (seen.has(target)) return join(target, ...missing);
+        return join(onDiskOrNearestAncestorPath(target, new Set([...seen, target])), ...missing);
+      }
+    } catch (error) {
+      if (!isErrno(error, 'ENOENT')) throw error;
+    }
+    cursor = parent;
   }
 };
 

--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -1,5 +1,5 @@
 import { lstatSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path';
 
 import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
 import type { DescriptiveMetadataResult } from './descriptive-metadata.ts';
@@ -259,8 +259,14 @@ const projectRelativePath = (root: string, value: string, label: string): string
   return projectRelative;
 };
 
-const isUnresolvedPathError = (error: unknown): boolean =>
-  isErrno(error, 'ENOENT') || isErrno(error, 'ELOOP');
+const isMissingPathError = (error: unknown): boolean => isErrno(error, 'ENOENT');
+
+const symlinkLoopError = (path: string): Error =>
+  Object.assign(new Error(`ELOOP: too many symbolic links encountered, stat '${path}'`), {
+    code: 'ELOOP',
+    path,
+    syscall: 'stat',
+  });
 
 /**
  * Existing paths collapse to on-disk identity (8.3, junctions, symlink hops).
@@ -270,27 +276,56 @@ const isUnresolvedPathError = (error: unknown): boolean =>
  * current path or any recursively visited target is not treated as missing:
  * its chain is fully resolved even when the final target does not exist yet,
  * then the missing suffix is appended, so containment sees the escape before
- * the link materializes. Symlink cycles stop walking and still go through
- * containment. A path with no existing ancestor stays lexical.
+ * the link materializes. Relative `readlink` targets are resolved against the
+ * physical containing directory so a parent that is itself a symlink does not
+ * keep a `../escape` hop inside the lexical spelling. Authored `..` is applied
+ * after each hop; `path.resolve` is not used to flatten a `symlink/../leaf`
+ * spelling. Symlink cycles propagate `ELOOP` and are never returned as a
+ * contained path. A path with no existing ancestor stays lexical.
  */
-const onDiskOrNearestAncestorPath = (lexicalPath: string, seen: ReadonlySet<string> = new Set()): string => {
+const resolveExistingOrMissing = (lexicalPath: string, seen: ReadonlySet<string>): string => {
   try {
     return realpathSync(lexicalPath);
   } catch (error) {
-    if (!isUnresolvedPathError(error)) throw error;
+    if (!isMissingPathError(error)) throw error;
   }
   try {
     if (lstatSync(lexicalPath).isSymbolicLink()) {
-      const target = resolve(dirname(lexicalPath), readlinkSync(lexicalPath));
-      if (seen.has(target)) return target;
-      return onDiskOrNearestAncestorPath(target, new Set([...seen, target]));
+      const parent = dirname(lexicalPath);
+      const physicalParent = parent === lexicalPath
+        ? lexicalPath
+        : onDiskOrNearestAncestorPath(parent, seen);
+      const target = resolve(physicalParent, readlinkSync(lexicalPath));
+      if (seen.has(lexicalPath) || seen.has(target)) throw symlinkLoopError(lexicalPath);
+      return onDiskOrNearestAncestorPath(target, new Set([...seen, lexicalPath]));
     }
   } catch (error) {
-    if (!isUnresolvedPathError(error)) throw error;
+    if (!isMissingPathError(error)) throw error;
   }
   const parent = dirname(lexicalPath);
   if (parent === lexicalPath) return lexicalPath;
   return join(onDiskOrNearestAncestorPath(parent, seen), basename(lexicalPath));
+};
+
+const onDiskOrNearestAncestorPath = (
+  lexicalPath: string,
+  seen: ReadonlySet<string> = new Set(),
+): string => {
+  const root = parse(lexicalPath).root;
+  const parts = lexicalPath
+    .slice(root.length)
+    .split(/[/\\]/u)
+    .filter((part) => part.length > 0 && part !== '.');
+  if (parts.length === 0) return resolveExistingOrMissing(lexicalPath, seen);
+  let current = root.length === 0 ? sep : root;
+  for (const part of parts) {
+    if (part === '..') {
+      current = dirname(resolveExistingOrMissing(current, seen));
+      continue;
+    }
+    current = resolveExistingOrMissing(join(current, part), seen);
+  }
+  return current;
 };
 
 /**
@@ -312,7 +347,9 @@ const resolvedProjectPath = (
   // (Windows `C:\…`, 8.3 aliases) are judged by realpath identity so a
   // short-name root and a long-name config file still name one project.
   if (!isAbsolute(value)) projectRelativePath(lexicalRoot, value, label);
-  const lexicalPath = isAbsolute(value) ? resolve(value) : resolve(lexicalRoot, value);
+  // Absolute authored paths keep `..` segments so a `symlink/../leaf` hop is
+  // walked in filesystem order. `path.resolve` would erase the symlink.
+  const lexicalPath = isAbsolute(value) ? value : resolve(lexicalRoot, value);
   const referencedPath = onDiskOrNearestAncestorPath(lexicalPath);
   if (escapesRoot(canonicalRoot, referencedPath)) {
     throw new RangeError(`${label} ${JSON.stringify(referencedPath)} is outside project root ${JSON.stringify(canonicalRoot)}.`);

--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -1,5 +1,5 @@
 import { lstatSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path';
 
 import type { SkillHostDocument, SkillIr, SkillSidecarRef } from '../skills/ir.ts';
 import type { DescriptiveMetadataResult } from './descriptive-metadata.ts';
@@ -276,57 +276,106 @@ const symlinkLoopError = (path: string): Error =>
  * current path or any recursively visited target is not treated as missing:
  * its chain is fully resolved even when the final target does not exist yet,
  * then the missing suffix is appended, so containment sees the escape before
- * the link materializes. Relative `readlink` targets are resolved against the
- * physical containing directory so a parent that is itself a symlink does not
- * keep a `../escape` hop inside the lexical spelling. Authored `..` is applied
- * after each hop; `path.resolve` is not used to flatten a `symlink/../leaf`
- * spelling. Symlink cycles propagate `ELOOP` and are never returned as a
- * contained path. A path with no existing ancestor stays lexical.
+ * the link materializes. Relative `readlink` targets are walked from the
+ * physical containing directory without `path.resolve`, so a stored
+ * `pivot/../missing` hop is applied after the pivot. Absolute stored targets
+ * are walked the same way from their own root. POSIX tokenization keeps
+ * literal backslashes inside one filename; Windows still splits on both
+ * separators. The walk retains the resolved prefix and missing suffix as it
+ * advances, so a deeper missing path does not re-walk every parent. Existing
+ * paths use native `realpath` (or inspect a symlink before any JS
+ * `realpathSync`) so an inside decoy cannot hide an outside destination.
+ * Symlink cycles propagate `ELOOP` and are never returned as a contained
+ * path. A path with no existing ancestor stays lexical.
  */
-const resolveExistingOrMissing = (lexicalPath: string, seen: ReadonlySet<string>): string => {
+const pathComponentSeparator = sep === '\\' ? /[/\\]/u : '/';
+
+const splitPathComponents = (value: string): readonly string[] =>
+  value.split(pathComponentSeparator).filter((part) => part.length > 0 && part !== '.');
+
+const tokenizeLexicalPath = (
+  lexicalPath: string,
+): { readonly parts: readonly string[]; readonly root: string } => {
+  const root = parse(lexicalPath).root;
+  return {
+    parts: splitPathComponents(lexicalPath.slice(root.length)),
+    root: root.length === 0 ? sep : root,
+  };
+};
+
+const realpathExisting = (value: string): string =>
+  typeof realpathSync.native === 'function' ? realpathSync.native(value) : realpathSync(value);
+
+const followSymlink = (
+  linkPath: string,
+  physicalParent: string,
+  seen: ReadonlySet<string>,
+): string => {
+  if (seen.has(linkPath)) throw symlinkLoopError(linkPath);
+  const rawTarget = readlinkSync(linkPath);
+  const nextSeen = new Set([...seen, linkPath]);
+  if (nextSeen.has(rawTarget)) throw symlinkLoopError(linkPath);
+  return isAbsolute(rawTarget)
+    ? walkFilesystemOrder(rawTarget, nextSeen)
+    : walkFrom(physicalParent, splitPathComponents(rawTarget), nextSeen);
+};
+
+const resolveExistingNode = (
+  path: string,
+  physicalParent: string,
+  seen: ReadonlySet<string>,
+): string => {
   try {
-    return realpathSync(lexicalPath);
+    if (lstatSync(path).isSymbolicLink()) return followSymlink(path, physicalParent, seen);
   } catch (error) {
     if (!isMissingPathError(error)) throw error;
+    return path;
   }
   try {
-    if (lstatSync(lexicalPath).isSymbolicLink()) {
-      const parent = dirname(lexicalPath);
-      const physicalParent = parent === lexicalPath
-        ? lexicalPath
-        : onDiskOrNearestAncestorPath(parent, seen);
-      const target = resolve(physicalParent, readlinkSync(lexicalPath));
-      if (seen.has(lexicalPath) || seen.has(target)) throw symlinkLoopError(lexicalPath);
-      return onDiskOrNearestAncestorPath(target, new Set([...seen, lexicalPath]));
+    return realpathExisting(path);
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+    return path;
+  }
+};
+
+const walkFrom = (
+  start: string,
+  parts: readonly string[],
+  seen: ReadonlySet<string>,
+): string => {
+  let current = resolveExistingNode(start, dirname(start), seen);
+  for (const part of parts) {
+    if (part === '..') {
+      const parent = dirname(current);
+      current = parent === current ? current : resolveExistingNode(parent, dirname(parent), seen);
+      continue;
     }
-  } catch (error) {
-    if (!isMissingPathError(error)) throw error;
+    current = resolveExistingNode(join(current, part), current, seen);
   }
-  const parent = dirname(lexicalPath);
-  if (parent === lexicalPath) return lexicalPath;
-  return join(onDiskOrNearestAncestorPath(parent, seen), basename(lexicalPath));
+  return current;
+};
+
+const walkFilesystemOrder = (
+  lexicalPath: string,
+  seen: ReadonlySet<string> = new Set(),
+): string => {
+  if (seen.size === 0) {
+    try {
+      return realpathExisting(lexicalPath);
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+    }
+  }
+  const { parts, root } = tokenizeLexicalPath(lexicalPath);
+  if (parts.length === 0) return resolveExistingNode(lexicalPath, root, seen);
+  return walkFrom(root, parts, seen);
 };
 
 const onDiskOrNearestAncestorPath = (
   lexicalPath: string,
   seen: ReadonlySet<string> = new Set(),
-): string => {
-  const root = parse(lexicalPath).root;
-  const parts = lexicalPath
-    .slice(root.length)
-    .split(/[/\\]/u)
-    .filter((part) => part.length > 0 && part !== '.');
-  if (parts.length === 0) return resolveExistingOrMissing(lexicalPath, seen);
-  let current = root.length === 0 ? sep : root;
-  for (const part of parts) {
-    if (part === '..') {
-      current = dirname(resolveExistingOrMissing(current, seen));
-      continue;
-    }
-    current = resolveExistingOrMissing(join(current, part), seen);
-  }
-  return current;
-};
+): string => walkFilesystemOrder(lexicalPath, seen);
 
 /**
  * Project-relative POSIX path using on-disk identity. Snapshot inputs and

--- a/packages/agent-bundle/src/core/project-context.ts
+++ b/packages/agent-bundle/src/core/project-context.ts
@@ -259,43 +259,38 @@ const projectRelativePath = (root: string, value: string, label: string): string
   return projectRelative;
 };
 
+const isUnresolvedPathError = (error: unknown): boolean =>
+  isErrno(error, 'ENOENT') || isErrno(error, 'ELOOP');
+
 /**
  * Existing paths collapse to on-disk identity (8.3, junctions, symlink hops).
  * Missing paths resolve the nearest existing ancestor and append the missing
  * suffix so a dangling leaf under an escaping symlink is judged against the
- * canonical target, not the lexical spelling. A dangling symlink ancestor is
- * not treated as missing: its target is resolved even when that target does
- * not exist yet, so containment sees the escape before the link materializes.
- * A path with no existing ancestor stays lexical.
+ * canonical target, not the lexical spelling. A dangling symlink at the
+ * current path or any recursively visited target is not treated as missing:
+ * its chain is fully resolved even when the final target does not exist yet,
+ * then the missing suffix is appended, so containment sees the escape before
+ * the link materializes. Symlink cycles stop walking and still go through
+ * containment. A path with no existing ancestor stays lexical.
  */
 const onDiskOrNearestAncestorPath = (lexicalPath: string, seen: ReadonlySet<string> = new Set()): string => {
   try {
     return realpathSync(lexicalPath);
   } catch (error) {
-    if (!isErrno(error, 'ENOENT')) throw error;
+    if (!isUnresolvedPathError(error)) throw error;
   }
-  const missing: string[] = [];
-  let cursor = lexicalPath;
-  for (;;) {
-    const parent = dirname(cursor);
-    if (parent === cursor) return lexicalPath;
-    missing.unshift(basename(cursor));
-    try {
-      return join(realpathSync(parent), ...missing);
-    } catch (error) {
-      if (!isErrno(error, 'ENOENT')) throw error;
+  try {
+    if (lstatSync(lexicalPath).isSymbolicLink()) {
+      const target = resolve(dirname(lexicalPath), readlinkSync(lexicalPath));
+      if (seen.has(target)) return target;
+      return onDiskOrNearestAncestorPath(target, new Set([...seen, target]));
     }
-    try {
-      if (lstatSync(parent).isSymbolicLink()) {
-        const target = resolve(dirname(parent), readlinkSync(parent));
-        if (seen.has(target)) return join(target, ...missing);
-        return join(onDiskOrNearestAncestorPath(target, new Set([...seen, target])), ...missing);
-      }
-    } catch (error) {
-      if (!isErrno(error, 'ENOENT')) throw error;
-    }
-    cursor = parent;
+  } catch (error) {
+    if (!isUnresolvedPathError(error)) throw error;
   }
+  const parent = dirname(lexicalPath);
+  if (parent === lexicalPath) return lexicalPath;
+  return join(onDiskOrNearestAncestorPath(parent, seen), basename(lexicalPath));
 };
 
 /**

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -899,6 +899,35 @@ it('reports snapshot failures as frozen preparation diagnostics', async () => {
   }
 });
 
+it('rejects a missing path under a dangling symlink that escapes the project', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const danglingTarget = `${root}-missing-external-dir`;
+    await symlink(danglingTarget, join(root, 'escaped-dir'), 'dir');
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: 'escaped-dir/missing.ts', sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/outside project root/i);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 it.each([
   { code: 'claude.outputStyles.directory.outside', field: 'outputStyles' },
   { code: 'claude.workflows.directory.outside', field: 'workflows' },

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -1293,9 +1293,10 @@ posixContainmentIt('rejects a POSIX symlink target that uses a backslash in one 
       sourceInputs: prepared.projectContext?.sourceInputs ?? [],
     })).toThrow(/outside project root/i);
 
-    await writeFile(join(outside, 'missing'), 'OUTSIDE\n');
+    const outsideMissing = join(outside, 'anchor', 'missing');
+    await writeFile(outsideMissing, 'OUTSIDE\n');
     expect(await readFile(payload, 'utf8')).toBe('OUTSIDE\n');
-    expect(nodeFs.realpathSync.native(payload)).toBe(nodeFs.realpathSync.native(join(outside, 'missing')));
+    expect(nodeFs.realpathSync.native(payload)).toBe(nodeFs.realpathSync.native(outsideMissing));
   } finally {
     await Promise.all([
       rm(root, { force: true, recursive: true }),

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join, relative, win32 } from 'node:path';
+import { dirname, join, relative, sep, win32 } from 'node:path';
 
 import { expect, it } from '@rstest/core';
 
@@ -1027,7 +1027,7 @@ it('accepts a missing payload directory that stays inside the project', async ()
   }
 });
 
-it('stops a dangling symlink cycle and still judges containment', async () => {
+it('rejects a cyclic payload-root symlink instead of hashing it as contained', async () => {
   const root = await createProject([
     '---',
     'name: review',
@@ -1044,12 +1044,18 @@ it('stops a dangling symlink cycle and still judges containment', async () => {
     const loopB = join(root, 'loop-b');
     await symlink('loop-b', loopA);
     await symlink('loop-a', loopB);
-    expect(createProjectContext({
+    expect(() => createProjectContext({
       configPath: prepared.configPath,
       model: withPayloadSource(model, loopA),
       root,
       sourceInputs: prepared.projectContext?.sourceInputs ?? [],
-    }).modelDigest).toEqual(expect.any(String));
+    })).toThrow(/ELOOP/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, loopB),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/ELOOP/i);
     expect(() => createProjectContext({
       configPath: prepared.configPath,
       model,
@@ -1061,6 +1067,138 @@ it('stops a dangling symlink cycle and still judges containment', async () => {
     })).toThrow(/ELOOP/i);
   } finally {
     await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('rejects an outside-crossing symlink cycle from both entry points', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  const outside = `${root}-outside-loop`;
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const inside = join(root, 'inside-loop');
+    await symlink(outside, inside, 'dir');
+    await symlink(inside, outside, 'dir');
+    for (const entry of [inside, outside]) {
+      expect(() => createProjectContext({
+        configPath: prepared.configPath,
+        model: withPayloadSource(model, entry),
+        root,
+        sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+      })).toThrow(/ELOOP/i);
+    }
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: 'inside-loop/missing.ts', sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/ELOOP/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: join(outside, 'missing.ts'), sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/ELOOP/i);
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(outside, { force: true, recursive: true }),
+    ]);
+  }
+});
+
+it('rejects a dangling relative symlink under a parent that itself is a symlink', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  const elsewhere = await mkdtemp(join(tmpdir(), 'agent-bundle-symlink-parent-'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const physical = join(elsewhere, 'physical');
+    await mkdir(physical);
+    await symlink(join('..', 'escape'), join(physical, 'rel'));
+    await symlink(physical, join(root, 'alias'), 'dir');
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, join(root, 'alias', 'rel')),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: 'alias/rel/missing.ts', sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/outside project root/i);
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(elsewhere, { force: true, recursive: true }),
+    ]);
+  }
+});
+
+it('rejects symlink/../payload that escapes after the symlink hop', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  const outside = await mkdtemp(join(tmpdir(), 'agent-bundle-symlink-dotdot-'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    await mkdir(join(root, 'payload'));
+    await symlink(outside, join(root, 'link'), 'dir');
+    const authored = [root, 'link', '..', 'payload'].join(sep);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, authored),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: [root, 'link', '..', 'payload', 'missing.ts'].join(sep), sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/outside project root/i);
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(outside, { force: true, recursive: true }),
+    ]);
   }
 });
 

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, win32 } from 'node:path';
+import { dirname, join, relative, win32 } from 'node:path';
 
 import { expect, it } from '@rstest/core';
 
@@ -899,6 +899,80 @@ it('reports snapshot failures as frozen preparation diagnostics', async () => {
   }
 });
 
+const withPayloadSource = (
+  model: NonNullable<Awaited<ReturnType<ProjectService['prepare']>>['model']>,
+  source: string,
+) => ({
+  ...model,
+  payloads: [{
+    files: [],
+    id: 'payload:runtime',
+    name: 'runtime',
+    provenance: model.metadata.provenance,
+    runtimeDependencies: [],
+    source,
+    targets: ['portable'],
+  }],
+});
+
+it('rejects a dangling payload-root symlink that escapes the project', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const payload = join(root, 'payload');
+    await symlink(`${root}-missing-external-payload`, payload, 'dir');
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, payload),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('rejects a missing path under chained relative dangling symlinks that escape the project', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const hop = join(root, 'hop');
+    const escaped = join(root, 'escaped-dir');
+    const danglingTarget = `${root}-missing-external-dir`;
+    await symlink(relative(dirname(hop), danglingTarget), hop);
+    await symlink('hop', escaped);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: 'escaped-dir/missing.ts', sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/outside project root/i);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 it('rejects a missing path under a dangling symlink that escapes the project', async () => {
   const root = await createProject([
     '---',
@@ -923,6 +997,68 @@ it('rejects a missing path under a dangling symlink that escapes the project', a
         { path: 'escaped-dir/missing.ts', sha256: 'a'.repeat(64) },
       ],
     })).toThrow(/outside project root/i);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('accepts a missing payload directory that stays inside the project', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const context = createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, join(root, 'built', 'runtime')),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    });
+    expect(context.modelDigest).toEqual(expect.any(String));
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+it('stops a dangling symlink cycle and still judges containment', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const loopA = join(root, 'loop-a');
+    const loopB = join(root, 'loop-b');
+    await symlink('loop-b', loopA);
+    await symlink('loop-a', loopB);
+    expect(createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, loopA),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    }).modelDigest).toEqual(expect.any(String));
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: 'loop-a/missing.ts', sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/ELOOP/i);
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/packages/agent-bundle/tests/dev-services.test.ts
+++ b/packages/agent-bundle/tests/dev-services.test.ts
@@ -1,3 +1,4 @@
+import * as nodeFs from 'node:fs';
 import { chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, sep, win32 } from 'node:path';
@@ -1194,6 +1195,107 @@ it('rejects symlink/../payload that escapes after the symlink hop', async () => 
         { path: [root, 'link', '..', 'payload', 'missing.ts'].join(sep), sha256: 'a'.repeat(64) },
       ],
     })).toThrow(/outside project root/i);
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(outside, { force: true, recursive: true }),
+    ]);
+  }
+});
+
+const posixContainmentIt = process.platform === 'win32' ? it.skip : it;
+
+const storedDotDotTarget = (root: string, kind: 'relative' | 'absolute'): string =>
+  kind === 'relative' ? 'pivot/../missing' : `${root}${sep}pivot${sep}..${sep}missing`;
+
+it.each([
+  { kind: 'relative' as const },
+  { kind: 'absolute' as const },
+])('rejects a payload symlink whose stored $kind target is pivot/../missing', async ({ kind }) => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  const outside = await mkdtemp(join(tmpdir(), `agent-bundle-stored-${kind}-dotdot-`));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    await mkdir(join(outside, 'anchor'));
+    await mkdir(join(root, 'missing'));
+    await writeFile(join(root, 'missing', 'decoy.txt'), 'inside-decoy\n');
+    await symlink(join(outside, 'anchor'), join(root, 'pivot'), 'dir');
+    const payload = join(root, 'payload');
+    await symlink(storedDotDotTarget(root, kind), payload);
+    expect(await nodeFs.promises.readlink(payload)).toBe(storedDotDotTarget(root, kind));
+
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, payload),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, join(payload, 'child')),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model,
+      root,
+      sourceInputs: [
+        ...(prepared.projectContext?.sourceInputs ?? []),
+        { path: join(payload, 'missing.ts'), sha256: 'a'.repeat(64) },
+      ],
+    })).toThrow(/outside project root/i);
+
+    await writeFile(join(outside, 'missing'), 'OUTSIDE\n');
+    expect(await readFile(payload, 'utf8')).toBe('OUTSIDE\n');
+    expect(nodeFs.realpathSync.native(payload)).toBe(nodeFs.realpathSync.native(join(outside, 'missing')));
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(outside, { force: true, recursive: true }),
+    ]);
+  }
+});
+
+posixContainmentIt('rejects a POSIX symlink target that uses a backslash in one filename', async () => {
+  const root = await createProject([
+    '---',
+    'name: review',
+    'description: Reviews changes',
+    '---',
+    'Review the changed files.',
+    '',
+  ].join('\n'));
+  const outside = await mkdtemp(join(tmpdir(), 'agent-bundle-posix-backslash-'));
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    await mkdir(join(outside, 'anchor'));
+    await symlink(join(outside, 'anchor'), join(root, 'odd\\dir'), 'dir');
+    const payload = join(root, 'payload');
+    await symlink('odd\\dir/missing', payload);
+    expect(await nodeFs.promises.readlink(payload)).toBe('odd\\dir/missing');
+
+    expect(() => createProjectContext({
+      configPath: prepared.configPath,
+      model: withPayloadSource(model, payload),
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    })).toThrow(/outside project root/i);
+
+    await writeFile(join(outside, 'missing'), 'OUTSIDE\n');
+    expect(await readFile(payload, 'utf8')).toBe('OUTSIDE\n');
+    expect(nodeFs.realpathSync.native(payload)).toBe(nodeFs.realpathSync.native(join(outside, 'missing')));
   } finally {
     await Promise.all([
       rm(root, { force: true, recursive: true }),

--- a/packages/agent-bundle/tests/project-context-walk-bound.test.ts
+++ b/packages/agent-bundle/tests/project-context-walk-bound.test.ts
@@ -1,8 +1,9 @@
-import { expect, it } from '@rstest/core';
-
+import { realpathSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+import { expect, it, rs } from '@rstest/core';
 
 import { createProjectContext, ProjectService } from '../src/dev/index.ts';
 
@@ -32,36 +33,45 @@ const createProject = async (): Promise<string> => {
   return root;
 };
 
-it('accepts a deep missing payload path without overflowing the walk', async () => {
+it('bounds filesystem probes for deep missing payload paths', async () => {
   const root = await createProject();
+  // The walker prefers `realpathSync.native` on the original function. Module
+  // spies on `node:fs` wrap the export and miss those named-import snapshots.
+  const realpathNative = rs.spyOn(realpathSync, 'native');
   try {
     const prepared = await new ProjectService({ root }).prepare('build');
     const model = prepared.model;
     if (model === undefined) throw new Error('Expected a prepared model.');
-    const source = join(
-      root,
-      'built',
-      ...Array.from({ length: 80 }, (_, index) => `seg${String(index)}`),
-    );
-    const context = createProjectContext({
-      configPath: prepared.configPath,
-      model: {
-        ...model,
-        payloads: [{
-          files: [],
-          id: 'payload:runtime',
-          name: 'runtime',
-          provenance: model.metadata.provenance,
-          runtimeDependencies: [],
-          source,
-          targets: ['portable'],
-        }],
-      },
-      root,
-      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
-    });
-    expect(context.modelDigest).toEqual(expect.any(String));
+    const probe = (depth: number): number => {
+      realpathNative.mockClear();
+      const source = join(root, 'built', ...Array.from({ length: depth }, (_, index) => `seg${String(index)}`));
+      const context = createProjectContext({
+        configPath: prepared.configPath,
+        model: {
+          ...model,
+          payloads: [{
+            files: [],
+            id: 'payload:runtime',
+            name: 'runtime',
+            provenance: model.metadata.provenance,
+            runtimeDependencies: [],
+            source,
+            targets: ['portable'],
+          }],
+        },
+        root,
+        sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+      });
+      expect(context.modelDigest).toEqual(expect.any(String));
+      return realpathNative.mock.calls.length;
+    };
+    const depth6 = probe(6);
+    const depth14 = probe(14);
+    expect(depth6).toBeGreaterThan(0);
+    expect(depth14).toBeLessThan(200);
+    expect(depth14).toBeLessThan(depth6 * 4);
   } finally {
+    realpathNative.mockRestore();
     await rm(root, { force: true, recursive: true });
   }
 });

--- a/packages/agent-bundle/tests/project-context-walk-bound.test.ts
+++ b/packages/agent-bundle/tests/project-context-walk-bound.test.ts
@@ -1,8 +1,5 @@
-import { expect, it, rs } from '@rstest/core';
+import { expect, it } from '@rstest/core';
 
-rs.mock('node:fs', { spy: true });
-
-import * as nodeFs from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -35,43 +32,35 @@ const createProject = async (): Promise<string> => {
   return root;
 };
 
-it('bounds filesystem probes for deep missing payload paths', async () => {
+it('accepts a deep missing payload path without overflowing the walk', async () => {
   const root = await createProject();
   try {
     const prepared = await new ProjectService({ root }).prepare('build');
     const model = prepared.model;
     if (model === undefined) throw new Error('Expected a prepared model.');
-    const realpath = rs.mocked(nodeFs.realpathSync);
-    const lstat = rs.mocked(nodeFs.lstatSync);
-    const probe = (depth: number): number => {
-      realpath.mockClear();
-      lstat.mockClear();
-      const source = join(root, 'built', ...Array.from({ length: depth }, (_, index) => `seg${String(index)}`));
-      const context = createProjectContext({
-        configPath: prepared.configPath,
-        model: {
-          ...model,
-          payloads: [{
-            files: [],
-            id: 'payload:runtime',
-            name: 'runtime',
-            provenance: model.metadata.provenance,
-            runtimeDependencies: [],
-            source,
-            targets: ['portable'],
-          }],
-        },
-        root,
-        sourceInputs: prepared.projectContext?.sourceInputs ?? [],
-      });
-      expect(context.modelDigest).toEqual(expect.any(String));
-      return realpath.mock.calls.length + lstat.mock.calls.length;
-    };
-    const depth6 = probe(6);
-    const depth14 = probe(14);
-    expect(depth6).toBeGreaterThan(0);
-    expect(depth14).toBeLessThan(200);
-    expect(depth14).toBeLessThan(depth6 * 4);
+    const source = join(
+      root,
+      'built',
+      ...Array.from({ length: 80 }, (_, index) => `seg${String(index)}`),
+    );
+    const context = createProjectContext({
+      configPath: prepared.configPath,
+      model: {
+        ...model,
+        payloads: [{
+          files: [],
+          id: 'payload:runtime',
+          name: 'runtime',
+          provenance: model.metadata.provenance,
+          runtimeDependencies: [],
+          source,
+          targets: ['portable'],
+        }],
+      },
+      root,
+      sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+    });
+    expect(context.modelDigest).toEqual(expect.any(String));
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/packages/agent-bundle/tests/project-context-walk-bound.test.ts
+++ b/packages/agent-bundle/tests/project-context-walk-bound.test.ts
@@ -1,0 +1,78 @@
+import { expect, it, rs } from '@rstest/core';
+
+rs.mock('node:fs', { spy: true });
+
+import * as nodeFs from 'node:fs';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createProjectContext, ProjectService } from '../src/dev/index.ts';
+
+const createProject = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-bundle-walk-bound-'));
+  await mkdir(join(root, 'src', 'skills', 'review'), { recursive: true });
+  await Promise.all([
+    writeFile(
+      join(root, 'agent-bundle.config.ts'),
+      [
+        'export default {',
+        "  plugin: { name: 'dev-service-fixture', version: '1.0.0' },",
+        "  targets: ['portable'],",
+        '};',
+        '',
+      ].join('\n'),
+    ),
+    writeFile(join(root, 'src', 'skills', 'review', 'SKILL.md'), [
+      '---',
+      'name: review',
+      'description: Reviews changes',
+      '---',
+      'Review the changed files.',
+      '',
+    ].join('\n')),
+  ]);
+  return root;
+};
+
+it('bounds filesystem probes for deep missing payload paths', async () => {
+  const root = await createProject();
+  try {
+    const prepared = await new ProjectService({ root }).prepare('build');
+    const model = prepared.model;
+    if (model === undefined) throw new Error('Expected a prepared model.');
+    const realpath = rs.mocked(nodeFs.realpathSync);
+    const lstat = rs.mocked(nodeFs.lstatSync);
+    const probe = (depth: number): number => {
+      realpath.mockClear();
+      lstat.mockClear();
+      const source = join(root, 'built', ...Array.from({ length: depth }, (_, index) => `seg${String(index)}`));
+      const context = createProjectContext({
+        configPath: prepared.configPath,
+        model: {
+          ...model,
+          payloads: [{
+            files: [],
+            id: 'payload:runtime',
+            name: 'runtime',
+            provenance: model.metadata.provenance,
+            runtimeDependencies: [],
+            source,
+            targets: ['portable'],
+          }],
+        },
+        root,
+        sourceInputs: prepared.projectContext?.sourceInputs ?? [],
+      });
+      expect(context.modelDigest).toEqual(expect.any(String));
+      return realpath.mock.calls.length + lstat.mock.calls.length;
+    };
+    const depth6 = probe(6);
+    const depth14 = probe(14);
+    expect(depth6).toBeGreaterThan(0);
+    expect(depth14).toBeLessThan(200);
+    expect(depth14).toBeLessThan(depth6 * 4);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

GPT 6 Pro marked #789 FIX, not GO. Containment still collapsed stored `readlink` hops, treated POSIX backslashes as separators, swallowed cycles as contained, and (in an earlier walker) re-walked every parent of a missing leaf.

## What this does

- Walk authored components and raw `readlink` targets in filesystem order. Do not `path.resolve` away `pivot/../missing` or `symlink/../payload`.
- Resolve relative targets from the physical containing directory.
- Inspect with `lstat` before accepting JS `realpathSync`; existing paths use native `realpath`.
- Tokenize with the platform separator. POSIX keeps literal backslashes as filename data.
- Retain the resolved prefix while advancing so a deeper missing path does not re-walk every parent.
- Propagate `ELOOP` for cyclic payload roots and descendants.
- Public-API regressions via `createProjectContext`:
  - dangling payload-root / chained hops / missing leaf under an escape → `outside project root`
  - missing in-project payload → accepted
  - cyclic payload (both entries) and outside-crossing cycles → `ELOOP`
  - stored relative or absolute `pivot/../missing`, including descendants and an inside decoy
  - POSIX `odd\\dir/missing` filename (skipped on Windows)
  - walk-bound: depth-6 missing payload records `realpathSync.native` probes > 0; depth-14 stays < 200 and < 4× depth-6
- One changeset. Version Packages #411 is untouched.

## Out of scope

- No merge without review.
- Does not rewrite `.changeset/host-install-windows-path-identity.md`.

## Verification

```text
Verify (fast) Node 24/26 failed on 02722f05:
  project-context-walk-bound.test.ts
  expected 0 to be greater than 0
  (rs.mock('node:fs', { spy: true }) wraps the export and misses
   named-import snapshots / realpathSync.native)

After 0f3c5d48 (same unit command CI uses):
  rstest.unit.config.ts project-context-walk-bound.test.ts  1 passed
  rstest.unit.config.ts dangling/cycle/pivot/POSIX cases    passed
```

Draft until review. Follow-up to https://github.com/ScriptedAlchemy/agent-bundle/pull/787.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45140c2c-2829-4533-947f-595f01e3e93a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45140c2c-2829-4533-947f-595f01e3e93a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

