### PR TITLE
ci: run full check:release for Version Packages candidates

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -125,9 +125,14 @@ because they change no publishable package.
    PR CI the repository needs a `CHANGESETS_GITHUB_TOKEN` secret (fine-grained
    PAT or GitHub App installation token with `contents: write` and
    `pull-requests: write` on this repository). When the workflow falls back to
-   `GITHUB_TOKEN`, it explicitly dispatches `ci.yml` on the generated
-   `changeset-release/main` branch after confirming the Version Packages PR
-   exists, so no close/reopen is needed.
+   `GITHUB_TOKEN`, it explicitly dispatches `ci.yml` (per-PR gates, including
+   `pnpm check:release:ci`) and `release-candidate.yml` (the packed-release
+   boundary, `pnpm check:release`) on the generated `changeset-release/main`
+   branch after confirming the Version Packages PR exists, so no
+   close/reopen is needed. When a `CHANGESETS_GITHUB_TOKEN` is configured,
+   that token's push to `changeset-release/main` starts
+   `release-candidate.yml` directly.
+
 3. Merging Version Packages pushes a `Version Packages` commit to `main`
    with no pending changesets. With publishing disabled (the default) the
    workflow then runs the release gates (`pnpm check:release`) and stops;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,8 +310,11 @@ jobs:
           playwright-browser: chromium
       # Per-PR packed pool: single pack+install proofs plus the
       # minimal-template scaffolder smoke. The full template matrix runs in
-      # nightly.yml's packed-matrix job and in pre-publish `pnpm check:release`.
+      # nightly.yml's packed-matrix job, in release-candidate.yml for
+      # Version Packages / on-demand qualification, and in pre-publish
+      # `pnpm check:release`.
       - run: pnpm check:release:ci
+
       - if: failure()
         name: Preserve Playwright traces of failed browser tests
         uses: actions/upload-artifact@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,10 @@ jobs:
   # Release-boundary scaffolder template matrix (mcp-server, cli-tool) plus
   # the full packed pool — the nightly form of pre-publish `check:release`.
   # The per-PR release-gates job runs the `check:release:ci` subset.
+  # Version Packages candidates and manual qualification use
+  # release-candidate.yml (same `pnpm check:release` command, not this
+  # schedule).
+
   # Known red until test/576-p1-test-fixes lands: scaffold-packed-matrix.e2e
   # asserts the scaffolded project's test output contains `"failedTests": 0`,
   # a string only Rstest's `md` reporter prints (auto-selected under an

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,56 @@
+name: Release candidate
+
+# Packed-release boundary (`pnpm check:release`) for Version Packages
+# candidates and on-demand qualification. Ordinary pull requests keep the
+# faster `check:release:ci` contract in ci.yml; the nightly schedule and MCP
+# conformance lane stay in nightly.yml.
+on:
+  push:
+    branches:
+      - changeset-release/main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only the latest candidate SHA matters: a Version Packages refresh cancels
+# the superseded packed-release run instead of stacking 40-minute jobs.
+concurrency:
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Same browser pin as ci.yml and nightly.yml: Workbench browser suites
+  # launch Playwright's bundled Chromium (see packages/workbench/tests/
+  # support/workbench-e2e.ts).
+  AGENT_BUNDLE_PLAYWRIGHT_CHANNEL: chromium
+
+jobs:
+  # Same packed-release lane as nightly.yml's packed-matrix job: Node 22.19,
+  # setup-workspace + Playwright Chromium, `pnpm check:release` (pack dry-run,
+  # lint:release, the full scaffolder template matrix, dist freshness).
+  packed-release:
+    # Defense in depth: this workflow's triggers already exclude ordinary
+    # PRs and main pushes. Keep the same predicate on the job so a later
+    # trigger expansion cannot silently qualify every PR.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/changeset-release/main'
+    name: Packed release (Node 22.19)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-workspace
+        with:
+          node-version: 22.19.0
+          playwright-browser: chromium
+      - run: pnpm check:release
+      - if: failure()
+        name: Preserve Playwright traces of failed browser tests
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-traces-release-candidate
+          path: .rstest/playwright-traces
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,13 @@ jobs:
       # GITHUB_TOKEN-created pushes do not recursively start workflows, but
       # workflow_dispatch is an explicit GitHub exception. ci.yml documents
       # manual dispatch as the full main-push matrix on any ref, including the
-      # Node floor and release-gates job, so qualify the exact generated head.
-      # Skip this when an external Changesets token is configured to avoid a
-      # duplicate run: that token's pull_request event already starts CI.
-      - name: Dispatch CI for Version Packages candidate
+      # Node floor and per-PR release-gates job (`pnpm check:release:ci`).
+      # release-candidate.yml is the packed-release boundary
+      # (`pnpm check:release`) for this same candidate. Skip both when an
+      # external Changesets token is configured: that token's pull_request
+      # event already starts CI, and its push to changeset-release/main
+      # starts release-candidate.yml.
+      - name: Dispatch qualification for Version Packages candidate
         if: >-
           steps.changesets.outputs.has-changesets == 'true' &&
           steps.changesets.outputs.pr-number != '' &&
@@ -95,7 +98,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh workflow run ci.yml --ref changeset-release/main
+        run: |
+          set -euo pipefail
+          gh workflow run ci.yml --ref changeset-release/main
+          gh workflow run release-candidate.yml --ref changeset-release/main
+
       # Publishing disabled: when the Version Packages PR lands (no pending
       # changesets, "Version Packages" merge commit), prove the versioned
       # tree still passes the pre-publish gates that `pnpm release` would run.

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -80,8 +80,9 @@ install, which one worktree provides just as well as three.
 `gates-node22` runs the full `check:release`, a strict superset of the hosted
 per-PR release-gates job (`check:release:ci`): it additionally runs the
 scaffolder template matrix that the hosted side defers to the nightly
-`packed-matrix` job, so local green covers both the per-PR and nightly packed
-pools.
+`packed-matrix` job and to `release-candidate.yml` (Version Packages
+candidates and `workflow_dispatch`), so local green covers the per-PR,
+nightly, and release-candidate packed pools.
 
 All four legs run concurrently. The summary table (leg × step × status ×
 duration × test census) is printed and written to


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the GPT P1 gap that Version Packages / release-candidate qualification ran `pnpm check:release:ci` (the per-PR packed subset) instead of the packed-release boundary `pnpm check:release`.

Ordinary PRs stay on the current faster contract. This does **not** make every PR wait on the ~40-minute full release gate.

## What changed

- New `.github/workflows/release-candidate.yml` reuses the nightly packed-release lane (Node 22.19, `setup-workspace`, Playwright Chromium, 40-minute timeout) and runs **`pnpm check:release`**.
- `.github/workflows/release.yml` now dispatches that workflow alongside `ci.yml` when `GITHUB_TOKEN` refreshes Version Packages (the existing recursion exception). A configured `CHANGESETS_GITHUB_TOKEN` still skips the dispatch; its push to `changeset-release/main` starts the new workflow directly.
- Comments in `ci.yml`, `nightly.yml`, `.changeset/README.md`, and `docs/local-ci.md` record the split. No publishable package files changed, so no changeset (CI/docs only, per `.changeset/README.md`).

Nightly already had `pnpm check:release` on a schedule / manual dispatch, but `release.yml` never invoked it for a Version Packages candidate. A dedicated workflow keeps nightly’s MCP-conformance lane out of RC qualification.

## When it fires

| Event | Runs `pnpm check:release`? |
| --- | --- |
| Ordinary PR / push to `main` / merge queue | No. `ci.yml` `release-gates` still runs `pnpm check:release:ci`. |
| Push to `changeset-release/main` (external Changesets token) | Yes. Workflow `on.push` + job `if`. |
| Version Packages refresh with only `GITHUB_TOKEN` | Yes. `release.yml` runs `gh workflow run release-candidate.yml --ref changeset-release/main`. |
| `workflow_dispatch` of `release-candidate.yml` on any ref | Yes. Manual qualification of a later RC / branch. |
| Nightly schedule | Unchanged: `nightly.yml` `packed-matrix` still runs `pnpm check:release`. |
| Version Packages merge to `main` (publish disabled) | Unchanged: `release.yml` “Release gates (publish disabled)” still runs `pnpm check:release`. |

Job `if` (defense in depth on top of the triggers):

```yaml
if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/changeset-release/main'
```

Command in that job: `pnpm check:release`.

## Verification

- Parsed the workflow YAML: triggers are only `push: changeset-release/main` and `workflow_dispatch` (no `pull_request`); job command is `pnpm check:release`; `ci.yml` release-gates remains `pnpm check:release:ci`; `release.yml` dispatches `release-candidate.yml`.
- Did **not** run the full ~40-minute packed-release suite locally.
- Did **not** update, push, or close Version Packages PR #411. `changeset-release/main` remains `ff5ad23d` (`Version Packages`).

## Out of scope

- Not required on ordinary PRs (a skipped required check would block them).
- No change to `check:release` / `check:release:ci` script definitions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff664e36-c6e7-40a8-ae95-b1ef555993e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff664e36-c6e7-40a8-ae95-b1ef555993e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

