### PR TITLE
Fail closed when a discovered route module cannot be read

### DIFF
--- a/.changeset/fail-closed-route-module-reads.md
+++ b/.changeset/fail-closed-route-module-reads.md
@@ -1,0 +1,5 @@
+---
+"agent-bundle": patch
+---
+
+Fail closed when `compileRouteGraph` cannot read a discovered route module: only a racing `ENOENT` stays silent, so `inspect` and `validate` no longer treat permission or I/O failures as a vanished file.

--- a/.changeset/fail-closed-route-module-reads.md
+++ b/.changeset/fail-closed-route-module-reads.md
@@ -2,4 +2,4 @@
 "agent-bundle": patch
 ---
 
-Fail closed when `compileRouteGraph` cannot read a discovered route module: only a racing `ENOENT` stays silent, so `inspect` and `validate` no longer treat permission or I/O failures as a vanished file.
+Fail closed when `compileRouteGraph` cannot read a discovered route module: only a racing `ENOENT` stays silent, so `inspect` and `validate` no longer treat permission or I/O failures as a vanished file. (#791)

--- a/packages/agent-bundle/src/routes/graph.ts
+++ b/packages/agent-bundle/src/routes/graph.ts
@@ -42,6 +42,7 @@ import { isLayoutRouteKind } from './layouts.ts';
 import { providerKeyFromName } from './providers.ts';
 import type { Diagnostic } from '../core/diagnostics.ts';
 import { digest } from '../core/digest.ts';
+import { isErrno } from '../core/errors.ts';
 import { deepFreeze } from '../core/freeze.ts';
 import { isRecord } from '../core/strict-json.ts';
 import type { AgentBundleConfig } from '../core/types.ts';
@@ -522,14 +523,17 @@ const compiledRoute = (
 });
 
 /**
- * Reads one route module's source text. A racing deletion returns no text so
- * extract/validate skip the same way a later snapshot would.
+ * Reads one route module's source text. A racing deletion (`ENOENT`) returns
+ * no text so extract/validate skip the same way a later snapshot would.
+ * Permission, I/O, and other read failures propagate — they are not
+ * disappearance.
  */
 const readRouteModuleText = async (source: string): Promise<string | undefined> => {
   try {
     return await readFile(source, 'utf8');
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (isErrno(error, 'ENOENT')) return undefined;
+    throw error;
   }
 };
 

--- a/packages/agent-bundle/tests/route-graph.test.ts
+++ b/packages/agent-bundle/tests/route-graph.test.ts
@@ -1,5 +1,5 @@
-import { unlinkSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdirSync, unlinkSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -2327,17 +2327,18 @@ it('skips extract and validate when a discovered route module disappears before 
 });
 
 it('fails closed when a discovered route module cannot be read', async () => {
-  if (process.getuid?.() === 0) return;
   const root = await createRoot();
   const relativePath = 'src/mcp/curator/tools/inspect.tsx';
   await writeTree(root, {
     [relativePath]: `export const config = { title: 'Inspect' }; ${moduleSource}`,
   });
-  const source = join(root, relativePath);
-  await chmod(source, 0o000);
-  try {
-    await expect(compileRouteGraph(root, fixtureConfig())).rejects.toMatchObject({ code: 'EACCES' });
-  } finally {
-    await chmod(source, 0o644);
-  }
+
+  await expect(compileRouteGraph(
+    root,
+    fixtureConfig(),
+    mutateDiscoveredSource(root, relativePath, (source) => {
+      unlinkSync(source);
+      mkdirSync(source);
+    }),
+  )).rejects.toMatchObject({ code: 'EISDIR' });
 });

--- a/packages/agent-bundle/tests/route-graph.test.ts
+++ b/packages/agent-bundle/tests/route-graph.test.ts
@@ -1,8 +1,10 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { unlinkSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { afterEach, expect, it } from '@rstest/core';
+import ignore from 'ignore';
 import ts from 'typescript-5';
 
 import { inspect, type ReadyInspectResult, validate } from '../src/api.ts';
@@ -68,6 +70,24 @@ const conventionalTree: Readonly<Record<string, string>> = {
 
 const codesOf = (diagnostics: readonly { readonly code: string }[]): string[] =>
   diagnostics.map((diagnostic) => diagnostic.code);
+
+/**
+ * Runs `mutate` after glob lists `relativePath` and before the source read, so
+ * the test can reproduce a scan-to-read race without mocking `readFile`.
+ */
+const mutateDiscoveredSource = (
+  root: string,
+  relativePath: string,
+  mutate: (source: string) => void,
+) => {
+  const rules = ignore();
+  const ignores = rules.ignores.bind(rules);
+  rules.ignores = (pathname: string) => {
+    if (pathname === relativePath) mutate(join(root, pathname));
+    return ignores(pathname);
+  };
+  return rules;
+};
 
 const createInspectProject = async (files: Readonly<Record<string, string>>): Promise<string> => {
   const root = await createRoot();
@@ -2282,4 +2302,42 @@ it('rejects orphan views and misplaced view configuration', async () => {
   });
   const graph = await compileRouteGraph(root, fixtureConfig());
   expect(graph.diagnostics.map(({ code }) => code)).toEqual(['AB4840', 'AB4840']);
+});
+
+it('skips extract and validate when a discovered route module disappears before read', async () => {
+  const root = await createRoot();
+  const relativePath = 'src/mcp/curator/tools/inspect.tsx';
+  await writeTree(root, {
+    [relativePath]: `export const config = { title: 'Inspect' }; ${moduleSource}`,
+  });
+
+  const graph = await compileRouteGraph(
+    root,
+    fixtureConfig(),
+    mutateDiscoveredSource(root, relativePath, unlinkSync),
+  );
+
+  expect(graph.diagnostics).toEqual([]);
+  expect(graph.servers[0]!.routes).toEqual([
+    expect.objectContaining({
+      config: emptyRouteConfig,
+      id: 'tool:curator/inspect',
+    }),
+  ]);
+});
+
+it('fails closed when a discovered route module cannot be read', async () => {
+  if (process.getuid?.() === 0) return;
+  const root = await createRoot();
+  const relativePath = 'src/mcp/curator/tools/inspect.tsx';
+  await writeTree(root, {
+    [relativePath]: `export const config = { title: 'Inspect' }; ${moduleSource}`,
+  });
+  const source = join(root, relativePath);
+  await chmod(source, 0o000);
+  try {
+    await expect(compileRouteGraph(root, fixtureConfig())).rejects.toMatchObject({ code: 'EACCES' });
+  } finally {
+    await chmod(source, 0o644);
+  }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`compileRouteGraph` treated every `readFile` failure as a racing deletion. That made `EACCES` / `EIO` / `EMFILE` look like a vanished module: extract and validate skipped, and `inspect` / `validate` reported no error.

## Change

`readRouteModuleText` now uses the existing `isErrno` helper — the same disappearance check as `discoverState` and `readProjectIgnoreRules`.

| Error | Behavior |
| --- | --- |
| `ENOENT` | Silent skip (`undefined` text). Extract/validate stay off, same as a later snapshot that no longer lists the file. |
| Everything else (`EACCES`, `EIO`, `EMFILE`, `EISDIR`, `ENOTDIR`, `EPERM`, uncoded errors, …) | Rethrow. Not a new `ABxxxx` — route graph has no unreadable-source diagnostic, and this PR does not invent one. |

## Tests

- ENOENT after glob still compiles the discovered route with empty config and no diagnostics.
- After discovery, replacing the route file with a directory (`EISDIR`) rejects `compileRouteGraph` instead of omitting the module. This is deterministic across platforms; it does not depend on `chmod 000`.

Local proof (after `pnpm build`):

```text
pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/route-graph.test.ts \
  -t 'skips extract and validate when a discovered route module disappears before read|fails closed when a discovered route module cannot be read'
# 2 passed (ENOENT race + EISDIR fail-closed)

pnpm exec rstest --config rstest.unit.config.ts packages/agent-bundle/tests/route-graph.test.ts
# 66 passed

pnpm exec rslint packages/agent-bundle/src/routes/graph.ts packages/agent-bundle/tests/route-graph.test.ts
# passed
```

Draft only; do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b533a9bc-7259-4eff-a4be-bddd7f4fa02c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b533a9bc-7259-4eff-a4be-bddd7f4fa02c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

